### PR TITLE
dont use EOF when connection is terminated

### DIFF
--- a/includes/ziti/error_defs.h
+++ b/includes/ziti/error_defs.h
@@ -76,6 +76,8 @@ limitations under the License.
     XX(INVALID_STATE, "invalid state") \
     /** SDK detected invalid cryptographic state of Ziti connection */ \
     XX(CRYPTO_FAIL, "crypto failure") \
+    /** connection was closed */ \
+    XX(CONN_CLOSED, "connection is closed") \
     /** Inspired by the Android SDK: What a Terrible Failure. A condition that should never happen. */ \
     XX(WTF, "WTF: programming error")
 

--- a/library/channel.c
+++ b/library/channel.c
@@ -563,7 +563,7 @@ static void on_channel_data(uv_stream_t *s, ssize_t len, const uv_buf_t *buf) {
             case UV_EPIPE:
                 ZITI_LOG(INFO, "channel was closed: %d(%s)", (int) len, uv_strerror((int) len));
                 // propagate close
-                on_channel_close(ch, ZITI_EOF);
+                on_channel_close(ch, ZITI_CONNABORT);
                 break;
 
             default:

--- a/library/channel.c
+++ b/library/channel.c
@@ -293,10 +293,10 @@ static void process_edge_message(struct ziti_conn *conn, message *msg) {
         case ContentTypeStateClosed:
             ZITI_LOG(VERBOSE, "connection status[%d] conn_id[%d] seq[%d]", msg->header.content, conn_id, seq);
             if (conn->state == Bound) {
-                conn->client_cb(conn, NULL, ZITI_EOF);
+                conn->client_cb(conn, NULL, ZITI_CONN_CLOSED);
             }
             else if (conn->state == Connected || conn->state == CloseWrite) {
-                conn->data_cb(conn, NULL, ZITI_EOF);
+                conn->data_cb(conn, NULL, ZITI_CONN_CLOSED);
             }
             conn->state = Closed;
             break;

--- a/library/connect.c
+++ b/library/connect.c
@@ -349,7 +349,7 @@ static void ziti_write_async(uv_async_t *ar) {
         ZITI_LOG(WARN, "got write req for closed conn[%d]", conn->conn_id);
         conn->write_reqs--;
 
-        req->cb(conn, ZITI_EOF, req->ctx);
+        req->cb(conn, ZITI_CONN_CLOSED, req->ctx);
         free(req);
     }
     else {
@@ -586,7 +586,7 @@ void connect_reply_cb(void *ctx, message *msg) {
                      conn->conn_id, conn->state == Binding ? "bind" : "connect",
                      msg->header.body_len, msg->header.body_len, msg->body);
             conn->state = Closed;
-            req->cb(conn, ZITI_EOF);
+            req->cb(conn, ZITI_CONN_CLOSED);
             req->failed = true;
             break;
 

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -734,7 +734,6 @@ static int _cmp_map(model_map *lh, model_map *rh) {
             char *rhv = model_map_get(rh, model_map_it_key(it));
             if (rhv == NULL) {
                 rc = 1;
-
             }
             else {
                 rc = strcmp(lhv, rhv);
@@ -1032,7 +1031,7 @@ static int model_map_compare(model_map *lh, model_map *rh, type_meta *m) {
                 rc = 1;
             }
             else {
-                if (m == get_string_meta()) {
+                if (m == get_string_meta() || m == get_json_meta()) {
                     rc = m->comparer(&lhv, &rhv);
                 }
                 else {

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -330,6 +330,11 @@ static void update_listener(ziti_service *service, int status, struct listener *
     PREPF(uv, uv_strerror);
 
     if (status == ZITI_OK && (service->perm_flags & ZITI_CAN_DIAL)) {
+        if (uv_is_active((const uv_handle_t *) &l->server)) {
+            ZITI_LOG(INFO, "listener for service[%s] is already active on port[%d]", l->service_name, l->port);
+            return;
+        }
+
         ZITI_LOG(INFO, "starting listener for service[%s] on port[%d]", l->service_name, l->port);
 
         NEWP(addr, struct sockaddr_in);

--- a/tests/test_ziti_model.cpp
+++ b/tests/test_ziti_model.cpp
@@ -337,6 +337,67 @@ TEST_CASE("service config test", "[model]") {
     free_ziti_intercept(&cfg);
 }
 
+TEST_CASE("config change", "[model]") {
+    const char *j1 = R"({
+    "id": "c8c07cb8-5234-4106-92ea-fde5721095fd",
+    "tags": {},
+    "config": {
+      "ziti-tunneler-client.v1": {
+        "hostname": "hello.ziti",
+        "port": 80
+      }
+    },
+    "configs": [
+      "d1339ad5-6556-4297-b357-308b3bc79db0"
+    ],
+    "name": "hello-svc",
+    "permissions": [
+      "Bind",
+      "Dial"
+    ],
+    "roleAttributes": null,
+    "terminatorStrategy": "smartrouting"
+  }
+)";
+
+    const char *j2 = R"({
+    "id": "c8c07cb8-5234-4106-92ea-fde5721095fd",
+    "tags": {},
+    "config": {
+      "ziti-tunneler-client.v1": {
+        "hostname": "hello.ziti",
+        "port": 8080
+      }
+    },
+    "configs": [
+      "d1339ad5-6556-4297-b357-308b3bc79db0"
+    ],
+    "name": "hello-svc",
+    "permissions": [
+      "Bind",
+      "Dial"
+    ],
+    "roleAttributes": null,
+    "terminatorStrategy": "smartrouting"
+  }
+)";
+
+
+    ziti_service s, s1, s2;
+    REQUIRE(parse_ziti_service(&s, j1, strlen(j1)) == 0);
+    REQUIRE(parse_ziti_service(&s1, j1, strlen(j1)) == 0);
+    REQUIRE(parse_ziti_service(&s2, j2, strlen(j2)) == 0);
+
+    CHECK(cmp_ziti_service(&s, &s1) == 0);
+    CHECK(cmp_ziti_service(&s, &s2) != 0);
+    CHECK(cmp_ziti_service(&s2, &s1) != 0);
+
+
+    free_ziti_service(&s);
+    free_ziti_service(&s1);
+    free_ziti_service(&s2);
+}
+
 TEST_CASE("identity tags", "[model]") {
     const char *json = R"(        {
             "_links": {


### PR DESCRIPTION
this a quick fix -- better solution is outlined in #154 

for now: since ZITI_EOF indicates that connection is still alive (per half-close feature) don't use it if connection state is `Closed`