### PR TITLE
reworks session expiration tracking

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -49,6 +49,7 @@ XX(path, string, none, path, __VA_ARGS__)
 XX(id, string, none, id, __VA_ARGS__) \
 XX(token, string, none, token, __VA_ARGS__) \
 XX(expires, timestamp, ptr, expiresAt, __VA_ARGS__) \
+XX(expireSeconds, int, ptr, expirationSeconds, __VA_ARGS__) \
 XX(updated, timestamp, ptr, updatedAt, __VA_ARGS__) \
 XX(cached_last_activity_at, timestamp, ptr, cachedLastActivityAt, __VA_ARGS__) \
 XX(identity, ziti_identity, ptr, identity, __VA_ARGS__) \

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -190,6 +190,7 @@ struct ziti_ctx {
     int ctrl_status;
 
     ziti_api_session *api_session;
+    uv_timeval64_t api_session_expires_at;
     ziti_api_session_state api_session_state;
 
     uv_timeval64_t session_received_at;
@@ -206,8 +207,8 @@ struct ziti_ctx {
 
     char *last_update;
 
-    uv_timer_t session_timer;
-    uv_timer_t refresh_timer;
+    uv_timer_t api_session_timer;
+    uv_timer_t service_refresh_timer;
     uv_prepare_t reaper;
 
     uv_loop_t *loop;
@@ -245,7 +246,7 @@ void ziti_invalidate_session(ziti_context ztx, ziti_net_session *session, const 
 
 void ziti_on_channel_event(ziti_channel_t *ch, ziti_router_status status, ziti_context ztx);
 
-void ziti_force_session_refresh(ziti_context ztx);
+void ziti_force_api_session_refresh(ziti_context ztx);
 
 int ziti_close_channels(ziti_context ztx, int err);
 

--- a/library/channel.c
+++ b/library/channel.c
@@ -780,7 +780,7 @@ static void on_channel_close(ziti_channel_t *ch, int ziti_err, ssize_t uv_err) {
     if (ch->state != Closed) {
         if (uv_err == UV_EOF) {
             ZTX_LOG(VERBOSE, "edge router closed connection, trying to refresh api session");
-            ziti_force_session_refresh(ch->ctx);
+            ziti_force_api_session_refresh(ch->ctx);
         }
         reconnect_channel(ch, false);
     }

--- a/library/connect.c
+++ b/library/connect.c
@@ -418,7 +418,7 @@ static void connect_get_net_session_cb(ziti_net_session *s, const ziti_error *er
 
     if (err != NULL) {
         if (err->err == ZITI_NOT_AUTHORIZED) {
-            ziti_force_session_refresh(ztx);
+            ziti_force_api_session_refresh(ztx);
             restart_connect(conn);
         } else {
             int e = err->err == ZITI_NOT_FOUND ? ZITI_SERVICE_UNAVAILABLE : err->err;


### PR DESCRIPTION
- adds debug to session expiration
- adds session timer debug
- centralizes api_session_refresh timer control
- updates remaining "session" to "api_session" function/member names