### PR TITLE
try flush only once (after IO) per loop iteration

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -120,7 +120,7 @@ struct ziti_conn {
     int timeout;
 
     buffer *inbound;
-    uv_async_t *flusher;
+    uv_check_t *flusher;
     uv_async_t *disconnector;
     int write_reqs;
 


### PR DESCRIPTION
put guard to make sure that post-IO flush is only tried once per connection