### PR TITLE
guard against null pointer passed to metrics_rate_get

### DIFF
--- a/library/metrics.c
+++ b/library/metrics.c
@@ -125,6 +125,7 @@ extern void metrics_rate_update(rate_t *r, long delta) {
 }
 
 extern double metrics_rate_get(rate_t *r) {
+    if (r == NULL) return 0;
     double rate = (*(double*)&r->rate) * (SECOND);
     return rate;
 }


### PR DESCRIPTION
obviously one shouldn't pass a NULL pointer to this function but when that happens it'll crash. this could get fixed in `ziti_get_transfer_rates` too but this seems like the best place to me to handle this situation. open to other thoughts as to how to mitigate this issue but this still seems like 'a good idea', no?