### PR TITLE
add option to use UTC time in log file

### DIFF
--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -39,9 +39,9 @@ enum DebugLevel {
 
 #define ZITI_LOG(level, fmt, ...) do { \
 if (level <= ziti_debug_level) {\
-    long elapsed = get_elapsed();\
-    fprintf(ziti_debug_out, "[%9ld.%03ld] " #level "\t" to_str(ZITI_LOG_PREFIX) ":%s:%d %s(): " fmt "\n",\
-        elapsed/1000, elapsed%1000, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__);\
+    const char *elapsed = get_elapsed();\
+    fprintf(ziti_debug_out, "[%s] " #level "\t" to_str(ZITI_LOG_PREFIX) ":%s:%d %s(): " fmt "\n",\
+        elapsed, __FILENAME__, __LINE__, __func__, ##__VA_ARGS__);\
         }\
 } while(0)
 
@@ -49,9 +49,9 @@ if (level <= ziti_debug_level) {\
 extern "C" {
 #endif
 
-ZITI_FUNC long get_elapsed();
-ZITI_FUNC extern void init_debug();
-ZITI_FUNC extern void ziti_set_log(FILE *log);
+ZITI_FUNC extern const char* (*get_elapsed)();
+ZITI_FUNC extern void init_debug(uv_loop_t *loop);
+ZITI_FUNC extern void ziti_set_log(FILE *log, uv_loop_t *loop);
 ZITI_FUNC extern int ziti_debug_level;
 ZITI_FUNC extern FILE *ziti_debug_out;
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -180,7 +180,7 @@ int load_tls(ziti_config *cfg, tls_context **ctx) {
 }
 
 int ziti_init_opts(ziti_options *options, uv_loop_t *loop, void *init_ctx) {
-    init_debug();
+    init_debug(loop);
     metrics_init(loop, 5);
 
     uv_timeval64_t start_time;

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -90,7 +90,7 @@ static int check_cert_required(enroll_cfg *ecfg) {
 }
 
 int ziti_enroll(ziti_enroll_opts *opts, uv_loop_t *loop, ziti_enroll_cb enroll_cb, void *enroll_ctx) {
-    init_debug();
+    init_debug(loop);
 
     uv_timeval64_t start_time;
     uv_gettimeofday(&start_time);

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -28,7 +28,7 @@ limitations under the License.
 #include "../inc_internal/utils.h"
 
 int init() {
-    init_debug();
+   // init_debug();
     return 0;
 }
 


### PR DESCRIPTION
[fixes #177]

set environment variable `ZITI_TIME_FORMAT` to `utc`:
`ZITI_TIME_FORMAT=utc`

sample output:
```
[2020-11-23T22:47:10.505Z] DEBUG	ziti-sdk:library/posture.c:165 ziti_send_posture_data(): done sending posture data, free
[2020-11-23T22:47:10.505Z] DEBUG	ziti-sdk:library/posture.c:170 ziti_send_posture_data(): done sending posture data
[2020-11-23T22:47:30.505Z] DEBUG	ziti-sdk:library/posture.c:67 ziti_send_posture_data(): starting to send posture data
[2020-11-23T22:47:30.505Z] DEBUG	ziti-sdk:library/posture.c:165 ziti_send_posture_data(): done sending posture data, free
[2020-11-23T22:47:30.505Z] DEBUG	ziti-sdk:library/posture.c:170 ziti_send_posture_data(): done sending posture data
```