### PR TITLE
update uv-mbed to v0.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required(VERSION 3.12)
 include(git.cmake)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_STANDARD 99)
@@ -6,6 +6,9 @@ project(ziti-sdk
         VERSION ${ver}
         LANGUAGES C CXX
         )
+
+option(ZITI_BUILD_PROGRAMS "Build programs." ON)
+option(ZITI_BUILD_TESTS "Build tests." ON)
 
 message("project version: ${PROJECT_VERSION}")
 message("git info:")
@@ -106,9 +109,13 @@ endif()
 
 add_subdirectory(library)
 
-if(NOT ${PUB_OS} STREQUAL "ios" )
-    add_subdirectory(programs)
-endif()
+if (ZITI_BUILD_PROGRAMS)
+    if (NOT ${PUB_OS} STREQUAL "ios")
+        add_subdirectory(programs)
+    endif ()
+endif ()
 
-add_subdirectory(tests)
+if (ZITI_BUILD_TESTS)
+    add_subdirectory(tests)
+endif ()
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(uv-mbed
         GIT_REPOSITORY https://github.com/netfoundry/uv-mbed.git
-        GIT_TAG v0.7.0
+        GIT_TAG v0.8.1
         )
 set(ENABLE_UM_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(uv-mbed)


### PR DESCRIPTION
this PR also adds options for downstream projects to skip building ziti tests and programs