### PR TITLE
remove unused argument from ziti_init_opts

### DIFF
--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -443,7 +443,7 @@ extern int ziti_init(const char *config, uv_loop_t *loop, ziti_event_cb evnt_cb,
  * @see ziti_init()
  */
 ZITI_FUNC
-extern int ziti_init_opts(ziti_options *options, uv_loop_t *loop, void *init_ctx);
+extern int ziti_init_opts(ziti_options *options, uv_loop_t *loop);
 
 /**
  * @brief returns ziti_options.app_ctx for the given Ziti context.

--- a/includes/ziti/ziti_events.h
+++ b/includes/ziti/ziti_events.h
@@ -71,7 +71,7 @@ struct ziti_router_event {
  * \brief Ziti Service Status event.
  *
  * Event notifying app about service access changes.
- * Each fiels is a NULL-terminated array of `ziti_service*`.
+ * Each field is a NULL-terminated array of `ziti_service*`.
  *
  * \see ziti_service
  */

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -153,7 +153,7 @@ int load_tls(ziti_config *cfg, tls_context **ctx) {
     return ZITI_OK;
 }
 
-int ziti_init_opts(ziti_options *options, uv_loop_t *loop, void *init_ctx) {
+int ziti_init_opts(ziti_options *options, uv_loop_t *loop) {
     ziti_log_init(loop, ZITI_LOG_DEFAULT_LEVEL, NULL);
     metrics_init(loop, 5);
 
@@ -254,7 +254,7 @@ int ziti_init(const char *config, uv_loop_t *loop, ziti_event_cb event_cb, int e
     opts->app_ctx = app_ctx;
     opts->config_types = ALL_CONFIG_TYPES;
 
-    return ziti_init_opts(opts, loop, app_ctx);
+    return ziti_init_opts(opts, loop);
 }
 
 extern void *ziti_app_ctx(ziti_context ztx) {

--- a/programs/wzcat/ziti_ws.c
+++ b/programs/wzcat/ziti_ws.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
             .events = ZitiContextEvent,
             .app_ctx = ws_service,
     };
-    ziti_init_opts(&opts, l, ws_service);
+    ziti_init_opts(&opts, l);
 
     uv_run(l, UV_RUN_DEFAULT);
 

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -521,7 +521,7 @@ void run(int argc, char **argv) {
             .metrics_type = INSTANT,
     };
 
-    ziti_init_opts(&opts, loop, &app_ctx);
+    ziti_init_opts(&opts, loop);
 
 
 #if __unix__ || __unix


### PR DESCRIPTION
The app context is passed via ziti_options.app_ctx when using ziti_init_opts. This PR removes the unused and potentially misleading `init_ctx` argument from `ziti_init_opts`.