### PR TITLE
Posture Timer Service Events & Forced Service Update Refresh

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -130,6 +130,16 @@ XX(typeId, string, none, typeId, __VA_ARGS__) \
 XX(unlocked, bool, none, unlocked, __VA_ARGS__) \
 XX(woken, bool, none, woken, __VA_ARGS__)
 
+#define ZITI_SERVICE_TIMER(XX, ...) \
+XX(id, string, none, id, __VA_ARGS__) \
+XX(name, string, none, name, __VA_ARGS__) \
+XX(posture_query_type, string, none, postureQueryType, __VA_ARGS__) \
+XX(timeout, int, ptr, timeout, __VA_ARGS__) \
+XX(timeoutRemaining, int, ptr, timeoutRemaining, __VA_ARGS__) \
+
+#define ZITI_PR_RESPONSE(XX, ...) \
+XX(services, ziti_service_timer, array, services, __VA_ARGS__)
+
 #define ZITI_SERVICE_UPDATE(XX, ...) \
 XX(last_change, string, none, lastChangeAt, __VA_ARGS__)
 
@@ -182,6 +192,10 @@ DECLARE_MODEL(ziti_service_update, ZITI_SERVICE_UPDATE)
 DECLARE_MODEL(ziti_mfa_code_req, ZITI_MFA_CODE_REQ)
 
 DECLARE_MODEL(ziti_mfa_recovery_codes, ZITI_MFA_RECOVERY_CODES_MODEL)
+
+DECLARE_MODEL(ziti_service_timer, ZITI_SERVICE_TIMER)
+
+DECLARE_MODEL(ziti_pr_response, ZITI_PR_RESPONSE)
 
 #ifdef __cplusplus
 }

--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -135,7 +135,7 @@ XX(id, string, none, id, __VA_ARGS__) \
 XX(name, string, none, name, __VA_ARGS__) \
 XX(posture_query_type, string, none, postureQueryType, __VA_ARGS__) \
 XX(timeout, int, ptr, timeout, __VA_ARGS__) \
-XX(timeoutRemaining, int, ptr, timeoutRemaining, __VA_ARGS__) \
+XX(timeoutRemaining, int, ptr, timeoutRemaining, __VA_ARGS__)
 
 #define ZITI_PR_RESPONSE(XX, ...) \
 XX(services, ziti_service_timer, array, services, __VA_ARGS__)

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -83,9 +83,9 @@ void ziti_ctrl_enroll(ziti_controller *ctrl, const char *method, const char *tok
                       void (*cb)(ziti_enrollment_resp *, const ziti_error *, void *), void *ctx);
 
 //Posture
-void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
+void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(ziti_pr_response *, const ziti_error *, void *), void *ctx);
 
-void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(void *, const ziti_error *, void *), void *ctx);
+void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len, void(*cb)(ziti_pr_response *, const ziti_error *, void *), void *ctx);
 
 
 //MFA

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -312,6 +312,8 @@ void ziti_set_unauthenticated(ziti_context ztx);
 
 void ziti_force_service_update(ziti_context ztx, const char* service_id);
 
+void ziti_services_refresh(uv_timer_t *t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -204,6 +204,9 @@ struct ziti_ctx {
     // map<service_id,ziti_net_session>
     model_map sessions;
 
+    // map<service_id,*bool>
+    model_map service_forced_updates;
+
     bool no_service_updates_api; // controller API has no last-update endpoint
     bool no_bulk_posture_response_api; // controller API does not support bulk posture response submission
     bool no_current_edge_routers;
@@ -306,6 +309,8 @@ void ziti_queue_work(ziti_context ztx, ztx_work_f w, void *data);
 void ziti_set_api_session(ziti_context ztx, ziti_api_session *session);
 
 void ziti_set_unauthenticated(ziti_context ztx);
+
+void ziti_force_service_update(ziti_context ztx, const char* service_id);
 
 #ifdef __cplusplus
 }

--- a/library/auth_queries.c
+++ b/library/auth_queries.c
@@ -314,7 +314,9 @@ void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
             return;
         }
     } else {
+        bool is_auth = false;
         if (mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx != NULL) {
+            is_auth = true;
             ziti_mfa_auth_ctx *outstanding_ctx = mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx;
             mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx = NULL;
 
@@ -328,6 +330,11 @@ void ziti_mfa_auth_internal_cb(void *empty, const ziti_error *err, void *ctx) {
             mfa_auth_ctx->cb(ztx, ZITI_OK, mfa_auth_ctx->cb_ctx);
         } else {
             ZTX_LOG(WARN, "no mfa status callback provided, mfa was a success, status was: %d", err->err);
+        }
+
+        if(!is_auth){
+            //not authenticating, mfa re-check, refresh services
+            ziti_services_refresh(&ztx->service_refresh_timer);
         }
 
         FREE(ctx);

--- a/library/internal_model.c
+++ b/library/internal_model.c
@@ -85,6 +85,10 @@ IMPL_MODEL(ziti_pr_domain_req, ZITI_PR_DOMAIN_REQ)
 
 IMPL_MODEL(ziti_pr_endpoint_state_req, ZITI_PR_ENDPOINT_STATE_REQ)
 
+IMPL_MODEL(ziti_service_timer, ZITI_SERVICE_TIMER)
+
+IMPL_MODEL(ziti_pr_response, ZITI_PR_RESPONSE)
+
 IMPL_MODEL(ziti_service_update, ZITI_SERVICE_UPDATE)
 
 IMPL_MODEL(ziti_mfa_recovery_codes, ZITI_MFA_RECOVERY_CODES_MODEL)

--- a/library/posture.c
+++ b/library/posture.c
@@ -419,6 +419,7 @@ static void ziti_pr_post_bulk_cb(ziti_pr_response *pr_resp, const ziti_error *er
     } else {
         ztx->posture_checks->must_send = false; //did not error, can skip submissions
         handle_pr_resp_timer_events(ztx, pr_resp);
+        ziti_services_refresh(&ztx->service_refresh_timer);
         ZTX_LOG(DEBUG, "done with bulk posture response submission");
     }
 
@@ -455,6 +456,7 @@ static void ziti_pr_post_cb(ziti_pr_response *pr_resp, const ziti_error *err, vo
     } else {
         ziti_pr_set_info_success(pr_ctx->ztx, pr_ctx->info->id);
         handle_pr_resp_timer_events(ztx, pr_resp);
+        ziti_services_refresh(&ztx->service_refresh_timer);
         ZTX_LOG(TRACE, "done with one pr response submission, object: %s", pr_ctx->info->obj);
     }
 

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -647,7 +647,7 @@ void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len,
     if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
-    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response;
+    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response_ptr;
     resp->resp_cb = (void (*)(void *, const ziti_error *, void *)) cb;
     resp->ctx = ctx;
     resp->ctrl = ctrl;
@@ -663,7 +663,7 @@ void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len,
     if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
-    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response;
+    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response_ptr;
     resp->resp_cb = (void (*)(void *, const ziti_error *, void *)) cb;
     resp->ctx = ctx;
     resp->ctrl = ctrl;

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -643,11 +643,11 @@ static char *str_array_to_json(const char **arr) {
 }
 
 void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len,
-                  void(*cb)(void *, const ziti_error *, void *), void *ctx) {
+                  void(*cb)(ziti_pr_response *, const ziti_error *, void *), void *ctx) {
     if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
-    resp->body_parse_func = NULL;
+    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response;
     resp->resp_cb = (void (*)(void *, const ziti_error *, void *)) cb;
     resp->ctx = ctx;
     resp->ctrl = ctrl;
@@ -659,11 +659,11 @@ void ziti_pr_post(ziti_controller *ctrl, char *body, size_t body_len,
 }
 
 void ziti_pr_post_bulk(ziti_controller *ctrl, char *body, size_t body_len,
-                       void(*cb)(void *, const ziti_error *, void *), void *ctx) {
+                       void(*cb)(ziti_pr_response *, const ziti_error *, void *), void *ctx) {
     if(!verify_api_session(ctrl, cb, ctx)) return;
 
     struct ctrl_resp *resp = calloc(1, sizeof(struct ctrl_resp));
-    resp->body_parse_func = NULL;
+    resp->body_parse_func = (int (*)(void *, const char *, size_t)) parse_ziti_pr_response;
     resp->resp_cb = (void (*)(void *, const ziti_error *, void *)) cb;
     resp->ctx = ctx;
     resp->ctrl = ctrl;

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -534,8 +534,6 @@ const char *my_configs[] = {
         "all", NULL
 };
 
-uv_loop_t *global_loop;
-
 struct mfa_work {
     uv_work_t w;
     ziti_context ztx;

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -105,14 +105,6 @@ static void shutdown_timer_cb(uv_timer_t *t) {
     uv_print_active_handles(l, stderr);
 }
 
-void debug_timer(uv_timer_t *t){
-    ziti_context ztx = t->data;
-
-    ziti_endpoint_state_change(ztx, true, false);
-
-    FREE(t);
-}
-
 static void process_stop(uv_loop_t *loop, struct proxy_app_ctx *app_ctx) {
     PREPF(uv, uv_strerror);
 
@@ -475,12 +467,6 @@ static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
             } else {
                 ZITI_LOG(ERROR, "controller is not available: %s/%s", ziti_errorstr(event->event.ctx.ctrl_status), event->event.ctx.err);
             }
-            NEWP(timer, uv_timer_t);
-            uv_timer_init(global_loop, timer);
-            timer->data = ztx;
-            uv_timer_start(timer, debug_timer, 15000, 0);
-
-
             break;
 
         case ZitiServiceEvent:
@@ -547,6 +533,8 @@ char *pxoxystrndup(const char *s, int n);
 const char *my_configs[] = {
         "all", NULL
 };
+
+uv_loop_t *global_loop;
 
 struct mfa_work {
     uv_work_t w;

--- a/tests/test_ziti_model.cpp
+++ b/tests/test_ziti_model.cpp
@@ -32,6 +32,29 @@ limitations under the License.
 
 using Catch::Matchers::Equals;
 
+TEST_CASE("posture response response", "[model]") {
+    const char *json = R"({"services":[{"id":".T9TTXjPYy","name":"net-cat2","postureQueryType":"MFA","timeout":600,"timeoutRemaining":300}]})";
+
+    ziti_pr_response pr_resp;
+    int rc = parse_ziti_pr_response(&pr_resp, json, (int) strlen(json));
+    REQUIRE(rc == 0);
+
+
+    int idx;
+
+    for (idx = 0; pr_resp.services[idx] != nullptr; idx++) {
+
+    }
+    REQUIRE(idx == 1);
+
+
+    REQUIRE_THAT(pr_resp.services[0]->id, Equals(".T9TTXjPYy"));
+    REQUIRE_THAT(pr_resp.services[0]->name, Equals("net-cat2"));
+    REQUIRE_THAT(pr_resp.services[0]->posture_query_type, Equals("MFA"));
+    REQUIRE(*pr_resp.services[0]->timeout == 600);
+    REQUIRE(*pr_resp.services[0]->timeoutRemaining == 300);
+}
+
 TEST_CASE("multi-edge-router session", "[model]") {
 
     const char *ns = "{\n"


### PR DESCRIPTION
adds logic to detect timeout and timeoutRemaining changes on services, forces service refresh post MFA TOTP/posture submission

- timeout changes are detected during normal service refresh loop, compared with previous known value, triggers service changed events
- timeoutRemaning is checked during posture response submissions, the response carries a list of affected services (used for API tests but also works here), services are marked to be forced into the changed status in the subsequent service event
- after posture response and TOTP submissions, a service refresh check is immediately triggered