### PR TITLE
adds defensive channel reconnect after api session change

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -77,6 +77,7 @@ typedef struct ziti_channel {
     int port;
 
     uint32_t id;
+    char api_session_id[UUID_STR_LEN];
     char token[UUID_STR_LEN];
     uv_mbed_t connection;
 
@@ -249,6 +250,8 @@ void ziti_on_channel_event(ziti_channel_t *ch, ziti_router_status status, ziti_c
 void ziti_force_api_session_refresh(ziti_context ztx);
 
 int ziti_close_channels(ziti_context ztx, int err);
+
+int ziti_reconnect_old_api_session_channels(struct ziti_ctx *ztx);
 
 bool ziti_channel_is_connected(ziti_channel_t *ch);
 

--- a/includes/ziti/error_defs.h
+++ b/includes/ziti/error_defs.h
@@ -77,8 +77,8 @@ limitations under the License.
     /** SDK detected invalid cryptographic state of Ziti connection */ \
     XX(CRYPTO_FAIL, "crypto failure") \
     /** connection was closed */ \
-    XX(CONN_CLOSED, "connection is closed")               \
-    /** failed posture check */                    \
+    XX(CONN_CLOSED, "connection is closed") \
+    /** failed posture check */ \
     XX(INVALID_POSTURE, "failed posture check") \
     /** attempted to start MFA enrollment when it already has been started or completed */ \
     XX(MFA_EXISTS, "an MFA enrollment already exists") \
@@ -86,12 +86,14 @@ limitations under the License.
     XX(MFA_INVALID_TOKEN, "the token provided was invalid") \
     /** attempted to verify or retrieve details of an MFA enrollment that has not been completed */ \
     XX(MFA_NOT_ENROLLED, "the current identity has not completed MFA enrollment") \
-    /** not found, usually indicates stale reference or permission */    \
-    XX(NOT_FOUND, "entity no longer exists or is no longer accessible")  \
-    /** operation attempted while ziti_context is not enabled */                    \
-    XX(DISABLED, "ziti context is disabled")              \
-    /** returned when authentication is attempted but there is an existing api session waiting for auth queries to pass */                    \
-    XX(PARTIALLY_AUTHENTICATED, "api session is partially authenticated, waiting for auth query resolution") \
+    /** not found, usually indicates stale reference or permission */ \
+    XX(NOT_FOUND, "entity no longer exists or is no longer accessible") \
+    /** operation attempted while ziti_context is not enabled */  \
+    XX(DISABLED, "ziti context is disabled") \
+    /** returned when authentication is attempted but there is an existing api session waiting for auth queries to pass */ \
+    XX(PARTIALLY_AUTHENTICATED, "api session is partially authenticated, waiting for auth query resolution")               \
+    /** provided to channels being closed due to them being out of sync with the current ztx api_session */ \
+    XX(NEW_API_SESSION, "a new api session was detected") \
     /** Inspired by the Android SDK: What a Terrible Failure. A condition that should never happen. */ \
     XX(WTF, "WTF: programming error") \
 

--- a/library/channel.c
+++ b/library/channel.c
@@ -252,7 +252,7 @@ bool ziti_channel_is_connected(ziti_channel_t *ch) {
 
 static void ziti_channel_set_api_session_id(ziti_channel_t *ch, const char* api_session_id) {
     memset(ch->api_session_id, '\0', sizeof(ch->api_session_id));
-    strncpy(ch->api_session_id, api_session_id, strlen(api_session_id));
+    strncpy(ch->api_session_id, api_session_id, strlen(ch->api_session_id));
 }
 
 static ziti_channel_t *new_ziti_channel(ziti_context ztx, const char *ch_name, const char *url) {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -551,7 +551,7 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
     ziti_channel_t *ch;
     const char *url;
     MODEL_MAP_FOREACH(url, ch, &ztx->channels) {
-        printer(ctx, "ch[%d](%s) ", ch->id, url);
+        printer(ctx, "ch[%d](%s) api_session_id[%s]", ch->id, url, ch->api_session_id);
         if (ziti_channel_is_connected(ch)) {
             printer(ctx, "connected [latency=%ld]\n", (long) ch->latency);
         } else {
@@ -1128,7 +1128,6 @@ static void session_post_auth_query_cb(ziti_context ztx, int status, void *ctx) 
         if (!ztx->no_current_edge_routers) {
             ziti_ctrl_current_edge_routers(&ztx->controller, edge_routers_cb, ztx);
         }
-        
     } else {
         ZTX_LOG(VERBOSE, "transitioning to unauthenticated, unhandled status[%s]", ziti_errorstr(status));
         ziti_set_unauthenticated(ztx); //disable?


### PR DESCRIPTION
Previously it was possible for channels to remain connected to Edge Routers with previous API Sessions. This would occur in scenarios where the SDK requested a new API Session but did not invalidate the previous one. Under normal conditions, this shouldn't happen, but bugs have caused it to happen in the past. It can also happen when ERs are not properly receiving updates from controllers and C-SDK channels remain connected when all the others have disconnected.

