### PR TITLE
better model to json

### DIFF
--- a/inc_internal/buffer.h
+++ b/inc_internal/buffer.h
@@ -28,16 +28,37 @@ typedef intptr_t ssize_t;
 #endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct buffer_s buffer;
 
 buffer *new_buffer();
-void free_buffer(buffer*);
+void free_buffer(buffer *);
 
 void buffer_cleanup(buffer *);
-ssize_t buffer_get_next(buffer*, size_t want, uint8_t** ptr);
-void buffer_push_back(buffer*, size_t);
-void buffer_append(buffer*, uint8_t *buf, size_t len);
-size_t buffer_available(buffer*);
+ssize_t buffer_get_next(buffer *, size_t want, uint8_t **ptr);
+void buffer_push_back(buffer *, size_t);
+void buffer_append(buffer *, uint8_t *buf, size_t len);
+size_t buffer_available(buffer *);
 
+
+struct write_buf_s {
+    buffer *buf;
+    uint8_t *chunk;
+    uint8_t *wp;
+};
+typedef struct write_buf_s write_buf_t;
+
+void write_buf_init(write_buf_t *wb);
+int write_buf_append(write_buf_t *wb, const char *str);
+int write_buf_append_byte(write_buf_t *wb, char c);
+char *write_buf_to_string(write_buf_t *wb, size_t *outlen);
+void write_buf_free(write_buf_t *wb);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //ZITI_SDK_BUFFER_H

--- a/inc_internal/buffer.h
+++ b/inc_internal/buffer.h
@@ -47,14 +47,18 @@ size_t buffer_available(buffer *);
 
 struct write_buf_s {
     buffer *buf;
+    bool fixed;
+    size_t chunk_size;
     uint8_t *chunk;
     uint8_t *wp;
 };
 typedef struct write_buf_s write_buf_t;
 
 void write_buf_init(write_buf_t *wb);
+void write_buf_init_fixed(write_buf_t *wb, char *outbuf, size_t max);
 int write_buf_append(write_buf_t *wb, const char *str);
 int write_buf_append_byte(write_buf_t *wb, char c);
+size_t write_buf_size(write_buf_t *wb);
 char *write_buf_to_string(write_buf_t *wb, size_t *outlen);
 void write_buf_free(write_buf_t *wb);
 

--- a/inc_internal/buffer.h
+++ b/inc_internal/buffer.h
@@ -17,9 +17,10 @@ limitations under the License.
 #ifndef ZITI_SDK_BUFFER_H
 #define ZITI_SDK_BUFFER_H
 
+#include <stdint.h>
+
 #if !defined(__DEFINED_ssize_t) && !defined(__ssize_t_defined)
 #if _WIN32
-#include <stdint.h>
 typedef intptr_t ssize_t;
 #define __DEFINED_ssize_t
 #define __ssize_t_defined

--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -52,6 +52,8 @@ limitations under the License.
 
 #define MODEL_API
 
+#define MODEL_JSON_COMPACT 0x1
+
 #define none(t) t
 #define ptr(t)  t*
 #define array(t) t##_array

--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -28,6 +28,16 @@ limitations under the License.
 
 #include "externs.h"
 
+#if !defined(__DEFINED_ssize_t) && !defined(__ssize_t_defined)
+#if _WIN32
+typedef intptr_t ssize_t;
+#define __DEFINED_ssize_t
+#define __ssize_t_defined
+#else
+#include <unistd.h>
+#endif
+#endif
+
 /**
  * set of macros to help generate struct and function for our model;
  *
@@ -74,7 +84,7 @@ MODEL_API void free_##type##_array(array(type) *ap);\
 MODEL_API int parse_##type(ptr(type) v, const char* json, size_t len);\
 MODEL_API int parse_##type##_ptr(ptr(type) *p, const char* json, size_t len);\
 MODEL_API int parse_##type##_array(array(type) *a, const char* json, size_t len); \
-/** write to fixeb buffer */                                 \
+/** write to fixed buffer */                                 \
 MODEL_API ssize_t type##_to_json_r(const ptr(type) v, int flags, char *outbuf, size_t max); \
 MODEL_API char* type##_to_json(const ptr(type) v, int flags, size_t *len);
 
@@ -261,9 +271,6 @@ Values(enum_field, Enum)                          \
 };                                 \
 MODEL_API type_meta* get_##Enum##_meta();\
 extern const struct Enum##_s Enum##s;
-
-#define EVAL(...) __VA_ARGS__
-#define EVAL1(...) EVAL(EVAL(EVAL(__VA_ARGS__)))
 
 #define call_f(f,args) f args
 #define enum_value_of1(v, t, s, n) if(strncmp(s,#v,n) == 0){return (t)t##s.v;}

--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -74,6 +74,8 @@ MODEL_API void free_##type##_array(array(type) *ap);\
 MODEL_API int parse_##type(ptr(type) v, const char* json, size_t len);\
 MODEL_API int parse_##type##_ptr(ptr(type) *p, const char* json, size_t len);\
 MODEL_API int parse_##type##_array(array(type) *a, const char* json, size_t len); \
+/** write to fixeb buffer */                                 \
+MODEL_API ssize_t type##_to_json_r(const ptr(type) v, int flags, char *outbuf, size_t max); \
 MODEL_API char* type##_to_json(const ptr(type) v, int flags, size_t *len);
 
 #define gen_field_meta(n, memtype, modifier, p, partype) {\
@@ -107,6 +109,8 @@ ptr(type) alloc_##type() { return (ptr(type))calloc(1, sizeof(type)); } \
 int cmp_##type(const type *lh, const type *rh) { return model_cmp(lh, rh, &type##_META); }\
 void free_##type(type *v) { model_free(v, &type##_META); } \
 void free_##type##_array(array(type) *ap) { model_free_array((void***)ap, &type##_META); }                      \
+MODEL_API ssize_t type##_to_json_r(const ptr(type) v, int flags, char *outbuf, size_t max) {                    \
+return model_to_json_r(v, &type##_META, flags, outbuf, max); } \
 char* type##_to_json(const ptr(type) v, int flags, size_t *len) { return model_to_json(v, &type##_META, flags, len); }
 
 
@@ -164,6 +168,8 @@ ZITI_FUNC int model_parse(void *obj, const char *json, size_t len, type_meta *me
 ZITI_FUNC int model_parse_array(void ***arp, const char *json, size_t len, type_meta *meta);
 
 ZITI_FUNC char *model_to_json(const void *obj, const type_meta *meta, int flags, size_t *len);
+
+ZITI_FUNC ssize_t model_to_json_r(const void *obj, const type_meta *meta, int flags, char *outbuf, size_t max);
 
 ZITI_FUNC extern type_meta *get_bool_meta();
 

--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -72,8 +72,7 @@ MODEL_API void free_##type##_array(array(type) *ap);\
 MODEL_API int parse_##type(ptr(type) v, const char* json, size_t len);\
 MODEL_API int parse_##type##_ptr(ptr(type) *p, const char* json, size_t len);\
 MODEL_API int parse_##type##_array(array(type) *a, const char* json, size_t len); \
-MODEL_API char* type##_to_json(const ptr(type) v, int flags, size_t *len);\
-MODEL_API int json_from_##type(const ptr(type) v, char *buf, size_t maxlen, size_t *len);
+MODEL_API char* type##_to_json(const ptr(type) v, int flags, size_t *len);
 
 #define gen_field_meta(n, memtype, modifier, p, partype) {\
 .name = #n, \
@@ -106,9 +105,7 @@ ptr(type) alloc_##type() { return (ptr(type))calloc(1, sizeof(type)); } \
 int cmp_##type(const type *lh, const type *rh) { return model_cmp(lh, rh, &type##_META); }\
 void free_##type(type *v) { model_free(v, &type##_META); } \
 void free_##type##_array(array(type) *ap) { model_free_array((void***)ap, &type##_META); }                      \
-char* type##_to_json(const ptr(type) v, int flags, size_t *len) { return model_to_json2(v, &type##_META, flags, len); }\
-int json_from_##type(const ptr(type) v, char *json, size_t maxlen, size_t *len)\
-{ return -1; }
+char* type##_to_json(const ptr(type) v, int flags, size_t *len) { return model_to_json(v, &type##_META, flags, len); }
 
 
 #ifdef __cplusplus
@@ -164,8 +161,7 @@ ZITI_FUNC int model_parse(void *obj, const char *json, size_t len, type_meta *me
 
 ZITI_FUNC int model_parse_array(void ***arp, const char *json, size_t len, type_meta *meta);
 
-ZITI_FUNC int model_to_json(const void *obj, type_meta *meta, int indent, char *buf, size_t maxlen, size_t *len);
-ZITI_FUNC char *model_to_json2(const void *obj, const type_meta *meta, int flags, size_t *len);
+ZITI_FUNC char *model_to_json(const void *obj, const type_meta *meta, int flags, size_t *len);
 
 ZITI_FUNC extern type_meta *get_bool_meta();
 

--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -71,7 +71,8 @@ MODEL_API int cmp_##type(const type *lh, const type *rh); \
 MODEL_API void free_##type##_array(array(type) *ap);\
 MODEL_API int parse_##type(ptr(type) v, const char* json, size_t len);\
 MODEL_API int parse_##type##_ptr(ptr(type) *p, const char* json, size_t len);\
-MODEL_API int parse_##type##_array(array(type) *a, const char* json, size_t len);\
+MODEL_API int parse_##type##_array(array(type) *a, const char* json, size_t len); \
+MODEL_API char* type##_to_json(const ptr(type) v, int flags, size_t *len);\
 MODEL_API int json_from_##type(const ptr(type) v, char *buf, size_t maxlen, size_t *len);
 
 #define gen_field_meta(n, memtype, modifier, p, partype) {\
@@ -104,9 +105,10 @@ int parse_##type##_array(array(type) *a, const char *json, size_t len) { return 
 ptr(type) alloc_##type() { return (ptr(type))calloc(1, sizeof(type)); } \
 int cmp_##type(const type *lh, const type *rh) { return model_cmp(lh, rh, &type##_META); }\
 void free_##type(type *v) { model_free(v, &type##_META); } \
-void free_##type##_array(array(type) *ap) { model_free_array((void***)ap, &type##_META); }\
-MODEL_API int json_from_##type(const ptr(type) v, char *json, size_t maxlen, size_t *len)\
-{ return model_to_json(v, &type##_META, 0, json, maxlen, len); }
+void free_##type##_array(array(type) *ap) { model_free_array((void***)ap, &type##_META); }                      \
+char* type##_to_json(const ptr(type) v, int flags, size_t *len) { return model_to_json2(v, &type##_META, flags, len); }\
+int json_from_##type(const ptr(type) v, char *json, size_t maxlen, size_t *len)\
+{ return -1; }
 
 
 #ifdef __cplusplus
@@ -136,7 +138,7 @@ typedef struct field_meta {
 
 typedef int (*_parse_f)(void *obj, const char *json, void *tok);
 
-typedef int (*_to_json_f)(const void *obj, int indent, char *json, size_t max, size_t *len);
+typedef int (*_to_json_f)(const void *obj, void *buf, int indent, int flags);
 
 typedef void (*_free_f)(void *obj);
 typedef int (*_cmp_f)(const void *lh, const void *rh);
@@ -163,6 +165,7 @@ ZITI_FUNC int model_parse(void *obj, const char *json, size_t len, type_meta *me
 ZITI_FUNC int model_parse_array(void ***arp, const char *json, size_t len, type_meta *meta);
 
 ZITI_FUNC int model_to_json(const void *obj, type_meta *meta, int indent, char *buf, size_t maxlen, size_t *len);
+ZITI_FUNC char *model_to_json2(const void *obj, const type_meta *meta, int flags, size_t *len);
 
 ZITI_FUNC extern type_meta *get_bool_meta();
 

--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -234,7 +234,7 @@ typedef struct {
 ZITI_FUNC type_meta *get_tag_meta();
 
 ZITI_FUNC int parse_enum(void *ptr, const char *json, void *tok, const void *enum_type);
-ZITI_FUNC int json_enum(const void *ptr, char *json, size_t max, size_t *len, const void *enum_type);
+ZITI_FUNC int json_enum(const void *ptr, void *buf, int indent, int flags, const void *enum_type);
 
 #define mk_enum(v,t) t##_##v,
 #define enum_field(v,t) const t v;
@@ -290,8 +290,8 @@ return get_int_meta()->comparer(lh, rh);               \
 static int parse_##Enum(ptr(Enum) e, const char* json, void *tok) {     \
 return parse_enum(e, json, tok, &Enum##s);                              \
 }\
-static int Enum##_json(const ptr(Enum) e, int indent, char *json, size_t max, size_t *len) {     \
-return json_enum(e, json, max, len, &Enum##s);                              \
+static int Enum##_json(const ptr(Enum) e, void *buf, int indent, int flags) {     \
+return json_enum(e, buf, indent, flags, &Enum##s);                              \
 }\
 static type_meta Enum##_meta = {\
         .name = #Enum,        \

--- a/library/buffer.c
+++ b/library/buffer.c
@@ -117,6 +117,67 @@ void buffer_append(buffer* b, uint8_t *buf, size_t len) {
     STAILQ_INSERT_TAIL(&b->chunks, e, next);
 }
 
-size_t buffer_available(buffer* b) {
+size_t buffer_available(buffer *b) {
     return b->available;
+}
+
+#define WRITE_BUF_CHUNK_SIZE 1024
+
+void write_buf_init(write_buf_t *wb) {
+    wb->chunk = malloc(WRITE_BUF_CHUNK_SIZE);
+    wb->buf = new_buffer();
+    wb->wp = wb->chunk;
+}
+
+int write_buf_append_byte(write_buf_t *wb, char c) {
+    if (wb->wp - wb->chunk >= WRITE_BUF_CHUNK_SIZE) {
+        buffer_append(wb->buf, wb->chunk, wb->wp - wb->chunk);
+        wb->chunk = malloc(WRITE_BUF_CHUNK_SIZE);
+        wb->wp = wb->chunk;
+    }
+    *wb->wp++ = c;
+    return 0;
+}
+
+int write_buf_append(write_buf_t *wb, const char *str) {
+    const char *s = str;
+
+    copy:
+    while (*s != '\0' && wb->wp < wb->chunk + WRITE_BUF_CHUNK_SIZE) { *wb->wp++ = *s++; }
+
+    if (*s != 0) {
+        buffer_append(wb->buf, wb->chunk, wb->wp - wb->chunk);
+        wb->chunk = malloc(WRITE_BUF_CHUNK_SIZE);
+        wb->wp = wb->chunk;
+        goto copy;
+    }
+
+    return 0;
+}
+
+char *write_buf_to_string(write_buf_t *wb, size_t *outlen) {
+    size_t bytes_in_buffer = buffer_available(wb->buf);
+    char *result = malloc(bytes_in_buffer + (wb->wp - wb->chunk) + 1);
+
+    size_t copied = 0;
+    while (copied < bytes_in_buffer) {
+        uint8_t *copyp;
+        size_t copy_len = buffer_get_next(wb->buf, bytes_in_buffer, &copyp);
+        memcpy(result + copied, copyp, copy_len);
+        copied += copy_len;
+    }
+
+    memcpy(result + copied, wb->chunk, wb->wp - wb->chunk);
+    result[copied + (wb->wp - wb->chunk)] = 0;
+    if (outlen) {
+        *outlen = copied + (wb->wp - wb->chunk);
+    }
+    return result;
+}
+
+void write_buf_free(write_buf_t *wb) {
+    wb->wp = NULL;
+    FREE(wb->chunk);
+    free_buffer(wb->buf);
+    wb->buf = NULL;
 }

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -945,15 +945,12 @@ int parse_enum(void *ptr, const char *json, void *tok, const void *enum_type) {
     return 0;
 }
 
-int json_enum(const void *ptr, char *json, size_t max, size_t *len, const void *enum_type) {
+int json_enum(const void *ptr, void *bufp, int indent, int flags, const void *enum_type) {
+    write_buf_t *buf = bufp;
     int en_val = *(int*)ptr;
     const struct generic_enum_s *en = enum_type;
-    int rc = snprintf(json, max, "\"%s\"", en->name(en_val));
-    if (rc > 0) {
-        *len = rc;
-        return 0;
-    }
-    return rc;
+
+    return string_to_json(en->name(en_val), buf, indent, flags);
 }
 
 

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -186,7 +186,7 @@ int model_parse(void *obj, const char *json, size_t len, type_meta *meta) {
 
 static int write_model_to_buf(const void *obj, const type_meta *meta, write_buf_t *buf, int indent, int flags);
 
-char *model_to_json2(const void *obj, const type_meta *meta, int flags, size_t *len) {
+char *model_to_json(const void *obj, const type_meta *meta, int flags, size_t *len) {
     write_buf_t json;
     write_buf_init(&json);
     char *result = NULL;
@@ -299,8 +299,6 @@ int write_model_to_buf(const void *obj, const type_meta *meta, write_buf_t *buf,
     write_buf_append(buf, "}");
     return 0;
 }
-
-
 
 void model_free_array(void ***ap, type_meta *meta) {
     if (ap == NULL || *ap == NULL) { return; }
@@ -808,7 +806,7 @@ static int string_to_json(const char *str, write_buf_t *buf, int indent, int fla
     static char hex[] = "0123456789abcdef";
 
     write_buf_append(buf, "\"");
-    const char *s = str;
+    const unsigned char *s = (const unsigned char *) str;
 
     while (*s != '\0') {
         switch (*s) {

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -187,6 +187,11 @@ int model_parse(void *obj, const char *json, size_t len, type_meta *meta) {
 static int write_model_to_buf(const void *obj, const type_meta *meta, write_buf_t *buf, int indent, int flags);
 
 char *model_to_json(const void *obj, const type_meta *meta, int flags, size_t *len) {
+    if (obj == NULL) {
+        if (len) *len = 0;
+        return NULL;
+    }
+
     write_buf_t json;
     write_buf_init(&json);
     char *result = NULL;

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -24,6 +24,7 @@ limitations under the License.
 #include <jsmn.h>
 
 #include <ziti/model_support.h>
+#include <buffer.h>
 #include <utils.h>
 
 #if _WIN32
@@ -33,7 +34,6 @@ limitations under the License.
 #define _GNU_SOURCE //add time.h include after defining _GNU_SOURCE
 
 #include <time.h>
-#include <buffer.h>
 
 #endif
 

--- a/library/posture.c
+++ b/library/posture.c
@@ -467,10 +467,8 @@ static void ziti_pr_handle_mac(ziti_context ztx, char *id, char **mac_addresses,
             .mac_addresses = addresses,
     };
 
-    char *obj = malloc(1024);
     size_t obj_len;
-
-    json_from_ziti_pr_mac_req(&mac_req, obj, 1024, &obj_len);
+    char *obj = ziti_pr_mac_req_to_json(&mac_req, 0, &obj_len);
 
     ziti_collect_pr(ztx, PC_MAC_TYPE, obj, obj_len);
 
@@ -484,10 +482,8 @@ static void ziti_pr_handle_domain(ziti_context ztx, char *id, char *domain) {
             .typeId = (char *) PC_DOMAIN_TYPE,
     };
 
-    char *obj = malloc(1024);
     size_t obj_len;
-
-    json_from_ziti_pr_domain_req(&domain_req, obj, 1024, &obj_len);
+    char *obj = ziti_pr_domain_req_to_json(&domain_req, 0, &obj_len);
 
     ziti_collect_pr(ztx, PC_DOMAIN_TYPE, obj, obj_len);
 }
@@ -501,10 +497,8 @@ static void ziti_pr_handle_os(ziti_context ztx, char *id, char *os_type, char *o
             .build = (char *) os_build
     };
 
-    char *obj = malloc(1024);
     size_t obj_len;
-
-    json_from_ziti_pr_os_req(&os_req, obj, 1024, &obj_len);
+    char *obj = ziti_pr_os_req_to_json(&os_req, 0, &obj_len);
 
     ziti_collect_pr(ztx, PC_OS_TYPE, obj, obj_len);
 }
@@ -525,10 +519,8 @@ static void ziti_pr_handle_process(ziti_context ztx, char *id, char *path, bool 
             .signers = null_term_signers,
     };
 
-    char *obj = malloc(1024);
     size_t obj_len;
-
-    json_from_ziti_pr_process_req(&process_req, obj, 1024, &obj_len);
+    char *obj = ziti_pr_process_req_to_json(&process_req, 0, &obj_len);
 
     free(null_term_signers);
 

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -327,9 +327,8 @@ void ziti_ctrl_login(
             .config_types = (string_array) cfg_types,
     };
 
-    char *body = malloc(1024);
     size_t body_len;
-    json_from_ziti_auth_req(&authreq, body, 1024, &body_len);
+    char *body = ziti_auth_req_to_json(&authreq, 0, &body_len);
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_session_ptr;

--- a/programs/sample_enroll/sample_enroll.c
+++ b/programs/sample_enroll/sample_enroll.c
@@ -37,22 +37,22 @@ const char *output_file;
 static int write_identity_file(ziti_config *cfg) {
     FILE *f;
 
-    char output_buf[16000];
     size_t len;
-    json_from_ziti_config(cfg, output_buf, sizeof(output_buf), &len);
+    char *output_buf = ziti_config_to_json(cfg, 0, &len);
 
     if ((f = fopen(output_file, "wb")) == NULL) {
         return (-1);
     }
 
+    int rc = ZITI_OK;
     if (fwrite(output_buf, 1, len, f) != len) {
-        fclose(f);
-        return (-1);
+        rc = -1;
     }
 
+    free(output_buf);
     fclose( f );
 
-    return( ZITI_OK );
+    return rc;
 }
 
 void on_ziti_enroll(ziti_config *cfg, int status, char *err_message, void *ctx) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(all_tests
         model_tests.cpp
         test_metrics.cpp
         enum_tests.cpp
-        map_tests.cpp)
+        map_tests.cpp buffer_tests.cpp)
 if (WIN32)
     set_property(TARGET all_tests PROPERTY CXX_STANDARD 20)
 else ()

--- a/tests/buffer_tests.cpp
+++ b/tests/buffer_tests.cpp
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2021 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "catch2/catch.hpp"
+
+#include <buffer.h>
+#include <iostream>
+
+#define WRITE_BUF(name) struct name { \
+    buffer *buf; \
+    uint8_t *chunk; \
+    uint8_t *wp; \
+}
+
+#define WRITE_BUF_APPEND(b, s, n) do{ \
+    if ((b)->chunk == NULL) {             \
+        (b)->chunk = malloc(16);              \
+        (b)->wp = chunk;\
+    }                               \
+    if ((b)->wp - (b)->chunk + (n) > 16) {\
+        if ((b)->buf == NULL) (b)->buf = new_buffer(); \
+        buffer_append((b)->buf, (b)->chunk, wp - (b)->chunk);\
+    }\
+} while(0)
+
+TEST_CASE("buffer append", "[util]") {
+    write_buf_t json_buf;
+    write_buf_init(&json_buf);
+
+    std::string test_str;
+
+    for (int i = 0; i < 10; i++) {
+        write_buf_append(&json_buf, "this is a string\n");
+        test_str += "this is a string\n";
+    }
+
+    size_t len;
+    char *result = write_buf_to_string(&json_buf, &len);
+
+    CHECK_THAT(result, Catch::Equals(test_str));
+    CHECK(len == test_str.size());
+
+    write_buf_free(&json_buf);
+}
+

--- a/tests/enum_tests.cpp
+++ b/tests/enum_tests.cpp
@@ -56,14 +56,15 @@ TEST_CASE("parse enum", "[model]") {
 
 TEST_CASE("enum to json", "[model]") {
     FooWithEnum f;
-    f.name = (char*)"awesome foo";
+    f.name = (char *) "awesome foo";
     f.state = States.Bad;
 
-    char json[128];
-    size_t len;
-    REQUIRE(json_from_FooWithEnum(&f, json, 128, &len) == 0);
+    char *json = FooWithEnum_to_json(&f, 0, nullptr);
+
+    REQUIRE(json);
 
     REQUIRE_THAT(json, Catch::Contains("\"state\":\"Bad\""));
+    free(json);
 }
 
 TEST_CASE("enum compare", "[model]") {

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -164,11 +164,10 @@ TEST_CASE("test skipped fields") {
     REQUIRE(foo.barp->isOK);
     REQUIRE_THAT(foo.barp->msg, Catch::Matchers::Equals("hello world!"));
 
-    char json1[1024];
     size_t jsonlen;
-    CHECK(json_from_Foo(&foo, json1, sizeof(json1), &jsonlen) == 0);
+    char *json1 = Foo_to_json(&foo, 0, &jsonlen);
     std::cout << json1 << std::endl;
-
+    free(json1);
     free_Foo(&foo);
 }
 
@@ -180,6 +179,9 @@ TEST_CASE("test string escape", "[model]") {
     Bar bar;
     REQUIRE(parse_Bar(&bar, json, strlen(json)) == 0);
     REQUIRE_THAT(bar.msg, Equals("\thello\n\"world\"!"));
+
+    char *jsonout = Bar_to_json(&bar, 0, NULL);
+    std::cout << jsonout << std::endl;
 }
 
 #define baz_model(XX, ...) \
@@ -227,11 +229,10 @@ TEST_CASE("model map test", "[model]") {
     CHECK_THAT((const char *) model_map_get(&o.map, "num"), Equals("42"));
     CHECK_THAT((const char *) model_map_get(&o.map, "errors"), Equals(R"(["error1", "error2"])"));
 
-    char j[1024];
-    size_t jlen;
-    json_from_ObjMap(&o, j, sizeof(j), &jlen);
+    char *j = ObjMap_to_json(&o, 0, NULL);
 
     std::cout << j << std::endl;
+    free(j);
 
     model_map_clear(&o.map, nullptr);
 }
@@ -386,11 +387,11 @@ TEST_CASE("map of objects", "[model]") {
 
     CHECK_THAT(b1->msg, Equals("this is a message"));
 
-    char buf[1024];
-    size_t json_len;
-    REQUIRE(json_from_MapOfObjects(&m, buf, 1024, &json_len) == 0);
+    char *js = MapOfObjects_to_json(&m, 0, nullptr);
 
-    printf("%.*s", (int) json_len, buf);
+    std::cout << js << std::endl;
+
+    free(js);
 
     free_MapOfObjects(&m);
 }

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -383,7 +383,7 @@ TEST_CASE("map of objects", "[model]") {
 
     CHECK_THAT(b1->msg, Equals("this is a message"));
 
-    char *js = MapOfObjects_to_json(&m, 0, nullptr);
+    char *js = MapOfObjects_to_json(&m, MODEL_JSON_COMPACT, nullptr);
 
     std::cout << js << std::endl;
 

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -528,5 +528,10 @@ TEST_CASE("parse-bad-json-escapes", "[model]") {
         Foo foo;
         CHECK(parse_Foo(&foo, json[i], strlen(json[i])) < 0);
     }
+}
 
+TEST_CASE("null to JSON", "[model]") {
+    char *json = Foo_to_json(nullptr, 0, nullptr);
+
+    CHECK(json == nullptr);
 }

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -350,7 +350,7 @@ TEST_CASE("model with string map", "[model]") {
     CHECK_THAT((const char *) model_map_get(&obj.tags, "ok"), Equals("true"));
     CHECK_THAT((const char *) model_map_get(&obj.tags, "msg"), Equals("hello\nworld!"));
 
-    char *buf = tagged_to_json(&obj, NULL, nullptr);
+    char *buf = tagged_to_json(&obj, 0, nullptr);
 
     printf("%s", buf);
     free_tagged(&obj);

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -384,10 +384,17 @@ TEST_CASE("map of objects", "[model]") {
     CHECK_THAT(b1->msg, Equals("this is a message"));
 
     char *js = MapOfObjects_to_json(&m, MODEL_JSON_COMPACT, nullptr);
-
     std::cout << js << std::endl;
-
     free(js);
+
+    char small_buf[16];
+    ssize_t outlen = MapOfObjects_to_json_r(&m, 0, small_buf, sizeof(small_buf));
+    CHECK(outlen == -1);
+
+    char big_buf[1024];
+    outlen = MapOfObjects_to_json_r(&m, 0, big_buf, sizeof(big_buf));
+    CHECK(outlen > 0);
+    std::cout << std::string(big_buf, outlen) << std::endl;
 
     free_MapOfObjects(&m);
 }

--- a/tests/test_ziti_model.cpp
+++ b/tests/test_ziti_model.cpp
@@ -624,11 +624,10 @@ TEST_CASE("identity tags", "[model]") {
     REQUIRE(t->type == tag_number);
     REQUIRE(t->num_value == 42);
 
-    char buf[1024];
-    size_t l;
-    json_from_ziti_identity(&id, buf, 1024, &l);
+    char *js = ziti_identity_to_json(&id, 0, NULL);
 
-    printf("%.*s", (int)l, buf);
+    printf("%s", js);
+    free(js);
 
     free_ziti_identity(&id);
 }


### PR DESCRIPTION
replaces awkward to use `json_from_XXXX()` with `char* XXX_to_json()`. Freeing of returned string is responsibility of the caller
also adds `ssize_t XXX_to_json_r()` for fixed buffer output returns -1 if output buffer is too small for given model object