### PR TITLE
fix parsing null JSON fields

### DIFF
--- a/library/model_support.c
+++ b/library/model_support.c
@@ -528,21 +528,22 @@ static int parse_obj(void *obj, const char *json, jsmntok_t *tok, type_meta *met
         tokens_processed++;
 
         int rc;
-        if (fm != NULL) {
+        tok++;
+        if (tok->type == JSMN_PRIMITIVE && json[tok->start] == 'n') {
             tok++;
+            tokens_processed++;
+        } else if (fm != NULL) {
             void *field = (char *) obj + fm->offset;
             if (fm->mod == array_mod) {
                 rc = parse_array(field, json, tok, fm->meta());
-            }
-            else if (fm->mod == map_mod) {
+            } else if (fm->mod == map_mod) {
                 rc = parse_map(field, json, tok, fm->meta());
             }
             else {
                 char *memobj = NULL;
                 if (fm->mod == none_mod) {
                     memobj = (char *) (field);
-                }
-                else if (fm->mod == ptr_mod) {
+                } else if (fm->mod == ptr_mod) {
                     memobj = (char *) calloc(1, fm->meta()->size);
                     *(char **) field = memobj;
                 }
@@ -553,8 +554,7 @@ static int parse_obj(void *obj, const char *json, jsmntok_t *tok, type_meta *met
 
                 if (fm->meta()->parser != NULL) {
                     rc = fm->meta()->parser(memobj, json, tok);
-                }
-                else {
+                } else {
                     rc = parse_obj(memobj, json, tok, fm->meta());
                 }
             }
@@ -563,9 +563,7 @@ static int parse_obj(void *obj, const char *json, jsmntok_t *tok, type_meta *met
             }
             tok += rc;
             tokens_processed += rc;
-        }
-        else {
-            tok++;
+        } else {
             int end = tok->end;
             while (tok->type != JSMN_UNDEFINED && tok->start <= end) {
                 tok++;

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -96,7 +96,7 @@ static void checkBar2(const Bar &bar) {
     CHECK(bar.codes == nullptr);
 }
 
-TEST_CASE("new model tests") {
+TEST_CASE("new model tests", "[model]") {
     const char *bar_json = BAR1;
     Bar bar;
 
@@ -110,7 +110,47 @@ TEST_CASE("new model tests") {
     free_Bar(&bar);
 }
 
-TEST_CASE("embedded struct") {
+TEST_CASE("parse null", "[model]") {
+    const char *json = "{"
+                       "\"barp\":null,"
+                       "\"bara\":null"
+                       "}";
+    Foo foo;
+    REQUIRE(parse_Foo(&foo, json, strlen(json)) == 0);
+
+    REQUIRE(foo.barp == nullptr);
+
+    REQUIRE(foo.bar_arr == nullptr);
+
+    char *json1 = Foo_to_json(&foo, 0, NULL);
+    std::cout << json1 << std::endl;
+    free(json1);
+    free_Foo(&foo);
+}
+
+TEST_CASE("parse null in the middle", "[model]") {
+    const char *json = "{"
+                       "\"bar\":" BAR1 ","
+                       "\"barp\": null,"
+                       "\"bara\": [" BAR1 "," BAR2 "]"
+                       "}";
+    Foo foo;
+    REQUIRE(parse_Foo(&foo, json, strlen(json)) == 0);
+    checkBar1(foo.bar);
+
+    REQUIRE(foo.barp == nullptr);
+
+    REQUIRE(foo.bar_arr != nullptr);
+    CHECK(foo.bar_arr[2] == nullptr);
+    checkBar1(*foo.bar_arr[0]);
+    checkBar2(*foo.bar_arr[1]);
+
+    char *json1 = Foo_to_json(&foo, 0, NULL);
+    std::cout << json1 << std::endl;
+    free(json1);
+    free_Foo(&foo);
+}
+TEST_CASE("embedded struct", "[model]") {
     const char *json = "{"
                        "\"bar\":" BAR1 ","
                        "\"barp\": " BAR2 ","
@@ -134,7 +174,7 @@ TEST_CASE("embedded struct") {
     free_Foo(&foo);
 }
 
-TEST_CASE("test skipped fields") {
+TEST_CASE("test skipped fields", "[model]") {
     const char *json = R"({
         "bar":{
             "num":42,


### PR DESCRIPTION
skip over fields with `null` value (e.g. `"field": null`)