### PR TITLE
handle invalidation of sessions

### DIFF
--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -58,8 +58,8 @@ void ziti_ctrl_get_services(ziti_controller *ctrl, void (*srv_cb)(ziti_service_a
 void ziti_ctrl_get_service(ziti_controller *ctrl, const char* service_name, void (*srv_cb)(ziti_service *, ziti_error*, void*), void* ctx);
 
 void ziti_ctrl_get_net_session(
-        ziti_controller *ctrl, ziti_service *service, const char* type,
-        void (*cb)(ziti_net_session *, ziti_error*, void*), void* ctx);
+        ziti_controller *ctrl, const char *service_id, const char *type,
+        void (*cb)(ziti_net_session *, ziti_error *, void *), void *ctx);
 
 void ziti_ctrl_get_net_sessions(
         ziti_controller *ctrl, void (*cb)(ziti_net_session **, ziti_error*, void*), void* ctx);

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -107,6 +107,8 @@ struct ziti_write_req_s {
 
 struct ziti_conn {
     char *token;
+    char *service;
+    struct ziti_conn_req *conn_req;
 
     uint32_t edge_msg_seq;
     uint32_t conn_id;

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <stdbool.h>
 #include <uv_mbed/uv_mbed.h>
+#include <uv_mbed/queue.h>
 
 #include <ziti/ziti.h>
 #include "buffer.h"
@@ -86,7 +87,7 @@ typedef struct ziti_channel {
     message *in_next;
     int in_body_offset;
 
-    LIST_HEAD(con_list, ziti_conn) connections;
+    LIST_HEAD(con_list, msg_receiver) receivers;
     LIST_HEAD(waiter, waiter_s) waiters;
 
     LIST_ENTRY(ziti_channel) next;
@@ -177,6 +178,7 @@ struct ziti_ctx {
 
     // map<erUrl,ziti_channel>
     model_map channels;
+    LIST_HEAD(conns, ziti_conn) connections;
 
     uv_async_t connect_async;
     uint32_t conn_seq;
@@ -203,6 +205,10 @@ int ziti_close_channels(ziti_context ztx);
 int ziti_channel_connect(ziti_context ztx, const char *name, const char *url, ch_connect_cb, void *ctx);
 
 int ziti_channel_close(ziti_channel_t *ch);
+
+void ziti_channel_add_receiver(ziti_channel_t *ch, int id, void *receiver, void (*receive_f)(void *, message *, int));
+
+void ziti_channel_rem_receiver(ziti_channel_t *ch, int id);
 
 int ziti_channel_send(ziti_channel_t *ch, uint32_t content, const hdr_t *hdrs, int nhdrs, const uint8_t *body,
                       uint32_t body_len,

--- a/library/connect.c
+++ b/library/connect.c
@@ -256,6 +256,12 @@ static int ziti_connect(struct ziti_ctx *ctx, const ziti_net_session *session, s
     conn->token = session->token;
     conn->channel = NULL;
 
+    if (session->edge_routers == NULL) {
+        ZITI_LOG(ERROR, "no edge routers available for service[%s] session[%s]", conn->service, session->id);
+        conn->conn_req->cb(conn, ZITI_GATEWAY_UNAVAILABLE);
+        return ZITI_GATEWAY_UNAVAILABLE;
+    }
+
     ziti_edge_router **er;
     ziti_channel_t *best_ch = NULL;
     uint64_t best_latency = UINT64_MAX;
@@ -299,6 +305,7 @@ static void connect_get_service_cb(ziti_service* s, ziti_error *err, void *ctx) 
     if (s == NULL) {
         req->cb(conn, ZITI_SERVICE_UNAVAILABLE);
         free_conn_req(req);
+        conn->conn_req = NULL;
     }
     else {
         ZITI_LOG(INFO, "got service[%s] id[%s]", s->name, s->id);

--- a/library/connect.c
+++ b/library/connect.c
@@ -925,7 +925,7 @@ int ziti_bind(ziti_connection conn, const char *service, ziti_listen_opts *liste
 
     NEWP(async_cr, uv_async_t);
     uv_async_init(conn->ziti_ctx->loop, async_cr, ziti_connect_async);
-    async_cr->data = req;
+    async_cr->data = conn;
     return uv_async_send(async_cr);
 }
 

--- a/library/connect.c
+++ b/library/connect.c
@@ -353,7 +353,8 @@ static void ziti_connect_async(uv_async_t *ar) {
     net_session = model_map_get(&ctx->sessions, req->service->id);
     if (net_session == NULL || strcmp(net_session->session_type, req->session_type) != 0) {
         ZITI_LOG(DEBUG, "requesting '%s' session for service[%s]", req->session_type, req->service_name);
-        ziti_ctrl_get_net_session(&ctx->controller, req->service, req->session_type, connect_get_net_session_cb, ar);
+        ziti_ctrl_get_net_session(&ctx->controller, req->service->id, req->session_type, connect_get_net_session_cb,
+                                  ar);
         return;
     }
     else {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -327,19 +327,24 @@ int ziti_ctx_free(ziti_context *ctxp) {
 
 void ziti_dump(ziti_context ztx) {
     printf("\n=================\nSession:\n");
-    dump_ziti_session(ztx->session, 0);
+    printf("Session Info: id[%s] name[%s] api_session[%s]\n",
+           ztx->session->identity->id, ztx->session->identity->name, ztx->session->id);
 
     printf("\n=================\nServices:\n");
     ziti_service *zs;
     const char *name;
     MODEL_MAP_FOREACH(name, zs, &ztx->services) {
-        dump_ziti_service(zs, 0);
+
+        printf("%s: id[%s] perm(dial[%s],bind[%s]\n", zs->name, zs->id,
+               (zs->perm_flags & ZITI_CAN_DIAL ? "true" : "false"),
+               (zs->perm_flags & ZITI_CAN_BIND ? "true" : "false")
+        );
     }
 
     printf("\n==================\nNet Sessions:\n");
     ziti_net_session *it;
     MODEL_MAP_FOREACH(name, it, &ztx->sessions) {
-        dump_ziti_net_session(it, 0);
+        printf("%s: service_id[%s]\n", it->id, name);
     }
 
     printf("\n==================\nChannels:\n");
@@ -347,11 +352,15 @@ void ziti_dump(ziti_context ztx) {
     const char *url;
     MODEL_MAP_FOREACH(url, ch, &ztx->channels) {
         printf("ch[%d](%s)\n", ch->id, url);
-        ziti_connection conn;
-        LIST_FOREACH(conn, &ch->connections, next) {
-            printf("\tconn[%d]: state[%s] service[%s] session[%s]\n", conn->conn_id, strstate(conn->state),
-                   "TODO", "TODO"); // TODO
-        }
+    }
+
+    printf("\n==================\nConnections:\n");
+    ziti_connection conn;
+    LIST_FOREACH(conn, &ztx->connections, next) {
+        printf("conn[%d]: state[%d] service[TODO] using ch[%d] %s\n",
+               conn->conn_id, conn->state,
+               conn->channel ? conn->channel->id : -1,
+               conn->channel ? conn->channel->ingress : "(none)");
     }
 }
 
@@ -368,6 +377,7 @@ int ziti_conn_init(ziti_context ztx, ziti_connection *conn, void *data) {
     c->inbound = new_buffer();
 
     *conn = c;
+    LIST_INSERT_HEAD(&ctx->connections, c, next);
     return ZITI_OK;
 }
 
@@ -685,16 +695,13 @@ static void grim_reaper(uv_prepare_t *p) {
 
     int total = 0;
     int count = 0;
-    const char *url;
-    ziti_channel_t *ch;
-    MODEL_MAP_FOREACH(url, ch, &ztx->channels) {
-        ziti_connection conn = LIST_FIRST(&ch->connections);
-        while (conn != NULL) {
-            ziti_connection try_close = conn;
-            total++;
-            conn = LIST_NEXT(conn, next);
-            count += close_conn_internal(try_close);
-        }
+
+    ziti_connection conn = LIST_FIRST(&ztx->connections);
+    while (conn != NULL) {
+        ziti_connection try_close = conn;
+        total++;
+        conn = LIST_NEXT(conn, next);
+        count += close_conn_internal(try_close);
     }
     if (count > 0) {
         ZITI_LOG(INFO, "reaped %d closed (out of %d total) connections", count, total);

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -335,7 +335,7 @@ void ziti_dump(ziti_context ztx) {
     const char *name;
     MODEL_MAP_FOREACH(name, zs, &ztx->services) {
 
-        printf("%s: id[%s] perm(dial[%s],bind[%s]\n", zs->name, zs->id,
+        printf("%s: id[%s] perm(dial=%s,bind=%s)\n", zs->name, zs->id,
                (zs->perm_flags & ZITI_CAN_DIAL ? "true" : "false"),
                (zs->perm_flags & ZITI_CAN_BIND ? "true" : "false")
         );
@@ -357,8 +357,8 @@ void ziti_dump(ziti_context ztx) {
     printf("\n==================\nConnections:\n");
     ziti_connection conn;
     LIST_FOREACH(conn, &ztx->connections, next) {
-        printf("conn[%d]: state[%d] service[TODO] using ch[%d] %s\n",
-               conn->conn_id, conn->state,
+        printf("conn[%d]: state[%d] service[%s] using ch[%d] %s\n",
+               conn->conn_id, conn->state, conn->service,
                conn->channel ? conn->channel->id : -1,
                conn->channel ? conn->channel->ingress : "(none)");
     }

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -327,13 +327,13 @@ ziti_ctrl_get_service(ziti_controller *ctrl, const char *service_name, void (*cb
 }
 
 void ziti_ctrl_get_net_session(
-        ziti_controller *ctrl, ziti_service *service, const char *type,
+        ziti_controller *ctrl, const char *service_id, const char *type,
         void (*cb)(ziti_net_session *, ziti_error *, void *), void *ctx) {
 
     char *content = malloc(128);
     size_t len = snprintf(content, 128,
                           "{\"serviceId\": \"%s\", \"type\": \"%s\"}",
-                          service->id, type);
+                          service_id, type);
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_net_session_ptr;

--- a/tests/ctrl_tests.cpp
+++ b/tests/ctrl_tests.cpp
@@ -159,7 +159,7 @@ TEST_CASE("controller_test","[integ]") {
             auto *re = static_cast<struct uber_resp_s *>(ctx);
             resp_cb(s, e, &re->service);
             if (e == nullptr) {
-                ziti_ctrl_get_net_session(re->c, s, "Dial", resp_cb, &re->ns);
+                ziti_ctrl_get_net_session(re->c, s->id, "Dial", resp_cb, &re->ns);
             }
             ziti_ctrl_logout(re->c, logout_cb, &re->logout);
 


### PR DESCRIPTION
[fixes #164]

additionally this PR has the following:
- refactor connection/channel relationship: ziti_connections are now held by ziti_context
- connection requests are held by corresponding ziti_connection (instead of the other way around)