### PR TITLE
Fix enrollment request/response processing

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -65,6 +65,9 @@ XX(controller, string, none, iss, __VA_ARGS__) \
 XX(subject, string, none, sub, __VA_ARGS__) \
 XX(token, string, none, jti, __VA_ARGS__)
 
+#define ZITI_ENROLLMENT_RESP(XX, ...) \
+XX(cert, string, none, cert, __VA_ARGS__)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -87,6 +90,8 @@ DECLARE_MODEL(ziti_error, ZITI_ERROR_MODEL)
 
 DECLARE_MODEL(ziti_enrollment_jwt_header, ZITI_ENROLLMENT_JWT_HEADER_MODEL)
 DECLARE_MODEL(ziti_enrollment_jwt, ZITI_ENROLLMENT_JWT_MODEL)
+
+DECLARE_MODEL(ziti_enrollment_resp, ZITI_ENROLLMENT_RESP)
 
 #ifdef __cplusplus
 }

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -63,7 +63,8 @@ ziti_ctrl_get_well_known_certs(ziti_controller *ctrl, enroll_cfg *cfg, void (*cb
                                void *ctx);
 
 void
-ziti_ctrl_enroll(ziti_controller *ctrl, enroll_cfg *cfg, void (*cb)(ziti_config *, ziti_error *, void *), void *ctx);
+ziti_ctrl_enroll(ziti_controller *ctrl, enroll_cfg *cfg, void (*cb)(ziti_enrollment_resp *, ziti_error *, void *),
+                 void *ctx);
 
 #ifdef __cplusplus
 }

--- a/library/internal_model.c
+++ b/library/internal_model.c
@@ -48,6 +48,7 @@ IMPL_MODEL(ziti_error, ZITI_ERROR_MODEL)
 IMPL_MODEL(ziti_enrollment_jwt_header, ZITI_ENROLLMENT_JWT_HEADER_MODEL)
 
 IMPL_MODEL(ziti_enrollment_jwt, ZITI_ENROLLMENT_JWT_MODEL)
+IMPL_MODEL(ziti_enrollment_resp, ZITI_ENROLLMENT_RESP)
 
 const char *ziti_service_get_raw_config(ziti_service *service, const char *cfg_type) {
     return (const char *) model_map_get(&service->config, cfg_type);

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -367,15 +367,15 @@ void ziti_ctrl_get_net_sessions(
 }
 
 void
-ziti_ctrl_enroll(ziti_controller *ctrl, enroll_cfg *ecfg, void (*cb)(ziti_config *, ziti_error *, void *), void *ctx) {
+ziti_ctrl_enroll(ziti_controller *ctrl, enroll_cfg *ecfg, void (*cb)(ziti_enrollment_resp *, ziti_error *, void *),
+                 void *ctx) {
     char *content = strdup(ecfg->x509_csr_pem);
 
     char path[1024];
     snprintf(path, sizeof(path), "/enroll?method=%s&token=%s", ecfg->zej->method, ecfg->zej->token);
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
-    resp->resp_text_plain = true;   // Make no attempt in ctrl_resp_cb to parse response as JSON
-    resp->body_parse_func = NULL;   //   "  "  "  
+    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_enrollment_resp_ptr;   //   "  "  "
     resp->resp_cb = (void (*)(void *, ziti_error *, void *)) cb;
     resp->ctx = ctx;
     resp->ctrl = ctrl;

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -56,7 +56,9 @@ limitations under the License.
 #define ZITI_MD_MAX_SIZE_512 64  /* longest known is SHA512 */
 
 static void well_known_certs_cb(char *cert, ziti_error *err, void *req);
-static void enroll_cb(char *cert, ziti_error *err, void *ctx);
+
+static void enroll_cb(ziti_enrollment_resp *er, ziti_error *err, void *ctx);
+
 int extract_well_known_certs(char *base64_encoded_pkcs7, void *req);
 
 static void async_connects(uv_async_t *ar) {
@@ -479,8 +481,7 @@ static void well_known_certs_cb(char *base64_encoded_pkcs7, ziti_error *err, voi
     ziti_ctrl_enroll(&enroll_ctx->controller, enroll_req2->ecfg, enroll_cb, enroll_req2);
 }
 
-static void enroll_cb(char *cert, ziti_error *err, void *enroll_ctx) {
-
+static void enroll_cb(ziti_enrollment_resp *er, ziti_error *err, void *enroll_ctx) {
     struct ziti_enroll_req *enroll_req = enroll_ctx;
     struct ziti_ctx *ctx = enroll_req->enroll_ctx;
 
@@ -495,6 +496,7 @@ static void enroll_cb(char *cert, ziti_error *err, void *enroll_ctx) {
         free_ziti_error(err);
     }
     else {
+        char *cert = er->cert;
         ZITI_LOG(DEBUG, "successfully enrolled with controller %s:%s",
                  ctx->controller.client.host, ctx->controller.client.port);
 


### PR DESCRIPTION
Handle both pre-0.15 and 0.15.+ enrollment responses:
* client always requests `application/json` via `Accept` header
* pre-0.15.0: controller responds with `Content-type: application/x-pem-file` regardless of supplied `Accept` header
* 0.15.+: enrollment response contains PEM wrapped in standard controller response JSON