### PR TITLE
Instance.id.support

### DIFF
--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -34,7 +34,8 @@ struct posture_checks {
     // map<type/process_path, is errored
     model_map error_states;
 
-    char *previous_session_id;
+    char *previous_api_session_id;
+    char *controller_instance_id;
     bool must_send;
     bool must_send_every_time;
 };

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -45,7 +45,10 @@ typedef struct ziti_controller_s {
     unsigned int page_size;
 
     ziti_version version;
+
     char *api_session_token;
+    char *instance_id;
+
     ziti_ctrl_redirect_cb redirect_cb;
     void *redirect_ctx;
 } ziti_controller;
@@ -62,8 +65,7 @@ void ziti_ctrl_clear_api_session(ziti_controller *ctrl);
 
 void ziti_ctrl_get_version(ziti_controller *ctrl, void (*ver_cb)(ziti_version *, const ziti_error *, void *), void *ctx);
 
-void
-ziti_ctrl_login(ziti_controller *ctrl, const char **cfg_types, void (*login_cb)(ziti_api_session *, const ziti_error *, void *),
+void ziti_ctrl_login(ziti_controller *ctrl, const char **cfg_types, void (*login_cb)(ziti_api_session *, const ziti_error *, void *),
                 void *ctx);
 
 void ziti_ctrl_current_api_session(ziti_controller *ctrl, void(*cb)(ziti_api_session *, const ziti_error *, void *), void *ctx);

--- a/library/posture.c
+++ b/library/posture.c
@@ -130,7 +130,7 @@ void ziti_posture_init(ziti_context ztx, long interval_secs) {
 
         pc->timer = timer;
         pc->interval = (double) interval_secs;
-        pc->previous_session_id = NULL;
+        pc->previous_api_session_id = NULL;
         pc->must_send_every_time = true;
         pc->must_send = false;
 
@@ -181,15 +181,30 @@ void ziti_send_posture_data(ziti_context ztx) {
     }
 
     ZTX_LOG(VERBOSE, "starting to send posture data");
-    bool new_session_id = ztx->posture_checks->previous_session_id == NULL || strcmp(ztx->posture_checks->previous_session_id, ztx->api_session->id) != 0;
+    bool new_session_id = ztx->posture_checks->previous_api_session_id == NULL || strcmp(ztx->posture_checks->previous_api_session_id, ztx->api_session->id) != 0;
 
-    if (new_session_id || ztx->posture_checks->must_send_every_time) {
-        ZTX_LOG(DEBUG, "posture checks either never sent or api session changed, must_send = true");
+    bool new_controller_instance = (ztx->posture_checks->controller_instance_id == NULL && ztx->controller.instance_id != NULL) || strcmp(ztx->posture_checks->controller_instance_id, ztx->controller.instance_id) != 0;
+
+    if(new_controller_instance){
+        ZTX_LOG(WARN, "a new controller instance was detected");
+    }
+
+    if (new_session_id || ztx->posture_checks->must_send_every_time || new_controller_instance) {
+        ZTX_LOG(DEBUG, "posture checks must_send set to TRUE, new_session_id[%s], must_send_every_time[%s], new_controller_instance[%s]",
+                new_session_id ? "TRUE" : "FALSE",
+                ztx->posture_checks->must_send_every_time ? "TRUE" : "FALSE",
+                new_controller_instance ? "TRUE" : "FALSE");
+
         ztx->posture_checks->must_send = true;
-        FREE(ztx->posture_checks->previous_session_id);
-        ztx->posture_checks->previous_session_id = strdup(ztx->api_session->id);
+        FREE(ztx->posture_checks->previous_api_session_id);
+        ztx->posture_checks->previous_api_session_id = strdup(ztx->api_session->id);
+        ztx->posture_checks->controller_instance_id = strdup(ztx->controller.instance_id);
     } else {
-        ZTX_LOG(DEBUG, "posture checks using standard logic to submit, must_send = false");
+        ZTX_LOG(DEBUG, "posture checks must_send set to FALSE, new_session_id[%s], must_send_every_time[%s], new_controller_instance[%s]",
+                new_session_id ? "TRUE" : "FALSE",
+                ztx->posture_checks->must_send_every_time ? "TRUE" : "FALSE",
+                new_controller_instance ? "TRUE" : "FALSE");
+
         ztx->posture_checks->must_send = false;
     }
 

--- a/library/posture.c
+++ b/library/posture.c
@@ -186,7 +186,7 @@ void ziti_send_posture_data(ziti_context ztx) {
     bool new_controller_instance = (ztx->posture_checks->controller_instance_id == NULL && ztx->controller.instance_id != NULL) || strcmp(ztx->posture_checks->controller_instance_id, ztx->controller.instance_id) != 0;
 
     if(new_controller_instance){
-        ZTX_LOG(WARN, "a new controller instance was detected");
+        ZTX_LOG(WARN, "first run or potential controller restart detected");
     }
 
     if (new_session_id || ztx->posture_checks->must_send_every_time || new_controller_instance) {

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -127,8 +127,7 @@ static void ctrl_default_cb(void *s, const ziti_error *e, struct ctrl_resp *resp
 
 static void ctrl_body_cb(um_http_req_t *req, const char *b, ssize_t len);
 
-static um_http_req_t *
-start_request(um_http_t *http, const char *method, const char *path, um_http_resp_cb cb, struct ctrl_resp *resp) {
+static um_http_req_t *start_request(um_http_t *http, const char *method, const char *path, um_http_resp_cb cb, struct ctrl_resp *resp) {
     ziti_controller *ctrl = resp->ctrl;
     uv_gettimeofday(&resp->start);
     CTRL_LOG(DEBUG, "starting %s[%s]", method, path);
@@ -223,7 +222,7 @@ static void ctrl_version_cb(ziti_version *v, ziti_error *e, struct ctrl_resp *re
     ctrl_default_cb(v, e, resp);
 }
 
-void ziti_ctrl_clear_api_session(ziti_controller *ctrl) {
+void ziti_ctrl_clear_api_session(ziti_controller *ctrl){
     CTRL_LOG(DEBUG, "clearing api session token for ziti_controller");
     FREE(ctrl->api_session_token);
     um_http_header(&ctrl->client, "zt-session", NULL);
@@ -288,8 +287,7 @@ static void ctrl_body_cb(um_http_req_t *req, const char *b, ssize_t len) {
         } else {
             int rc = parse_api_resp(&cr, resp->body, resp->received);
             if (rc < 0) {
-                CTRL_LOG(ERROR, "failed to parse controller response for req[%s]>>>\n%.*s", req->path,
-                         (int) (resp->received), resp->body);
+                CTRL_LOG(ERROR, "failed to parse controller response for req[%s]>>>\n%.*s", req->path, (int)(resp->received), resp->body);
                 cr.error = alloc_ziti_error();
                 cr.error->err = ZITI_WTF;
                 cr.error->code = strdup("INVALID_CONTROLLER_RESPONSE");
@@ -304,13 +302,10 @@ static void ctrl_body_cb(um_http_req_t *req, const char *b, ssize_t len) {
                 } else {
                     uv_timeval64_t now;
                     uv_gettimeofday(&now);
-                    uint64_t elapsed =
-                            (now.tv_sec * 1000000 + now.tv_usec) - (resp->start.tv_sec * 1000000 + resp->start.tv_usec);
-                    CTRL_LOG(DEBUG, "completed %s[%s] in %ld.%03ld s", req->method, req->path, elapsed / 1000000,
-                             (elapsed / 1000) % 1000);
+                    uint64_t elapsed = (now.tv_sec * 1000000 + now.tv_usec) - (resp->start.tv_sec * 1000000 + resp->start.tv_usec);
+                    CTRL_LOG(DEBUG, "completed %s[%s] in %ld.%03ld s", req->method, req->path, elapsed / 1000000, (elapsed / 1000) % 1000);
                     if (resp->paging) {
-                        bool last_page =
-                                cr.meta.pagination.total <= cr.meta.pagination.offset + cr.meta.pagination.limit;
+                        bool last_page = cr.meta.pagination.total <= cr.meta.pagination.offset + cr.meta.pagination.limit;
                         if (cr.meta.pagination.total > resp->total) {
                             resp->total = cr.meta.pagination.total;
                             resp->resp_array = realloc(resp->resp_array, (resp->total + 1) * sizeof(void *));
@@ -324,8 +319,7 @@ static void ctrl_body_cb(um_http_req_t *req, const char *b, ssize_t len) {
                         while (*chunk != NULL) {
                             resp->resp_array[resp->recd++] = *chunk++;
                         }
-                        CTRL_LOG(DEBUG, "received %d/%d for paging request GET[%s]", resp->recd,
-                                 cr.meta.pagination.total, resp->base_path);
+                        CTRL_LOG(DEBUG, "received %d/%d for paging request GET[%s]", resp->recd, cr.meta.pagination.total, resp->base_path);
                         resp->resp_array[resp->recd] = NULL;
                         FREE(resp_obj);
                         resp->received = 0;
@@ -336,10 +330,8 @@ static void ctrl_body_cb(um_http_req_t *req, const char *b, ssize_t len) {
                             ctrl_paging_req(resp);
                             return;
                         }
-                        elapsed = (now.tv_sec * 1000000 + now.tv_usec) -
-                                  (resp->all_start.tv_sec * 1000000 + resp->all_start.tv_usec);
-                        CTRL_LOG(DEBUG, "completed paging request GET[%s] in %ld.%03ld s", resp->base_path,
-                                 elapsed / 1000000, (elapsed / 1000) % 1000);
+                        elapsed = (now.tv_sec * 1000000 + now.tv_usec) - (resp->all_start.tv_sec * 1000000 + resp->all_start.tv_usec);
+                        CTRL_LOG(DEBUG, "completed paging request GET[%s] in %ld.%03ld s", resp->base_path, elapsed / 1000000, (elapsed / 1000) % 1000);
                         resp_obj = resp->resp_array;
                     }
                 }
@@ -399,8 +391,7 @@ int ziti_ctrl_close(ziti_controller *ctrl) {
     return ZITI_OK;
 }
 
-void
-ziti_ctrl_get_version(ziti_controller *ctrl, void(*cb)(ziti_version *, const ziti_error *err, void *ctx), void *ctx) {
+void ziti_ctrl_get_version(ziti_controller *ctrl, void(*cb)(ziti_version *, const ziti_error *err, void *ctx), void *ctx) {
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_version_ptr;
     resp->resp_cb = (void (*)(void *, const ziti_error *, void *)) cb;
@@ -454,7 +445,7 @@ void ziti_ctrl_login(
 }
 
 static bool verify_api_session(ziti_controller *ctrl, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
-    if (ctrl->api_session_token == NULL) {
+    if(ctrl->api_session_token == NULL) {
         CTRL_LOG(WARN, "no API session");
         ziti_error err = {
                 .err = ZITI_NOT_AUTHORIZED,
@@ -468,9 +459,8 @@ static bool verify_api_session(ziti_controller *ctrl, void(*cb)(void *, const zi
     return true;
 }
 
-void ziti_ctrl_current_identity(ziti_controller *ctrl, void(*cb)(ziti_identity_data *, const ziti_error *, void *),
-                                void *ctx) {
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+void ziti_ctrl_current_identity(ziti_controller *ctrl, void(*cb)(ziti_identity_data *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_identity_data_ptr;
@@ -482,9 +472,8 @@ void ziti_ctrl_current_identity(ziti_controller *ctrl, void(*cb)(ziti_identity_d
     start_request(&ctrl->client, "GET", "/current-identity", ctrl_resp_cb, resp);
 }
 
-void ziti_ctrl_current_api_session(ziti_controller *ctrl, void(*cb)(ziti_api_session *, const ziti_error *, void *),
-                                   void *ctx) {
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+void ziti_ctrl_current_api_session(ziti_controller *ctrl, void(*cb)(ziti_api_session *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_api_session_ptr;
@@ -497,7 +486,7 @@ void ziti_ctrl_current_api_session(ziti_controller *ctrl, void(*cb)(ziti_api_ses
 }
 
 void ziti_ctrl_logout(ziti_controller *ctrl, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = NULL; /* no body */
@@ -509,9 +498,8 @@ void ziti_ctrl_logout(ziti_controller *ctrl, void(*cb)(void *, const ziti_error 
     start_request(&ctrl->client, "DELETE", "/current-api-session", ctrl_resp_cb, resp);
 }
 
-void ziti_ctrl_get_services_update(ziti_controller *ctrl, void (*cb)(ziti_service_update *, const ziti_error *, void *),
-                                   void *ctx) {
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+void ziti_ctrl_get_services_update(ziti_controller *ctrl, void (*cb)(ziti_service_update *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_service_update_ptr;
@@ -523,9 +511,8 @@ void ziti_ctrl_get_services_update(ziti_controller *ctrl, void (*cb)(ziti_servic
     start_request(&ctrl->client, "GET", "/current-api-session/service-updates", ctrl_resp_cb, resp);
 }
 
-void
-ziti_ctrl_get_services(ziti_controller *ctrl, void (*cb)(ziti_service_array, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+void ziti_ctrl_get_services(ziti_controller *ctrl, void (*cb)(ziti_service_array, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_service_array;
@@ -539,10 +526,9 @@ ziti_ctrl_get_services(ziti_controller *ctrl, void (*cb)(ziti_service_array, con
     ctrl_paging_req(resp);
 }
 
-void
-ziti_ctrl_current_edge_routers(ziti_controller *ctrl, void (*cb)(ziti_edge_router_array, const ziti_error *, void *),
-                               void *ctx) {
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+void ziti_ctrl_current_edge_routers(ziti_controller *ctrl, void (*cb)(ziti_edge_router_array, const ziti_error *, void *),
+                                    void *ctx) {
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_edge_router_array;
@@ -557,10 +543,9 @@ ziti_ctrl_current_edge_routers(ziti_controller *ctrl, void (*cb)(ziti_edge_route
 }
 
 void
-ziti_ctrl_get_service(ziti_controller *ctrl, const char *service_name,
-                      void (*cb)(ziti_service *, const ziti_error *, void *),
+ziti_ctrl_get_service(ziti_controller *ctrl, const char *service_name, void (*cb)(ziti_service *, const ziti_error *, void *),
                       void *ctx) {
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     char path[1024];
     snprintf(path, sizeof(path), "/services?filter=name=\"%s\"", service_name);
@@ -579,7 +564,7 @@ void ziti_ctrl_get_session(
         ziti_controller *ctrl, const char *service_id, ziti_session_type type,
         void (*cb)(ziti_net_session *, const ziti_error *, void *), void *ctx) {
 
-    if (!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
+    if(!verify_api_session(ctrl, (void (*)(void *, const ziti_error *, void *)) cb, ctx)) return;
 
     char *content = malloc(128);
     size_t len = snprintf(content, 128,
@@ -601,7 +586,7 @@ void ziti_ctrl_get_session(
 void ziti_ctrl_get_sessions(
         ziti_controller *ctrl, void (*cb)(ziti_net_session **, const ziti_error *, void *), void *ctx) {
 
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_net_session_array;
@@ -685,8 +670,7 @@ ziti_ctrl_get_well_known_certs(ziti_controller *ctrl, void (*cb)(char *, const z
     um_http_req_header(req, "Accept", "application/pkcs7-mime");
 }
 
-void ziti_ctrl_get_public_cert(ziti_controller *ctrl, enroll_cfg *ecfg,
-                               void (*cb)(ziti_config *, const ziti_error *, void *),
+void ziti_ctrl_get_public_cert(ziti_controller *ctrl, enroll_cfg *ecfg, void (*cb)(ziti_config *, const ziti_error *, void *),
                                void *ctx) {
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
@@ -702,7 +686,7 @@ void ziti_ctrl_get_public_cert(ziti_controller *ctrl, enroll_cfg *ecfg,
 
 void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len,
                   void(*cb)(ziti_pr_response *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response_ptr;
@@ -718,7 +702,7 @@ void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len,
 
 void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len,
                        void(*cb)(ziti_pr_response *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response_ptr;
@@ -749,10 +733,8 @@ static void ctrl_paging_req(struct ctrl_resp *resp) {
 }
 
 
-void
-ziti_ctrl_login_mfa(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *),
-                    void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+void ziti_ctrl_login_mfa(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = NULL;
@@ -767,7 +749,7 @@ ziti_ctrl_login_mfa(ziti_controller *ctrl, char *body, size_t body_len, void(*cb
 }
 
 void ziti_ctrl_post_mfa(ziti_controller *ctrl, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = NULL;
@@ -782,7 +764,7 @@ void ziti_ctrl_post_mfa(ziti_controller *ctrl, void(*cb)(void *, const ziti_erro
 }
 
 void ziti_ctrl_get_mfa(ziti_controller *ctrl, void(*cb)(ziti_mfa_enrollment *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_mfa_enrollment_ptr;
@@ -796,7 +778,7 @@ void ziti_ctrl_get_mfa(ziti_controller *ctrl, void(*cb)(ziti_mfa_enrollment *, c
 }
 
 void ziti_ctrl_delete_mfa(ziti_controller *ctrl, char *code, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = NULL;
@@ -810,9 +792,8 @@ void ziti_ctrl_delete_mfa(ziti_controller *ctrl, char *code, void(*cb)(void *, c
     um_http_req_header(req, "mfa-validation-code", code);
 }
 
-void ziti_ctrl_post_mfa_verify(ziti_controller *ctrl, char *body, size_t body_len,
-                               void(*cb)(void *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+void ziti_ctrl_post_mfa_verify(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = NULL;
@@ -826,9 +807,8 @@ void ziti_ctrl_post_mfa_verify(ziti_controller *ctrl, char *body, size_t body_le
     um_http_req_data(req, body, body_len, free_body_cb);
 }
 
-void ziti_ctrl_get_mfa_recovery_codes(ziti_controller *ctrl, char *code,
-                                      void(*cb)(ziti_mfa_recovery_codes *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+void ziti_ctrl_get_mfa_recovery_codes(ziti_controller *ctrl, char *code, void(*cb)(ziti_mfa_recovery_codes *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_mfa_recovery_codes_ptr;
@@ -837,15 +817,13 @@ void ziti_ctrl_get_mfa_recovery_codes(ziti_controller *ctrl, char *code,
     resp->ctrl = ctrl;
     resp->ctrl_cb = ctrl_default_cb;
 
-    um_http_req_t *req = start_request(&ctrl->client, "GET", "/current-identity/mfa/recovery-codes", ctrl_resp_cb,
-                                       resp);
+    um_http_req_t *req = start_request(&ctrl->client, "GET", "/current-identity/mfa/recovery-codes", ctrl_resp_cb, resp);
     um_http_req_header(req, "mfa-validation-code", code);
     um_http_req_header(req, "Content-Type", "application/json");
 }
 
-void ziti_ctrl_post_mfa_recovery_codes(ziti_controller *ctrl, char *body, size_t body_len,
-                                       void(*cb)(void *, const ziti_error *, void *), void *ctx) {
-    if (!verify_api_session(ctrl, cb, ctx)) return;
+void ziti_ctrl_post_mfa_recovery_codes(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx) {
+    if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
     resp->body_parse_func = NULL;
@@ -854,8 +832,7 @@ void ziti_ctrl_post_mfa_recovery_codes(ziti_controller *ctrl, char *body, size_t
     resp->ctrl = ctrl;
     resp->ctrl_cb = ctrl_default_cb;
 
-    um_http_req_t *req = start_request(&ctrl->client, "POST", "/current-identity/mfa/recovery-codes", ctrl_resp_cb,
-                                       resp);
+    um_http_req_t *req = start_request(&ctrl->client, "POST", "/current-identity/mfa/recovery-codes", ctrl_resp_cb, resp);
     um_http_req_header(req, "Content-Type", "application/json");
     um_http_req_data(req, body, body_len, free_body_cb);
 }


### PR DESCRIPTION
The Ziti controller has supported an instance id since 0.19. Which can be used to detect if the controller has been restarted. In this PR this is used to determine if all posture data should be resubmitted.