### PR TITLE
better handling of uninitialized/default Enums

### DIFF
--- a/includes/ziti/model_support.h
+++ b/includes/ziti/model_support.h
@@ -269,13 +269,13 @@ ZITI_FUNC int json_enum(const void *ptr, void *buf, int indent, int flags, const
 #define enum_field(v,t) const t v;
 
 #define DECLARE_ENUM(Enum, Values) \
-enum Enum {                             \
-Values(mk_enum, Enum)                   \
-Enum##_Unknown = -1,                    \
+enum Enum {                        \
+Enum##_Unknown = 0,                \
+Values(mk_enum, Enum)              \
 };                                 \
 typedef enum Enum Enum;            \
-typedef Enum **Enum##_array;         \
-struct Enum##_s { \
+typedef Enum **Enum##_array;       \
+struct Enum##_s {                  \
 const char* (*name)(int v);                       \
 Enum (*value_of)(const char* n);                  \
 Enum (*value_ofn)(const char* s, size_t n);       \

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -816,6 +816,10 @@ static int _cmp_map(model_map *lh, model_map *rh) {
     return rc;
 }
 
+static int null_to_json(string_buf_t *buf, int indent, int flags) {
+    return string_buf_append(buf, "null");
+}
+
 static int bool_to_json(bool *v, string_buf_t *buf, int indent, int flags) {
     return string_buf_append(buf, *v ? "true" : "false");
 }
@@ -975,6 +979,10 @@ int json_enum(const void *ptr, void *bufp, int indent, int flags, const void *en
     string_buf_t *buf = bufp;
     int en_val = *(int *) ptr;
     const struct generic_enum_s *en = enum_type;
+
+    if (en_val == 0) { // Enum_Unknown
+        return null_to_json(buf, indent, flags);
+    }
 
     return string_to_json(en->name(en_val), buf, indent, flags);
 }

--- a/tests/enum_tests.cpp
+++ b/tests/enum_tests.cpp
@@ -30,6 +30,7 @@ IMPL_ENUM(State, States)
 TEST_CASE("test enum", "[model]") {
     State good = States.value_of("Good");
 
+    CHECK(State_Unknown == 0);
     CHECK(good == States.Good);
     CHECK_THAT(States.name(good), Catch::Matches("Good"));
 }
@@ -54,10 +55,45 @@ TEST_CASE("parse enum", "[model]") {
     CHECK(f1.state == States.Ugly);
 }
 
-TEST_CASE("enum to json", "[model]") {
-    FooWithEnum f;
+TEST_CASE("parse null enum", "[model]") {
+    const char *json = R"({
+"name": "this is a name",
+"state": null
+})";
+
+    FooWithEnum f1;
+    REQUIRE(parse_FooWithEnum(&f1, json, strlen(json)) == 0);
+
+    CHECK_THAT(f1.name, Catch::Equals("this is a name"));
+    CHECK(f1.state == 0);
+}
+
+TEST_CASE("default enum", "[model]") {
+    FooWithEnum f = {0};
     f.name = (char *) "awesome foo";
-    f.state = States.Bad;
+
+    CHECK(f.state == State_Unknown);
+
+    char *json = FooWithEnum_to_json(&f, 0, nullptr);
+
+    REQUIRE(json);
+
+    REQUIRE_THAT(json, Catch::Contains("\"state\":null"));
+
+    FooWithEnum f2;
+    REQUIRE(0 == parse_FooWithEnum(&f2, json, strlen(json)));
+    CHECK(f2.state == State_Unknown);
+
+
+    free(json);
+}
+
+TEST_CASE("enum to json", "[model]") {
+    FooWithEnum f = {0};
+    f.name = (char *) "awesome foo";
+    f.state = States.Bad;/**
+ * Declares [Enum] with given [Values]
+ */
 
     char *json = FooWithEnum_to_json(&f, 0, nullptr);
 


### PR DESCRIPTION
- make 0 unset/default value, i.e. Enum_Unknown
- defined Enum values will start at 1
- serialize unset/0 Enum value to JSON as `null`