### PR TITLE
fix multiple posture submits erroring on top of eachother

### DIFF
--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -47,6 +47,8 @@ void ziti_posture_init(ziti_context ztx, long interval_secs);
 
 void ziti_posture_checks_free(struct posture_checks *pcs);
 
+void ziti_posture_checks_shutdown(struct posture_checks *pcs) ;
+
 void ziti_send_posture_data(ziti_context ztx);
 
 #ifdef __cplusplus

--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 struct posture_checks {
-    uv_timer_t timer;
+    uv_timer_t *timer;
     double interval;
 
     // map<type/process_path,response>
@@ -46,8 +46,6 @@ struct posture_checks {
 void ziti_posture_init(ziti_context ztx, long interval_secs);
 
 void ziti_posture_checks_free(struct posture_checks *pcs);
-
-void ziti_posture_checks_shutdown(struct posture_checks *pcs) ;
 
 void ziti_send_posture_data(ziti_context ztx);
 

--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -23,11 +23,31 @@ limitations under the License.
 #ifdef __cplusplus
 extern "C" {
 #endif
-void posture_init(struct ziti_ctx *ztx, long interval_secs);
+
+struct posture_checks {
+    uv_timer_t timer;
+    double interval;
+
+    // map<type/process_path,response>
+    model_map *previous_responses;
+
+    // map<type/process_path,response>
+    model_map *current_responses;
+
+
+    // map<type/process_path, is errored
+    model_map *error_states;
+
+    char *previous_session_id;
+    bool must_send;
+    bool must_send_every_time;
+};
+
+void ziti_posture_init(ziti_context ztx, long interval_secs);
 
 void ziti_posture_checks_free(struct posture_checks *pcs);
 
-void ziti_send_posture_data(struct ziti_ctx *ztx);
+void ziti_send_posture_data(ziti_context ztx);
 
 #ifdef __cplusplus
 }

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -29,6 +29,7 @@ limitations under the License.
 #include "ziti_ctrl.h"
 #include "metrics.h"
 #include "edge_protocol.h"
+#include "posture.h"
 
 #include <sodium.h>
 
@@ -156,21 +157,6 @@ struct process {
     char *sha_512_hash;
     char **signers;
     int num_signers;
-};
-
-struct posture_checks {
-    uv_timer_t timer;
-    double interval;
-
-    // map<type/process_path,response>
-    model_map *previous_responses;
-
-    // map<type/process_path,response>
-    model_map *current_responses;
-
-    char *previous_session_id;
-    bool must_send;
-    bool must_send_every_time;
 };
 
 struct ziti_ctx {

--- a/library/posture.c
+++ b/library/posture.c
@@ -82,7 +82,7 @@ static void ziti_pr_free_pr_cb_ctx(pr_cb_ctx *ctx) {
     FREE(ctx)
 }
 
-extern void ziti_posture_init(ziti_context ztx, long interval_secs) {
+void ziti_posture_init(ziti_context ztx, long interval_secs) {
     if (ztx->posture_checks == NULL) {
         NEWP(pc, struct posture_checks);
 
@@ -105,8 +105,16 @@ extern void ziti_posture_init(ziti_context ztx, long interval_secs) {
     }
 }
 
-extern void ziti_posture_checks_free(struct posture_checks *pcs) {
+void ziti_posture_checks_shutdown(struct posture_checks *pcs) {
+    if(pcs != NULL) {
+        uv_timer_stop(&pcs->timer);
+    }
+}
+
+void ziti_posture_checks_free(struct posture_checks *pcs) {
     if (pcs != NULL) {
+        ziti_posture_checks_shutdown(pcs);
+
         if(pcs->previous_responses != NULL) {
             model_map_clear(pcs->previous_responses, (_free_f) ziti_pr_free_pr_info_members);
             FREE(pcs->previous_responses)

--- a/library/posture.c
+++ b/library/posture.c
@@ -107,9 +107,21 @@ extern void ziti_posture_init(ziti_context ztx, long interval_secs) {
 
 extern void ziti_posture_checks_free(struct posture_checks *pcs) {
     if (pcs != NULL) {
-        model_map_clear(pcs->previous_responses, (_free_f) ziti_pr_free_pr_info_members);
-        model_map_clear(pcs->current_responses, (_free_f) ziti_pr_free_pr_info_members);
-        model_map_clear(pcs->error_states, NULL);
+        if(pcs->previous_responses != NULL) {
+            model_map_clear(pcs->previous_responses, (_free_f) ziti_pr_free_pr_info_members);
+            FREE(pcs->previous_responses)
+        }
+
+        if(pcs->current_responses != NULL) {
+            model_map_clear(pcs->current_responses, (_free_f) ziti_pr_free_pr_info_members);
+            FREE(pcs->current_responses)
+        }
+
+        if(pcs->error_states != NULL) {
+            model_map_clear(pcs->error_states, NULL);
+            FREE(pcs->error_states)
+        }
+
         FREE(pcs)
     }
 }
@@ -197,6 +209,7 @@ void ziti_send_posture_data(ziti_context ztx) {
     //free previous responses, set current responses to an empty map
     if (ztx->posture_checks->previous_responses != NULL) {
         model_map_clear(ztx->posture_checks->previous_responses, (_free_f) ziti_pr_free_pr_info_members);
+        FREE(ztx->posture_checks->previous_responses)
     }
 
     ztx->posture_checks->previous_responses = ztx->posture_checks->current_responses;

--- a/library/posture.c
+++ b/library/posture.c
@@ -22,8 +22,8 @@ limitations under the License.
 
 const int NO_TIMEOUTS = -1;
 
-const bool IS_ERRORED = TRUE;
-const bool IS_NOT_ERRORED = FALSE;
+const bool IS_ERRORED = true;
+const bool IS_NOT_ERRORED = false;
 
 struct query_info {
     ziti_service *service;
@@ -399,7 +399,7 @@ static void ziti_pr_send_bulk(ziti_context ztx) {
         }
     }
 
-    strncat(body, "]", 1);
+    strcat(body, "]");
 
     ZITI_LOG(DEBUG, "sending posture responses [%d]", obj_count);
     ZITI_LOG(TRACE, "bulk posture response: %s", body);

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -312,8 +312,7 @@ int ziti_shutdown(ziti_context ztx) {
 
     uv_timer_stop(&ztx->refresh_timer);
     uv_timer_stop(&ztx->session_timer);
-
-    ziti_posture_checks_shutdown(ztx->posture_checks);
+    uv_timer_stop(ztx->posture_checks->timer);
 
     ziti_close_channels(ztx);
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -794,7 +794,7 @@ static void session_cb(ziti_session *session, ziti_error *err, void *ctx) {
             uv_timer_stop(&ztx->refresh_timer);
         }
 
-        posture_init(ztx, 20);
+        ziti_posture_init(ztx, 20);
 
         if (!ztx->no_current_edge_routers) {
             ziti_ctrl_current_edge_routers(&ztx->controller, edge_routers_cb, ztx);

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -312,7 +312,8 @@ int ziti_shutdown(ziti_context ztx) {
 
     uv_timer_stop(&ztx->refresh_timer);
     uv_timer_stop(&ztx->session_timer);
-    uv_timer_stop(&ztx->posture_checks->timer);
+
+    ziti_posture_checks_shutdown(ztx->posture_checks);
 
     ziti_close_channels(ztx);
 


### PR DESCRIPTION
- fix memory leaks on model maps and ziti_error's in posture.c
- avoid using shared memory during individual posture response submits
  for older controllers