### PR TITLE
Fail dial without e2ee

### DIFF
--- a/library/channel.c
+++ b/library/channel.c
@@ -338,6 +338,9 @@ int ziti_channel_send(ziti_channel_t *ch, uint32_t content, const hdr_t *hdrs, i
 
     uv_buf_t buf = uv_buf_init(msg_buf, msg_size);
     NEWP(req, uv_write_t);
+    if (ziti_write == NULL) {
+        ziti_write = calloc(1, sizeof(struct ziti_write_req_s));
+    }
     req->data = ziti_write;
     ziti_write->payload = msg_buf;
     int rc = uv_mbed_write(req, &ch->connection, &buf, on_channel_send);

--- a/library/connect.c
+++ b/library/connect.c
@@ -687,7 +687,7 @@ int establish_crypto(ziti_connection conn, message *msg) {
 
     conn->tx = calloc(1, crypto_secretstream_xchacha20poly1305_KEYBYTES);
     conn->rx = calloc(1, crypto_secretstream_xchacha20poly1305_KEYBYTES);
-    int rc = ZITI_OK;
+    int rc = 0;
     if (conn->state == Connecting) {
         rc = crypto_kx_client_session_keys(conn->rx, conn->tx, conn->pk, conn->sk, peer_key);
     } else if (conn->state == Accepting) {
@@ -696,8 +696,11 @@ int establish_crypto(ziti_connection conn, message *msg) {
 
     if (rc != 0) {
         CONN_LOG(ERROR, "failed to establish encryption: crypto error");
+        FREE(conn->tx);
+        FREE(conn->rx);
+        return ZITI_CRYPTO_FAIL;
     }
-    return rc;
+    return ZITI_OK;
 }
 
 static int send_crypto_header(ziti_connection conn) {


### PR DESCRIPTION
Bug: crash happens if encryption is required and peer fails to send its e2ee key in the dial request (error in crypto setup was ignored)

Solution: reject dial request with `ContentTypeDialFailed` message, don't propagate it to the app