### PR TITLE
uv_shutdown requires a cb

### DIFF
--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -245,6 +245,10 @@ void on_ziti_connect(ziti_connection conn, int status) {
     }
 }
 
+static void tcp_shutdown_cb(uv_shutdown_t *sr, int code) {
+    free(sr);
+}
+
 ssize_t on_ziti_data(ziti_connection conn, uint8_t *data, ssize_t len) {
     uv_tcp_t *clt = ziti_conn_data(conn);
     struct client *c = clt ? clt->data : NULL;
@@ -282,7 +286,7 @@ ssize_t on_ziti_data(ziti_connection conn, uint8_t *data, ssize_t len) {
         }
         else {
             uv_shutdown_t *sr = calloc(1, sizeof(uv_shutdown_t));
-            uv_shutdown(sr, (uv_stream_t *) clt, NULL);
+            uv_shutdown(sr, (uv_stream_t *) clt, tcp_shutdown_cb);
             c->write_done = true;
         }
     }


### PR DESCRIPTION
core file backtrace
```
#0  0x0000000000000000 in ?? ()
#1  0x0000556180592699 in uv__stream_destroy (stream=0x556180902f80) at /var/lib/jenkins/workspace/ziti-sdk-c_master/build-Linux-x86_64/_deps/libuv-src/src/unix/stream.c:478
#2  0x000055618058948c in uv__finish_close (handle=0x556180902f80) at /var/lib/jenkins/workspace/ziti-sdk-c_master/build-Linux-x86_64/_deps/libuv-src/src/unix/core.c:277
#3  0x00005561805895a5 in uv__run_closing_handles (loop=0x5561808e03b0) at /var/lib/jenkins/workspace/ziti-sdk-c_master/build-Linux-x86_64/_deps/libuv-src/src/unix/core.c:307
#4  0x00005561805897a9 in uv_run (loop=0x5561808e03b0, mode=UV_RUN_DEFAULT) at /var/lib/jenkins/workspace/ziti-sdk-c_master/build-Linux-x86_64/_deps/libuv-src/src/unix/core.c:377
#5  0x000055618055dc41 in run (argc=6, argv=0x7ffe9dad7ab0) at /var/lib/jenkins/workspace/ziti-sdk-c_master/programs/ziti-prox-c/proxy.c:475
```