### PR TITLE
use ZTX_LOG in more places, early returns on service update checking

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -42,6 +42,8 @@ limitations under the License.
 #define TYPE_DIAL "Dial"
 #define TYPE_BIND "Bind"
 
+#define ZTX_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "ztx[%d] " fmt, ztx->id, ##__VA_ARGS__)
+
 extern const char *APP_ID;
 extern const char *APP_VERSION;
 

--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -43,8 +43,6 @@ enum DebugLevel {
 if (level <= ziti_log_level()) { ziti_logger(level, __FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__); }\
 } while(0)
 
-#define ZTX_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "ztx[%d] " fmt, ztx->id, ##__VA_ARGS__)
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -43,6 +43,8 @@ enum DebugLevel {
 if (level <= ziti_log_level()) { ziti_logger(level, __FILE__, __LINE__, __func__, fmt, ##__VA_ARGS__); }\
 } while(0)
 
+#define ZTX_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "ztx[%d] " fmt, ztx->id, ##__VA_ARGS__)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/library/auth_queries.c
+++ b/library/auth_queries.c
@@ -316,13 +316,13 @@ void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
         }
     } else {
         if (mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx != NULL) {
-            ziti_mfa_auth_ctx *ctx = mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx;
+            ziti_mfa_auth_ctx *outstanding_ctx = mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx;
             mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx = NULL;
 
-            ctx->cb(ztx, ZITI_OK, ctx->cb_ctx);
+            outstanding_ctx->cb(ztx, ZITI_OK, outstanding_ctx->cb_ctx);
 
-            FREE(ctx->code);
-            FREE(ctx);
+            FREE(outstanding_ctx->code);
+            FREE(outstanding_ctx);
         }
 
         if (mfa_auth_ctx->cb != NULL) {

--- a/library/auth_queries.c
+++ b/library/auth_queries.c
@@ -91,7 +91,7 @@ extern void ziti_auth_query_free(struct auth_queries *aq) {
 
 void ziti_mfa_auth(ziti_context ztx, const char *code, ziti_mfa_cb status_cb, void *status_ctx) {
     if (code == NULL) {
-        ZITI_LOG(ERROR, "unexpected NULL MFA code");
+        ZTX_LOG(ERROR, "unexpected NULL MFA code");
         status_cb(ztx, ZITI_WTF, status_ctx);
     }
 
@@ -137,12 +137,12 @@ void ziti_auth_query_process(ziti_context ztx, void(*cb)(ziti_context, int, void
                 if (ziti_mfa == NULL) {
                     ziti_mfa = current_aq;
                 } else {
-                    ZITI_LOG(ERROR, "multiple auth queries for [type: %s] [provider: %s], cannot continue", current_aq->type_id, current_aq->provider);
+                    ZTX_LOG(ERROR, "multiple auth queries for [type: %s] [provider: %s], cannot continue", current_aq->type_id, current_aq->provider);
                     cb(ztx, ZITI_OK, NULL);
                     return;
                 }
             } else {
-                ZITI_LOG(ERROR, "could not process authentication query [type: %s] [provider: %s], unknown type or provider", current_aq->type_id, current_aq->provider);
+                ZTX_LOG(ERROR, "could not process authentication query [type: %s] [provider: %s], unknown type or provider", current_aq->type_id, current_aq->provider);
                 cb(ztx, ZITI_WTF, NULL); //fail with unsupported auth query
                 return;
             }
@@ -159,18 +159,19 @@ void ziti_auth_query_process(ziti_context ztx, void(*cb)(ziti_context, int, void
     mfa_auth_ctx->ztx = ztx;
     mfa_auth_ctx->cb = cb;
 
-    ZITI_LOG(INFO, "sending auth query mfa authentication event, authentication cannot proceed if not handled");
+    ZTX_LOG(INFO, "sending auth query mfa authentication event, authentication cannot proceed if not handled");
     ziti_auth_query_mfa_process(mfa_auth_ctx);
 }
 
 
 void ziti_mfa_enroll_post_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_enroll_cb_ctx *mfa_enroll_cb_ctx = ctx;
+    ziti_context ztx = mfa_enroll_cb_ctx->ztx;
 
     if (err == NULL) {
         ziti_ctrl_get_mfa(&mfa_enroll_cb_ctx->ztx->controller, ziti_mfa_enroll_get_internal_cb, ctx);
     } else {
-        ZITI_LOG(ERROR, "error during create MFA call: %d - %s - %s", err->http_code, err->code, err->message);
+        ZTX_LOG(ERROR, "error during create MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, err->err, NULL, mfa_enroll_cb_ctx->cb_ctx);
         FREE(ctx);
     }
@@ -178,10 +179,11 @@ void ziti_mfa_enroll_post_internal_cb(void *empty, const ziti_error *err, void *
 
 void ziti_mfa_enroll_get_internal_cb(ziti_mfa_enrollment *mfa_enrollment, const ziti_error *err, void *ctx) {
     ziti_mfa_enroll_cb_ctx *mfa_enroll_cb_ctx = ctx;
+    ziti_context ztx = mfa_enroll_cb_ctx->ztx;
 
     if (err != NULL) {
         if (err->http_code != 404) {
-            ZITI_LOG(ERROR, "error during enroll MFA call: %d - %s - %s", err->http_code, err->code, err->message);
+            ZTX_LOG(ERROR, "error during enroll MFA call: %d - %s - %s", err->http_code, err->code, err->message);
             mfa_enroll_cb_ctx->cb(mfa_enroll_cb_ctx->ztx, err->err, NULL, mfa_enroll_cb_ctx->cb_ctx);
             FREE(ctx);
             return;
@@ -214,9 +216,10 @@ void ziti_mfa_enroll(ziti_context ztx, ziti_mfa_enroll_cb enroll_cb, void *ctx) 
 
 void ziti_mfa_remove_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_cb_ctx *mfa_cb_ctx = ctx;
+    ziti_context ztx = mfa_cb_ctx->ztx;
 
     if (err != NULL) {
-        ZITI_LOG(ERROR, "error during remove MFA call: %d - %s - %s", err->http_code, err->code, err->message);
+        ZTX_LOG(ERROR, "error during remove MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, err->err, mfa_cb_ctx->cb_ctx);
     } else {
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, ZITI_OK, mfa_cb_ctx->cb_ctx);
@@ -243,9 +246,10 @@ void ziti_mfa_remove(ziti_context ztx, char *code, ziti_mfa_cb remove_cb, void *
 
 void ziti_mfa_verify_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_cb_ctx *mfa_cb_ctx = ctx;
+    ziti_context ztx = mfa_cb_ctx->ztx;
 
     if (err != NULL) {
-        ZITI_LOG(ERROR, "error during verify MFA call: %d - %s - %s", err->http_code, err->code, err->message);
+        ZTX_LOG(ERROR, "error during verify MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, err->err, mfa_cb_ctx->cb_ctx);
     } else {
         mfa_cb_ctx->cb(mfa_cb_ctx->ztx, ZITI_OK, mfa_cb_ctx->cb_ctx);
@@ -272,9 +276,10 @@ void ziti_mfa_verify(ziti_context ztx, char *code, ziti_mfa_cb verify_cb, void *
 
 void ziti_mfa_re_auth_internal_cb(ziti_session *session, const ziti_error *err, void *ctx) {
     ziti_mfa_auth_ctx *mfa_auth_ctx = ctx;
+    ziti_context ztx = mfa_auth_ctx->ztx;
 
     if (err != NULL) {
-        ZITI_LOG(ERROR, "error during verify MFA call, could not re-authenticate: %d - %s - %s", err->http_code, err->code, err->message);
+        ZTX_LOG(ERROR, "error during verify MFA call, could not re-authenticate: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_auth_ctx->cb(mfa_auth_ctx->ztx, err->err, mfa_auth_ctx->cb_ctx);
     } else {
         ziti_session *old_session = mfa_auth_ctx->ztx->session;
@@ -291,6 +296,7 @@ void ziti_mfa_re_auth_internal_cb(ziti_session *session, const ziti_error *err, 
 void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_auth_ctx *mfa_auth_ctx = ctx;
     ziti_context ztx = mfa_auth_ctx->ztx;
+
     if (err != NULL) {
         if (err->http_code == 401 && !mfa_auth_ctx->auth_attempted) {
             // not authenticated, attempt re-auth once
@@ -298,12 +304,12 @@ void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
             ziti_re_auth_with_cb(mfa_auth_ctx->ztx, ziti_mfa_re_auth_internal_cb, mfa_auth_ctx);
             return;
         } else {
-            ZITI_LOG(ERROR, "error during MFA auth call: %d - %s - %s", err->http_code, err->code, err->message);
+            ZTX_LOG(ERROR, "error during MFA auth call: %d - %s - %s", err->http_code, err->code, err->message);
 
             if (mfa_auth_ctx->cb != NULL) {
                 mfa_auth_ctx->cb(ztx, err->err, mfa_auth_ctx->cb_ctx);
             } else {
-                ZITI_LOG(WARN, "no mfa status callback provided, mfa failed, status was: %d", err->err);
+                ZTX_LOG(WARN, "no mfa status callback provided, mfa failed, status was: %d", err->err);
             }
             FREE(ctx);
             return;
@@ -322,7 +328,7 @@ void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
         if (mfa_auth_ctx->cb != NULL) {
             mfa_auth_ctx->cb(ztx, ZITI_OK, mfa_auth_ctx->cb_ctx);
         } else {
-            ZITI_LOG(WARN, "no mfa status callback provided, mfa was a success, status was: %d", err->err);
+            ZTX_LOG(WARN, "no mfa status callback provided, mfa was a success, status was: %d", err->err);
         }
 
         FREE(ctx);
@@ -331,9 +337,9 @@ void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
 
 void ziti_mfa_get_recovery_codes_internal_cb(ziti_mfa_recovery_codes *rc, const ziti_error *err, void *ctx) {
     ziti_mfa_recovery_codes_cb_ctx *mfa_recovery_codes_cb_ctx = ctx;
-
+    ziti_context ztx = mfa_recovery_codes_cb_ctx->ztx;
     if (err != NULL) {
-        ZITI_LOG(ERROR, "error during get recovery codes MFA call: %d - %s - %s", err->http_code, err->code, err->message);
+        ZTX_LOG(ERROR, "error during get recovery codes MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_recovery_codes_cb_ctx->cb(mfa_recovery_codes_cb_ctx->ztx, err->err, NULL, mfa_recovery_codes_cb_ctx->cb_ctx);
     } else {
         mfa_recovery_codes_cb_ctx->cb(mfa_recovery_codes_cb_ctx->ztx, ZITI_OK, rc->recovery_codes, mfa_recovery_codes_cb_ctx->cb_ctx);
@@ -361,9 +367,10 @@ void ziti_mfa_get_recovery_codes(ziti_context ztx, char *code, ziti_mfa_recovery
 
 void ziti_mfa_post_recovery_codes_internal_cb(void *empty, const ziti_error *err, void *ctx) {
     ziti_mfa_recovery_codes_cb_ctx *mfa_recovery_codes_cb_ctx = ctx;
+    ziti_context ztx = mfa_recovery_codes_cb_ctx->ztx;
 
     if (err != NULL) {
-        ZITI_LOG(ERROR, "error during create recovery codes MFA call: %d - %s - %s", err->http_code, err->code, err->message);
+        ZTX_LOG(ERROR, "error during create recovery codes MFA call: %d - %s - %s", err->http_code, err->code, err->message);
         mfa_recovery_codes_cb_ctx->cb(mfa_recovery_codes_cb_ctx->ztx, err->err, NULL, mfa_recovery_codes_cb_ctx->cb_ctx);
     } else {
         ziti_mfa_get_recovery_codes(mfa_recovery_codes_cb_ctx->ztx, mfa_recovery_codes_cb_ctx->code, mfa_recovery_codes_cb_ctx->cb,

--- a/library/connect.c
+++ b/library/connect.c
@@ -255,6 +255,8 @@ send_message(struct ziti_conn *conn, uint32_t content, uint8_t *body, uint32_t b
 
 static void on_channel_connected(ziti_channel_t *ch, void *ctx, int status) {
     struct ziti_conn *conn = ctx;
+    ziti_context ztx = conn->ziti_ctx;
+
     // check if it is still a valid connection
     // connection may be completed and gone by the time this channel gets connected
     struct ziti_conn *c;
@@ -262,7 +264,7 @@ static void on_channel_connected(ziti_channel_t *ch, void *ctx, int status) {
         if (c == conn) { break; }
     }
     if (c == NULL) {
-        ZITI_LOG(VERBOSE, "ch[%d] connection(%p) is gone", ch->id, ctx);
+        ZTX_LOG(VERBOSE, "ch[%d] connection(%p) is gone", ch->id, ctx);
         return;
     }
 
@@ -272,7 +274,7 @@ static void on_channel_connected(ziti_channel_t *ch, void *ctx, int status) {
     }
     else {
         if (status < 0) {
-            ZITI_LOG(ERROR, "ch[%d] failed to connect [%d/%s]", ch->id, status, uv_strerror(status));
+            ZTX_LOG(ERROR, "ch[%d] failed to connect [%d/%s]", ch->id, status, uv_strerror(status));
         }
         else if (conn->conn_req && conn->conn_req->failed) {
             CONN_LOG(DEBUG, "request already timed out or closed");


### PR DESCRIPTION
- replaces ZITI_LOG  calls with ZTX_LOG where possible
- service update checking will now return earlier rather than performing
  additional checks