### PR TITLE
enroll using jwt content

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -280,6 +280,8 @@ int load_config(const char *filename, ziti_config **);
 
 int load_jwt(const char *filename, struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **, ziti_enrollment_jwt **);
 
+int load_jwt_content(struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **zejh, ziti_enrollment_jwt **zej);
+
 int load_tls(ziti_config *cfg, tls_context **tls);
 
 int ziti_bind(ziti_connection conn, const char *service, ziti_listen_opts *listen_opts, ziti_listen_cb listen_cb,

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -262,6 +262,7 @@ typedef struct ziti_enroll_opts_s {
     const char *enroll_key;
     const char *enroll_cert;
     const char *enroll_name;
+    const char *jwt_content;
 } ziti_enroll_opts;
 
 typedef struct ziti_dial_opts_s {

--- a/library/jwt.c
+++ b/library/jwt.c
@@ -24,24 +24,16 @@ limitations under the License.
 
 const char* ZITI_SDK_JWT_FILE = "ZITI_SDK_JWT_FILE";
 
-int parse_jwt_content(const char *filename, struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **zejh, ziti_enrollment_jwt **zej) {
+int parse_jwt_content(struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **zejh, ziti_enrollment_jwt **zej) {
 
     const char *dot1 = strchr(ecfg->raw_jwt, '.');
     if (NULL == dot1) {
-        if(filename) {
-            ZITI_LOG(ERROR, "%s - lacks a dot", filename);
-        } else {
-            ZITI_LOG(ERROR, "jwt input - lacks a dot");
-        }
+        ZITI_LOG(ERROR, "jwt input lacks a dot");
         return ZITI_JWT_INVALID_FORMAT;
     }
     const char *dot2 = strchr(dot1 + 1, '.');
     if (NULL == dot2) {
-        if(filename) {
-            ZITI_LOG(ERROR, "%s - lacks a second dot", filename);
-        } else {
-            ZITI_LOG(ERROR, "jwt input - lacks a second dot");
-        }
+        ZITI_LOG(ERROR, "jwt input lacks a second dot");
         return ZITI_JWT_INVALID_FORMAT;
     }
     ecfg->jwt_signing_input = (unsigned char *) calloc(1, strlen(ecfg->raw_jwt) + 1);
@@ -111,7 +103,7 @@ int load_jwt_file(const char *filename, struct enroll_cfg_s *ecfg, ziti_enrollme
 
     ZITI_LOG(DEBUG, "jwt file content is: \n%.*s", jwt_file_len, ecfg->raw_jwt);
 
-    return parse_jwt_content(filename, ecfg, zejh, zej);
+    return parse_jwt_content(ecfg, zejh, zej);
 }
 
 int load_jwt(const char *filename, struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **zejh, ziti_enrollment_jwt **zej) {
@@ -136,5 +128,5 @@ int load_jwt_content(struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **zej
 
     ZITI_LOG(DEBUG, "jwt file content is: \n%.*s", strlen(ecfg->raw_jwt), ecfg->raw_jwt);
 
-    return parse_jwt_content(NULL, ecfg, zejh, zej);
+    return parse_jwt_content(ecfg, zejh, zej);
 }

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -106,7 +106,12 @@ int ziti_enroll(ziti_enroll_opts *opts, uv_loop_t *loop, ziti_enroll_cb enroll_c
     ecfg->private_key = opts->enroll_key;
     ecfg->name = opts->enroll_name;
 
-    TRY(ziti, load_jwt(opts->jwt, ecfg, &ecfg->zejh, &ecfg->zej));
+    if (opts->jwt) {
+        TRY(ziti, load_jwt(opts->jwt, ecfg, &ecfg->zejh, &ecfg->zej));
+    } else {
+        ecfg->raw_jwt = opts->jwt_content;
+        TRY(ziti, load_jwt_content(ecfg, &ecfg->zejh, &ecfg->zej));
+    }
     TRY(ziti, check_cert_required(ecfg));
 
     NEWP(ctrl, ziti_controller);


### PR DESCRIPTION
ziti_enroll function currently accepts jwt file name and read the content from the file. We have added another function which accepts jwt content instead of jwt file name. So  when we call load_jwt_content function, it expects the jwt raw content in the enroll_cfg_s object