### PR TITLE
use standard compiler var to detect presence of stdatomic.h header

### DIFF
--- a/deps/libsodium.cmake
+++ b/deps/libsodium.cmake
@@ -55,12 +55,13 @@ if(NOT libsodium_POPULATED)
             endif()
             execute_process(
                     COMMAND "${libsodium_SOURCE_DIR}/configure" "--prefix=${libsodium_BINARY_DIR}"
-                    --disable-opt --without-pthreads --with-pic --host=${triple}
+                    --enable-opt --without-pthreads --with-pic --host=${triple}
+                    --with-sysroot=${CMAKE_SYSROOT}
                     WORKING_DIRECTORY ${libsodium_BINARY_DIR}
             )
         endif()
 		execute_process(
-                COMMAND make V=s
+                COMMAND make -j4
                 WORKING_DIRECTORY ${libsodium_BINARY_DIR}
         )
         execute_process(

--- a/inc_internal/metrics.h
+++ b/inc_internal/metrics.h
@@ -28,7 +28,7 @@ limitations under the License.
 using namespace std;
 #else
 #if defined(__linux) || defined(__APPLE__)
-# if defined(mips) || defined(__mips)
+# if __STDC_NO_ATOMICS__
 
 #   include <bits/atomic.h>
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -62,9 +62,14 @@ target_sources(ziti_dll PRIVATE ${ZITI_PRIVATE_SRC_FILES})
 target_link_libraries(ziti     PUBLIC uv_mbed sodium)
 target_link_libraries(ziti_dll PUBLIC uv_mbed sodium)
 
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+    target_link_libraries(ziti PUBLIC atomic)
+    target_link_libraries(ziti_dll PUBLIC atomic)
+endif()
+
 if (NOT WIN32)
-    target_link_libraries(ziti PUBLIC m PUBLIC atomic)
-    target_link_libraries(ziti_dll PUBLIC m PUBLIC atomic)
+    target_link_libraries(ziti PUBLIC m)
+    target_link_libraries(ziti_dll PUBLIC m)
 endif ()
 
 target_include_directories(ziti     ${ZITI_INCLUDE_DIRS})

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -63,9 +63,9 @@ target_link_libraries(ziti     PUBLIC uv_mbed sodium)
 target_link_libraries(ziti_dll PUBLIC uv_mbed sodium)
 
 if (NOT WIN32)
-    target_link_libraries(ziti     PUBLIC m )
-    target_link_libraries(ziti_dll PUBLIC m )
-endif()
+    target_link_libraries(ziti PUBLIC m PUBLIC atomic)
+    target_link_libraries(ziti_dll PUBLIC m PUBLIC atomic)
+endif ()
 
 target_include_directories(ziti     ${ZITI_INCLUDE_DIRS})
 target_include_directories(ziti_dll ${ZITI_INCLUDE_DIRS})

--- a/library/metrics.c
+++ b/library/metrics.c
@@ -23,7 +23,7 @@ limitations under the License.
 #include <uv.h>
 
 #if defined(__unix__) || defined(__APPLE__)
-# if defined(mips) || defined(__mips)
+# if __STDC_NO_ATOMICS__
 
 #   include <atomic.h>
 


### PR DESCRIPTION
needed for newer openwrt/teltonika SDK