### PR TITLE
changes service update logic

### DIFF
--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -202,6 +202,8 @@ typedef struct model_map {
     struct model_impl_s *impl;
 } model_map;
 
+int model_map_compare(const model_map *lh, const model_map *rh, type_meta *m);
+
 ZITI_FUNC size_t model_map_size(const model_map *map);
 
 ZITI_FUNC void *model_map_set(model_map *map, const char *key, void *val);

--- a/includes/ziti/ziti_model.h
+++ b/includes/ziti/ziti_model.h
@@ -80,7 +80,8 @@ XX(permissions, string, array, permissions, __VA_ARGS__) \
 XX(encryption, bool, none, encryptionRequired, __VA_ARGS__) \
 XX(perm_flags, int, none, NULL, __VA_ARGS__) \
 XX(config, json, map, config, __VA_ARGS__) \
-XX(posture_query_set, ziti_posture_query_set, array, postureQueries, __VA_ARGS__)
+XX(posture_query_set, ziti_posture_query_set, array, postureQueries, __VA_ARGS__) \
+XX(updated_at,string, none, updatedAt, __VA_ARGS__)
 
 #define ZITI_CLIENT_CFG_V1_MODEL(XX, ...) \
 XX(hostname, string, none, hostname, __VA_ARGS__) \

--- a/includes/ziti/ziti_model.h
+++ b/includes/ziti/ziti_model.h
@@ -81,6 +81,7 @@ XX(encryption, bool, none, encryptionRequired, __VA_ARGS__) \
 XX(perm_flags, int, none, NULL, __VA_ARGS__) \
 XX(config, json, map, config, __VA_ARGS__) \
 XX(posture_query_set, ziti_posture_query_set, array, postureQueries, __VA_ARGS__) \
+XX(posture_query_map, ziti_posture_query_set, map, posturePolicies, __VA_ARGS__) \
 XX(updated_at,string, none, updatedAt, __VA_ARGS__)
 
 #define ZITI_CLIENT_CFG_V1_MODEL(XX, ...) \

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -50,8 +50,6 @@ limitations under the License.
 
 static int parse_obj(void *obj, const char *json, jsmntok_t *tok, type_meta *meta);
 
-static int model_map_compare(const model_map *lh, const model_map *rh, type_meta *m);
-
 jsmntok_t* parse_tokens(jsmn_parser *parser, const char *json, size_t len, size_t *ntok) {
     size_t tok_cap = 256;
     jsmn_init(parser);
@@ -1156,7 +1154,7 @@ model_map_iter model_map_it_remove(model_map_iter it) {
     return next;
 }
 
-static int model_map_compare(const model_map *lh, const model_map *rh, type_meta *m) {
+int model_map_compare(const model_map *lh, const model_map *rh, type_meta *m) {
     null_checks(lh, rh)
 
     int rc = 0;


### PR DESCRIPTION
swap from a deep compare on service definitions to deep compare on
configurations and updatedAt comparisons for the rest of the service.
Ignores posture query values.