### PR TITLE
Proxy c packaging

### DIFF
--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -19,13 +19,11 @@ if (UNIX)
         COMMAND tar zcf ${ZITI_ARCHIVE_NAME} ${ZITI_EXECUTABLE_NAME}
     )
 else()
-    if(EXISTS "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}")
-        add_custom_target(ziti-prox-c-pack
-            BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
-            DEPENDS ziti-prox-c
-            COMMAND zip "${ZITI_ARCHIVE_NAME}" "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}"
-        )
-    endif()
+    add_custom_target(ziti-prox-c-pack
+        BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
+        DEPENDS ziti-prox-c
+        COMMAND zip "${ZITI_ARCHIVE_NAME}" "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}"
+    )
 endif()
 
 #add_dependencies(publish ${ZITI_ARCHIVE_NAME})

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -10,32 +10,33 @@ endif()
 target_link_libraries(ziti-prox-c PUBLIC ziti subcommand)
 target_include_directories(ziti-prox-c PRIVATE ${ziti-sdk_SOURCE_DIR}/inc_internal)
 
-set(ZITI_EXECUTABLE_NAME "ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx}")
+set(ZITI_ARCHIVE_NAME "ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx}")
+set(ZITI_EXECUTABLE_NAME "ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}")
 if (UNIX)
     add_custom_target(ziti-prox-c-pack
-            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
+            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}
             DEPENDS ziti-prox-c
-            COMMAND tar zcf ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+            COMMAND tar zcf ${ZITI_ARCHIVE_NAME} ${ZITI_EXECUTABLE_NAME}
             )
 else()
     if(EXISTS "${ZITI_EXECUTABLE_NAME}")
         add_custom_target(ziti-prox-c-pack
-                BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
+                BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
                 DEPENDS ziti-prox-c
-                COMMAND zip ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+                COMMAND zip "${ZITI_ARCHIVE_NAME}" "${ZITI_EXECUTABLE_NAME}"
                 )
     else()
-        if(EXISTS "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME}")
-        add_custom_target(ziti-prox-c-pack
-                BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
+        if(EXISTS "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}")
+            add_custom_target(ziti-prox-c-pack
+                BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
                 DEPENDS ziti-prox-c
-                COMMAND zip "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME}" ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
-                )
+                COMMAND zip "${ZITI_ARCHIVE_NAME}" "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}"
+            )
         else()
-            MESSAGE("NO EXECUTABLE EXISTS: ${ZITI_EXECUTABLE_NAME}")
+            MESSAGE(FATAL_ERROR "NO EXECUTABLE EXISTS AT THE EXPECTED LOCATION: ${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}")
         endif()
     endif()
 endif()
 
-#add_dependencies(publish ${ZITI_EXECUTABLE_NAME})
+#add_dependencies(publish ${ZITI_ARCHIVE_NAME})
 PUBCOMP(ziti-prox-c)

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
         add_custom_target(ziti-prox-c-pack
                 BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
                 DEPENDS ziti-prox-c
-                COMMAND ${CMAKE_BUILD_TYPE}/zip ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+                COMMAND ${CMAKE_BUILD_TYPE}/zip "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
                 )
         else()
             MESSAGE("NO EXECUTABLE EXISTS: ${ZITI_EXECUTABLE_NAME}")

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -14,27 +14,17 @@ set(ZITI_ARCHIVE_NAME "ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archiv
 set(ZITI_EXECUTABLE_NAME "ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}")
 if (UNIX)
     add_custom_target(ziti-prox-c-pack
-            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}
-            DEPENDS ziti-prox-c
-            COMMAND tar zcf ${ZITI_ARCHIVE_NAME} ${ZITI_EXECUTABLE_NAME}
-            )
+        BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}
+        DEPENDS ziti-prox-c
+        COMMAND tar zcf ${ZITI_ARCHIVE_NAME} ${ZITI_EXECUTABLE_NAME}
+    )
 else()
-    if(EXISTS "${ZITI_EXECUTABLE_NAME}")
+    if(EXISTS "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}")
         add_custom_target(ziti-prox-c-pack
-                BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
-                DEPENDS ziti-prox-c
-                COMMAND zip "${ZITI_ARCHIVE_NAME}" "${ZITI_EXECUTABLE_NAME}"
-                )
-    else()
-        if(EXISTS "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}")
-            add_custom_target(ziti-prox-c-pack
-                BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
-                DEPENDS ziti-prox-c
-                COMMAND zip "${ZITI_ARCHIVE_NAME}" "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}"
-            )
-        else()
-            MESSAGE(FATAL_ERROR "NO EXECUTABLE EXISTS AT THE EXPECTED LOCATION: ${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}")
-        endif()
+            BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/${ZITI_ARCHIVE_NAME}"
+            DEPENDS ziti-prox-c
+            COMMAND zip "${ZITI_ARCHIVE_NAME}" "${PROJECT_BINARY_DIR}/${CMAKE_BUILD_TYPE_INIT}/${ZITI_EXECUTABLE_NAME}"
+        )
     endif()
 endif()
 

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -37,5 +37,5 @@ else()
     endif()
 endif()
 
-#add_dependencies(publish ZITI_EXECUTABLE_NAME)
+#add_dependencies(publish ${ZITI_EXECUTABLE_NAME})
 PUBCOMP(ziti-prox-c)

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
         add_custom_target(ziti-prox-c-pack
                 BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
                 DEPENDS ziti-prox-c
-                COMMAND zip "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+                COMMAND zip "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME}" ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
                 )
         else()
             MESSAGE("NO EXECUTABLE EXISTS: ${ZITI_EXECUTABLE_NAME}")

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
         add_custom_target(ziti-prox-c-pack
                 BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
                 DEPENDS ziti-prox-c
-                COMMAND ${CMAKE_BUILD_TYPE}/zip "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+                COMMAND zip "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
                 )
         else()
             MESSAGE("NO EXECUTABLE EXISTS: ${ZITI_EXECUTABLE_NAME}")

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -10,19 +10,30 @@ endif()
 target_link_libraries(ziti-prox-c PUBLIC ziti subcommand)
 target_include_directories(ziti-prox-c PRIVATE ${ziti-sdk_SOURCE_DIR}/inc_internal)
 
+set(ZITI_EXECUTABLE_NAME "ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx}")
 if (UNIX)
     add_custom_target(ziti-prox-c-pack
-            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx}
+            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
             DEPENDS ziti-prox-c
-            COMMAND tar zcf ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+            COMMAND tar zcf ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
             )
 else()
-    add_custom_target(ziti-prox-c-pack
-            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx}
-            DEPENDS ziti-prox-c
-            COMMAND zip ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
-            )
+    if(EXISTS "${ZITI_EXECUTABLE_NAME}")
+        add_custom_target(ziti-prox-c-pack
+                BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
+                DEPENDS ziti-prox-c
+                COMMAND zip ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+                )
+    else()
+        if(EXISTS "${CMAKE_BUILD_TYPE}/${ZITI_EXECUTABLE_NAME}")
+        add_custom_target(ziti-prox-c-pack
+                BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${ZITI_EXECUTABLE_NAME}
+                DEPENDS ziti-prox-c
+                COMMAND ${CMAKE_BUILD_TYPE}/zip ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
+                )
+        else()
+    endif()
 endif()
 
-#add_dependencies(publish ziti-prox-c-${ZITI_VERSION}-${CPACK_SYSTEM_NAME}.${archive_sfx})
+#add_dependencies(publish ZITI_EXECUTABLE_NAME)
 PUBCOMP(ziti-prox-c)

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -32,6 +32,8 @@ else()
                 COMMAND ${CMAKE_BUILD_TYPE}/zip ${ZITI_EXECUTABLE_NAME} ziti-prox-c${CMAKE_EXECUTABLE_SUFFIX}
                 )
         else()
+            MESSAGE("NO EXECUTABLE EXISTS: ${ZITI_EXECUTABLE_NAME}")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
when building with msbuild/visual studio the packaging of ziti-prox-c fails because the executable is located in a folder named either Debug or Release... this should fix that - as well as work the way it used to...

also extracted all the common variable stuff to a single variable