### PR TITLE
try to disable potentially non-portable optimizations

### DIFF
--- a/deps/libsodium.cmake
+++ b/deps/libsodium.cmake
@@ -53,12 +53,12 @@ if(NOT libsodium_POPULATED)
             endif()
             execute_process(
                     COMMAND "${libsodium_SOURCE_DIR}/configure" "--prefix=${libsodium_BINARY_DIR}"
-                    --enable-opt --without-pthreads --with-pic --host=${triple}
+                    --disable-opt --without-pthreads --with-pic --host=${triple}
                     WORKING_DIRECTORY ${libsodium_BINARY_DIR}
             )
         endif()
 		execute_process(
-                COMMAND make
+                COMMAND make V=s
                 WORKING_DIRECTORY ${libsodium_BINARY_DIR}
         )
         execute_process(


### PR DESCRIPTION
libsodium build with `--enable-opts` turns on gcc `-Ofast` flag which may lead to non-portable code:

```
  --enable-opt            Optimize for the native CPU - The resulting library
                          will be faster but not portable
```