### PR TITLE
consolidate controller error cleanup

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(uv-mbed
         GIT_REPOSITORY https://github.com/netfoundry/uv-mbed.git
-        GIT_TAG v0.13.1
+        GIT_TAG v0.13.2
         )
 set(ENABLE_UM_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(uv-mbed)

--- a/inc_internal/utils.h
+++ b/inc_internal/utils.h
@@ -65,7 +65,7 @@ typedef int *(*cond_error_t)(int);
 
 #define NEWP(var, type) type *var = calloc(1, sizeof(type))
 #define VAL_OR_ELSE(v, def) ((v) != NULL ? (v) : (def))
-#define FREE(v) if ((v) != NULL) { free((void*)v); (v) = NULL; }
+#define FREE(v)  do { if ((v) != NULL) { free((void*)(v)); (v) = NULL; } } while(0)
 
 #define FMT(ex) _##ex##_fmt
 #define COND(ex) _##ex##_cond

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -45,61 +45,61 @@ int ziti_ctrl_init(uv_loop_t *loop, ziti_controller *ctlr, const char *url, tls_
 
 int ziti_ctrl_close(ziti_controller *ctrl);
 
-void ziti_ctrl_get_version(ziti_controller *ctrl, void (*ver_cb)(ziti_version *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_get_version(ziti_controller *ctrl, void (*ver_cb)(ziti_version *, const ziti_error *, void *), void *ctx);
 
 void
-ziti_ctrl_login(ziti_controller *ctrl, const char **cfg_types, void (*login_cb)(ziti_session *, ziti_error *, void *),
+ziti_ctrl_login(ziti_controller *ctrl, const char **cfg_types, void (*login_cb)(ziti_session *, const ziti_error *, void *),
                 void *ctx);
 
-void ziti_ctrl_current_api_session(ziti_controller *ctrl, void(*cb)(ziti_session *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_current_api_session(ziti_controller *ctrl, void(*cb)(ziti_session *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_current_identity(ziti_controller *ctrl, void(*cb)(ziti_identity_data *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_current_identity(ziti_controller *ctrl, void(*cb)(ziti_identity_data *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_current_edge_routers(ziti_controller *ctrl, void(*cb)(ziti_edge_router_array, ziti_error *, void *),
+void ziti_ctrl_current_edge_routers(ziti_controller *ctrl, void(*cb)(ziti_edge_router_array, const ziti_error *, void *),
                                     void *ctx);
 
-void ziti_ctrl_logout(ziti_controller *ctrl, void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_logout(ziti_controller *ctrl, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_get_services_update(ziti_controller *ctrl, void (*cb)(ziti_service_update *, ziti_error *, void *),
+void ziti_ctrl_get_services_update(ziti_controller *ctrl, void (*cb)(ziti_service_update *, const ziti_error *, void *),
                                    void *ctx);
 
-void ziti_ctrl_get_services(ziti_controller *ctrl, void (*srv_cb)(ziti_service_array, ziti_error *, void *), void *ctx);
+void ziti_ctrl_get_services(ziti_controller *ctrl, void (*srv_cb)(ziti_service_array, const ziti_error *, void *), void *ctx);
 
 void ziti_ctrl_get_service(ziti_controller *ctrl, const char *service_name,
-                           void (*srv_cb)(ziti_service *, ziti_error *, void *), void *ctx);
+                           void (*srv_cb)(ziti_service *, const ziti_error *, void *), void *ctx);
 
 void ziti_ctrl_get_net_session(
         ziti_controller *ctrl, const char *service_id, const char *type,
-        void (*cb)(ziti_net_session *, ziti_error *, void *), void *ctx);
+        void (*cb)(ziti_net_session *, const ziti_error *, void *), void *ctx);
 
 void ziti_ctrl_get_sessions(
-        ziti_controller *ctrl, void (*cb)(ziti_net_session **, ziti_error *, void *), void *ctx);
+        ziti_controller *ctrl, void (*cb)(ziti_net_session **, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_get_well_known_certs(ziti_controller *ctrl, void (*cb)(char *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_get_well_known_certs(ziti_controller *ctrl, void (*cb)(char *, const ziti_error *, void *), void *ctx);
 
 void ziti_ctrl_enroll(ziti_controller *ctrl, const char *method, const char *token, const char *csr,
-                      void (*cb)(ziti_enrollment_resp *, ziti_error *, void *), void *ctx);
+                      void (*cb)(ziti_enrollment_resp *, const ziti_error *, void *), void *ctx);
 
 //Posture
-void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
-void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len,void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
 
 //MFA
-void ziti_ctrl_login_mfa(ziti_controller *ctrl, char* body, size_t body_len, void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_login_mfa(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_post_mfa(ziti_controller *ctrl,void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_post_mfa(ziti_controller *ctrl, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_get_mfa(ziti_controller *ctrl, void(*cb)(ziti_mfa_enrollment *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_get_mfa(ziti_controller *ctrl, void(*cb)(ziti_mfa_enrollment *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_delete_mfa(ziti_controller *ctrl, char* code, void(*cb)(void*, ziti_error *, void *), void *ctx);
+void ziti_ctrl_delete_mfa(ziti_controller *ctrl, char *code, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_post_mfa_verify(ziti_controller *ctrl, char* body, size_t body_len, void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_post_mfa_verify(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_get_mfa_recovery_codes(ziti_controller *ctrl, char* code, void(*cb)(ziti_mfa_recovery_codes *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_get_mfa_recovery_codes(ziti_controller *ctrl, char *code, void(*cb)(ziti_mfa_recovery_codes *, const ziti_error *, void *), void *ctx);
 
-void ziti_ctrl_post_mfa_recovery_codes(ziti_controller *ctrl, char* body, size_t body_len, void(*cb)(void *, ziti_error *, void *), void *ctx);
+void ziti_ctrl_post_mfa_recovery_codes(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
 
 
 #ifdef __cplusplus

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -266,7 +266,7 @@ void ziti_fmt_time(char *time_str, size_t time_str_len, uv_timeval64_t *tv);
 
 void hexify(const uint8_t *bin, size_t bin_len, char sep, char **buf);
 
-void ziti_re_auth_with_cb(ziti_context ztx, void(*cb)(ziti_session *, ziti_error *, void *), void* ctx);
+void ziti_re_auth_with_cb(ziti_context ztx, void(*cb)(ziti_session *, const ziti_error *, void *), void *ctx);
 
 #ifdef __cplusplus
 }

--- a/library/auth_queries.c
+++ b/library/auth_queries.c
@@ -58,13 +58,15 @@ struct ziti_mfa_cb_ctx_s {
 };
 typedef struct ziti_mfa_cb_ctx_s ziti_mfa_cb_ctx;
 
-void ziti_auth_query_mfa_auth_internal_cb(void *empty, ziti_error *err, void *ctx);
+static void ziti_auth_query_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx);
 
-void ziti_auth_query_mfa_process(ziti_mfa_auth_ctx *mfa_auth_ctx);
+static void ziti_auth_query_mfa_process(ziti_mfa_auth_ctx *mfa_auth_ctx);
 
-void ziti_mfa_re_auth_internal_cb(ziti_session *session, ziti_error *err, void *ctx);
+static void ziti_mfa_re_auth_internal_cb(ziti_session *session, const ziti_error *err, void *ctx);
 
-void ziti_mfa_verify_internal_cb(void *empty, ziti_error *err, void *ctx);
+static void ziti_mfa_verify_internal_cb(void *empty, const ziti_error *err, void *ctx);
+
+static void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, const ziti_error *err, void *ctx);
 
 char *ziti_mfa_code_body(char *code) {
     NEWP(code_req, ziti_mfa_code_req);
@@ -164,9 +166,8 @@ void ziti_auth_query_process(ziti_context ztx, void(*cb)(ziti_context)) {
     ziti_auth_query_mfa_process(mfa_auth_ctx);
 }
 
-void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, ziti_error *err, void *ctx);
 
-void ziti_mfa_enroll_post_internal_cb(void *empty, ziti_error *err, void *ctx) {
+void ziti_mfa_enroll_post_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_enroll_cb_ctx *mfa_enroll_cb_ctx = ctx;
 
     if (err == NULL) {
@@ -174,23 +175,20 @@ void ziti_mfa_enroll_post_internal_cb(void *empty, ziti_error *err, void *ctx) {
     } else {
         ZITI_LOG(ERROR, "error during create MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, err->err, NULL, mfa_enroll_cb_ctx->cb_ctx);
-        FREE(err)
         FREE(ctx)
     }
 }
 
-void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, ziti_error *err, void *ctx) {
+void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, const ziti_error *err, void *ctx) {
     ziti_mfa_enroll_cb_ctx *mfa_enroll_cb_ctx = ctx;
 
     if (err != NULL) {
         if (err->http_code != 404) {
             ZITI_LOG(ERROR, "error during enroll MFA call: %d - %s - %s", err->http_code, err->code, err->message);
             mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, err->err, NULL, mfa_enroll_cb_ctx->cb_ctx);
-            FREE(err)
             FREE(ctx)
             return;
         }
-        FREE(err)
     }
 
     if (mfa_enrollment == NULL) {
@@ -212,13 +210,12 @@ void ziti_mfa_enroll(ziti_context ztx, ziti_mfa_enroll_cb enroll_cb, void *ctx) 
     ziti_ctrl_get_mfa(&ztx->controller, ziti_mfa_enroll_get_internal_cb, mfa_enroll_cb_ctx);
 }
 
-void ziti_mfa_remove_internal_cb(void *empty, ziti_error *err, void *ctx) {
+void ziti_mfa_remove_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_cb_ctx *mfa_cb_ctx = ctx;
 
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during remove MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, err->err, mfa_cb_ctx->cb_ctx);
-        FREE(err)
     } else {
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, ZITI_OK, mfa_cb_ctx->cb_ctx);
     }
@@ -237,13 +234,12 @@ void ziti_mfa_remove(ziti_context ztx, char *code, ziti_mfa_cb remove_cb, void *
     ziti_ctrl_delete_mfa(&ztx->controller, mfa_cb_ctx->code, ziti_mfa_remove_internal_cb, mfa_cb_ctx);
 }
 
-void ziti_mfa_re_auth_internal_cb(ziti_session *session, ziti_error *err, void *ctx) {
+void ziti_mfa_re_auth_internal_cb(ziti_session *session, const ziti_error *err, void *ctx) {
     ziti_mfa_auth_ctx *mfa_auth_ctx = ctx;
 
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during verify MFA call, could not re-authenticate: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_auth_ctx->status_cb(mfa_auth_ctx->ztx, mfa_auth_ctx, err->err, mfa_auth_ctx->status_ctx);
-        FREE(err)
     } else {
         ziti_session *old_session = mfa_auth_ctx->ztx->session;
         mfa_auth_ctx->ztx->session = session;
@@ -256,13 +252,12 @@ void ziti_mfa_re_auth_internal_cb(ziti_session *session, ziti_error *err, void *
     }
 }
 
-void ziti_mfa_verify_internal_cb(void *empty, ziti_error *err, void *ctx) {
+void ziti_mfa_verify_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_cb_ctx *mfa_cb_ctx = ctx;
 
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during verify MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, err->err, mfa_cb_ctx->cb_ctx);
-        FREE(err)
     } else {
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, ZITI_OK, mfa_cb_ctx->cb_ctx);
     }
@@ -281,7 +276,7 @@ void ziti_mfa_verify(ziti_context ztx, char *code, ziti_mfa_cb verify_cb, void *
     ziti_ctrl_post_mfa_verify(&ztx->controller, body, strlen(body), ziti_mfa_verify_internal_cb, mfa_cb_ctx);
 }
 
-void ziti_auth_query_mfa_auth_internal_cb(void *empty, ziti_error *err, void *ctx) {
+void ziti_auth_query_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_auth_ctx *mfa_auth_ctx = ctx;
     ziti_context ztx = mfa_auth_ctx->ztx;
     if (err != NULL) {
@@ -300,7 +295,6 @@ void ziti_auth_query_mfa_auth_internal_cb(void *empty, ziti_error *err, void *ct
                 //status handler to try again (submit another mfa code, or call ziti_mfa_abort()
                 FREE(ctx)
             }
-            FREE(err)
             return;
         }
 
@@ -322,13 +316,12 @@ void ziti_mfa_abort(void *mfa_ctx) {
     FREE(mfa_ctx)
 }
 
-void ziti_mfa_get_recovery_codes_internal_cb(ziti_mfa_recovery_codes *rc, ziti_error *err, void *ctx) {
+void ziti_mfa_get_recovery_codes_internal_cb(ziti_mfa_recovery_codes *rc, const ziti_error *err, void *ctx) {
     ziti_mfa_recovery_codes_cb_ctx *mfa_recovery_codes_cb_ctx = ctx;
 
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during get recovery codes MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_recovery_codes_cb_ctx->cb(mfa_recovery_codes_cb_ctx->ztx, err->err, NULL, mfa_recovery_codes_cb_ctx->cb_ctx);
-        FREE(err)
     } else {
         mfa_recovery_codes_cb_ctx->cb(mfa_recovery_codes_cb_ctx->ztx, ZITI_OK, rc->recovery_codes, mfa_recovery_codes_cb_ctx->cb_ctx);
         free_ziti_mfa_recovery_codes(rc);
@@ -348,15 +341,15 @@ void ziti_mfa_get_recovery_codes(ziti_context ztx, char *code, ziti_mfa_recovery
     ziti_ctrl_get_mfa_recovery_codes(&ztx->controller, mfa_rc_cb_ctx->code, ziti_mfa_get_recovery_codes_internal_cb, mfa_rc_cb_ctx);
 }
 
-void ziti_mfa_post_recovery_codes_internal_cb(void *empty, ziti_error *err, void *ctx) {
+void ziti_mfa_post_recovery_codes_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_recovery_codes_cb_ctx *mfa_recovery_codes_cb_ctx = ctx;
 
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during create recovery codes MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_recovery_codes_cb_ctx->cb(mfa_recovery_codes_cb_ctx->ztx, err->err, NULL, mfa_recovery_codes_cb_ctx->cb_ctx);
-        FREE(err)
     } else {
-        ziti_mfa_get_recovery_codes(mfa_recovery_codes_cb_ctx->ztx, mfa_recovery_codes_cb_ctx->code, mfa_recovery_codes_cb_ctx->cb, mfa_recovery_codes_cb_ctx->cb_ctx);
+        ziti_mfa_get_recovery_codes(mfa_recovery_codes_cb_ctx->ztx, mfa_recovery_codes_cb_ctx->code, mfa_recovery_codes_cb_ctx->cb,
+                                    mfa_recovery_codes_cb_ctx->cb_ctx);
     }
 
     FREE(ctx)

--- a/library/auth_queries.c
+++ b/library/auth_queries.c
@@ -75,7 +75,7 @@ char *ziti_mfa_code_body(char *code) {
     size_t len;
     char *body = ziti_mfa_code_req_to_json(code_req, 0, &len);
 
-    FREE(code_req)
+    FREE(code_req);
 
     return body;
 }
@@ -90,7 +90,7 @@ extern void ziti_auth_query_init(ziti_context ztx) {
 }
 
 extern void ziti_auth_query_free(struct auth_queries *aq) {
-    FREE(aq)
+    FREE(aq);
 }
 
 void ziti_auth_query_mfa_cb(ziti_context ztx, void *v_mfa_ctx, char *code, ziti_ar_mfa_status_cb status_cb, void *status_ctx) {
@@ -175,7 +175,7 @@ void ziti_mfa_enroll_post_internal_cb(void *empty, const ziti_error *err, void *
     } else {
         ZITI_LOG(ERROR, "error during create MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, err->err, NULL, mfa_enroll_cb_ctx->cb_ctx);
-        FREE(ctx)
+        FREE(ctx);
     }
 }
 
@@ -186,7 +186,7 @@ void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, const 
         if (err->http_code != 404) {
             ZITI_LOG(ERROR, "error during enroll MFA call: %d - %s - %s", err->http_code, err->code, err->message);
             mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, err->err, NULL, mfa_enroll_cb_ctx->cb_ctx);
-            FREE(ctx)
+            FREE(ctx);
             return;
         }
     }
@@ -195,7 +195,7 @@ void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, const 
         ziti_ctrl_post_mfa(&mfa_enroll_cb_ctx->ztx->controller, ziti_mfa_enroll_post_internal_cb, ctx);
     } else {
         mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, ZITI_OK, mfa_enrollment, mfa_enroll_cb_ctx->cb_ctx);
-        FREE(ctx)
+        FREE(ctx);
         free_ziti_mfa_enrollment(mfa_enrollment);
     }
 }
@@ -220,8 +220,8 @@ void ziti_mfa_remove_internal_cb(void *empty, const ziti_error *err, void *ctx) 
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, ZITI_OK, mfa_cb_ctx->cb_ctx);
     }
 
-    FREE(mfa_cb_ctx->code)
-    FREE(ctx)
+    FREE(mfa_cb_ctx->code);
+    FREE(ctx);
 }
 
 void ziti_mfa_remove(ziti_context ztx, char *code, ziti_mfa_cb remove_cb, void *ctx) {
@@ -262,7 +262,7 @@ void ziti_mfa_verify_internal_cb(void *empty, const ziti_error *err, void *ctx) 
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, ZITI_OK, mfa_cb_ctx->cb_ctx);
     }
 
-    FREE(ctx)
+    FREE(ctx);
 }
 
 void ziti_mfa_verify(ziti_context ztx, char *code, ziti_mfa_cb verify_cb, void *ctx) {
@@ -293,7 +293,7 @@ void ziti_auth_query_mfa_auth_internal_cb(void *empty, const ziti_error *err, vo
                 ZITI_LOG(WARN, "no mfa status callback provided, mfa failed, status was: %d", err->err);
                 //only free if there is no status handler, if there is a status handler it is up to the
                 //status handler to try again (submit another mfa code, or call ziti_mfa_abort()
-                FREE(ctx)
+                FREE(ctx);
             }
             return;
         }
@@ -308,12 +308,12 @@ void ziti_auth_query_mfa_auth_internal_cb(void *empty, const ziti_error *err, vo
         }
 
         mfa_auth_ctx->cb(ztx);
-        FREE(ctx)
+        FREE(ctx);
     }
 }
 
 void ziti_mfa_abort(void *mfa_ctx) {
-    FREE(mfa_ctx)
+    FREE(mfa_ctx);
 }
 
 void ziti_mfa_get_recovery_codes_internal_cb(ziti_mfa_recovery_codes *rc, const ziti_error *err, void *ctx) {
@@ -327,8 +327,8 @@ void ziti_mfa_get_recovery_codes_internal_cb(ziti_mfa_recovery_codes *rc, const 
         free_ziti_mfa_recovery_codes(rc);
     }
 
-    FREE(mfa_recovery_codes_cb_ctx->code)
-    FREE(ctx)
+    FREE(mfa_recovery_codes_cb_ctx->code);
+    FREE(ctx);
 }
 
 void ziti_mfa_get_recovery_codes(ziti_context ztx, char *code, ziti_mfa_recovery_codes_cb get_cb, void *ctx) {
@@ -352,7 +352,7 @@ void ziti_mfa_post_recovery_codes_internal_cb(void *empty, const ziti_error *err
                                     mfa_recovery_codes_cb_ctx->cb_ctx);
     }
 
-    FREE(ctx)
+    FREE(ctx);
 }
 
 void ziti_mfa_new_recovery_codes(ziti_context ztx, char *code, ziti_mfa_recovery_codes_cb new_cb, void *ctx) {

--- a/library/posture.c
+++ b/library/posture.c
@@ -391,7 +391,7 @@ static void ziti_collect_pr(ziti_context ztx, const char *pr_obj_key, char *pr_o
     }
 }
 
-static void ziti_pr_post_bulk_cb(__attribute__((unused)) void *empty, ziti_error *err, void *ctx) {
+static void ziti_pr_post_bulk_cb(__attribute__((unused)) void *empty, const ziti_error *err, void *ctx) {
     ziti_context ztx = ctx;
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during bulk posture response submission (%d) %s", err->http_code, err->message);
@@ -399,7 +399,6 @@ static void ziti_pr_post_bulk_cb(__attribute__((unused)) void *empty, ziti_error
         if (err->http_code == 404) {
             ztx->no_bulk_posture_response_api = true;
         }
-        FREE(err)
     } else {
         ztx->posture_checks->must_send = false; //did not error, can skip submissions
         ZITI_LOG(DEBUG, "done with bulk posture response submission");
@@ -423,14 +422,13 @@ static bool ziti_pr_is_info_errored(ziti_context ztx, const char *id) {
     return *is_errored;
 }
 
-static void ziti_pr_post_cb(__attribute__((unused)) void *empty, ziti_error *err, void *ctx) {
+static void ziti_pr_post_cb(__attribute__((unused)) void *empty, const ziti_error *err, void *ctx) {
     pr_cb_ctx *pr_ctx = ctx;
 
     if (err != NULL) {
         ZITI_LOG(ERROR, "error during individual posture response submission (%d) %s - object: %s", err->http_code,
                  err->message, pr_ctx->info->obj);
         ziti_pr_set_info_errored(pr_ctx->ztx, pr_ctx->info->id);
-        FREE(err)
     } else {
         ZITI_LOG(TRACE, "done with one pr response submission, object: %s", pr_ctx->info->obj);
         ziti_pr_set_info_success(pr_ctx->ztx, pr_ctx->info->id);

--- a/library/posture.c
+++ b/library/posture.c
@@ -101,19 +101,19 @@ static int hash_sha512(uv_loop_t *loop, const char *path, unsigned char **out_bu
 static bool check_running(uv_loop_t *loop, const char *path);
 
 static void ziti_pr_free_pr_info_members(pr_info *info) {
-    FREE(info->id)
-    FREE(info->obj)
+    FREE(info->id);
+    FREE(info->obj);
 }
 
 
 static void ziti_pr_free_pr_info(pr_info *info) {
     ziti_pr_free_pr_info_members(info);
-    FREE(info)
+    FREE(info);
 }
 
 static void ziti_pr_free_pr_cb_ctx(pr_cb_ctx *ctx) {
     ziti_pr_free_pr_info(ctx->info);
-    FREE(ctx)
+    FREE(ctx);
 }
 
 void ziti_posture_init(ziti_context ztx, long interval_secs) {
@@ -140,7 +140,7 @@ void ziti_posture_init(ziti_context ztx, long interval_secs) {
 }
 
 static void ziti_posture_checks_timer_free(uv_handle_t *handle) {
-    FREE(handle)
+    FREE(handle);
 }
 
 void ziti_posture_checks_free(struct posture_checks *pcs) {
@@ -150,7 +150,7 @@ void ziti_posture_checks_free(struct posture_checks *pcs) {
 
         model_map_clear(&pcs->responses, (_free_f) ziti_pr_free_pr_info_members);
         model_map_clear(&pcs->error_states, NULL);
-        FREE(pcs)
+        FREE(pcs);
     }
 }
 
@@ -181,7 +181,7 @@ void ziti_send_posture_data(ziti_context ztx) {
     if (new_session_id || ztx->posture_checks->must_send_every_time) {
         ZITI_LOG(DEBUG, "posture checks either never sent or session changed, must_send = true");
         ztx->posture_checks->must_send = true;
-        FREE(ztx->posture_checks->previous_session_id)
+        FREE(ztx->posture_checks->previous_session_id);
         ztx->posture_checks->previous_session_id = strdup(ztx->session->id);
     } else {
         ZITI_LOG(DEBUG, "posture checks using standard logic to submit, must_send = false");

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -921,7 +921,6 @@ static void session_cb(ziti_session *session, ziti_error *err, void *ctx) {
 
     update_ctrl_status(ztx, errCode, err ? err->message : NULL);
 
-    free_ziti_error(err);
     FREE(init_req);
 }
 
@@ -943,8 +942,6 @@ static void version_cb(ziti_version *v, ziti_error *err, void *ctx) {
     if (err != NULL) {
         ZTX_LOG(ERROR, "failed to get controller version from %s %s(%s)",
                  ztx->opts->controller, err->code, err->message);
-        free_ziti_error(err);
-        FREE(err);
     } else {
         ZTX_LOG(INFO, "connected to controller %s version %s(%s %s)",
                  ztx->opts->controller, v->version, v->revision, v->build_date);

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -33,9 +33,9 @@ limitations under the License.
 #endif
 #endif
 
-static void well_known_certs_cb(char *base64_encoded_pkcs7, ziti_error *err, void *req);
+static void well_known_certs_cb(char *base64_encoded_pkcs7, const ziti_error *err, void *req);
 
-static void enroll_cb(ziti_enrollment_resp *er, ziti_error *err, void *ctx);
+static void enroll_cb(ziti_enrollment_resp *er, const ziti_error *err, void *ctx);
 
 int verify_controller_jwt(tls_cert cert, void *ctx) {
     ZITI_LOG(INFO, "verifying JWT signature");
@@ -131,7 +131,7 @@ int ziti_enroll(ziti_enroll_opts *opts, uv_loop_t *loop, ziti_enroll_cb enroll_c
     return ERR(ziti);
 }
 
-static void well_known_certs_cb(char *base64_encoded_pkcs7, ziti_error *err, void *req) {
+static void well_known_certs_cb(char *base64_encoded_pkcs7, const ziti_error *err, void *req) {
     ZITI_LOG(DEBUG, "base64_encoded_pkcs7 is: %s", base64_encoded_pkcs7);
 
     int ziti_err;
@@ -213,7 +213,7 @@ static void well_known_certs_cb(char *base64_encoded_pkcs7, ziti_error *err, voi
     }
 }
 
-static void enroll_cb(ziti_enrollment_resp *er, ziti_error *err, void *enroll_ctx) {
+static void enroll_cb(ziti_enrollment_resp *er, const ziti_error *err, void *enroll_ctx) {
     struct ziti_enroll_req *enroll_req = enroll_ctx;
     ziti_controller *ctrl = enroll_req->controller;
 
@@ -224,8 +224,6 @@ static void enroll_cb(ziti_enrollment_resp *er, ziti_error *err, void *enroll_ct
         if (enroll_req->enroll_cb) {
             enroll_req->enroll_cb(NULL, ZITI_JWT_INVALID, err->code, enroll_req->external_enroll_ctx);
         }
-
-        free_ziti_error(err);
     }
     else {
         ZITI_LOG(DEBUG, "successfully enrolled with controller %s:%s",


### PR DESCRIPTION
fix error memory leak

quick summary:
- make controller _own_ `ziti_error` passed to all controller callbacks
- make all callbacks take `const ziti_error*` to indicate above
- fixes cases where error was not freed