### PR TITLE
fix crash in log message

### DIFF
--- a/library/posture.c
+++ b/library/posture.c
@@ -280,7 +280,7 @@ void ziti_send_posture_data(ziti_context ztx) {
             }
         } else {
             ZITI_LOG(DEBUG, "%s cb not set requested for: service %s, policy: %s, check: %s", PC_PROCESS_TYPE,
-                     osInfo->service->name, osInfo->query_set->policy_id, osInfo->query->id);
+                     procInfo->service->name, procInfo->query_set->policy_id, procInfo->query->id);
         }
     }
 


### PR DESCRIPTION
Pretty sure this should be procInfo - not osInfo
![image](https://user-images.githubusercontent.com/46322585/115283105-f4022380-a118-11eb-8dde-c329d441f0af.png)
