### PR TITLE
remove libsodium download verification for now

### DIFF
--- a/deps/libsodium.cmake
+++ b/deps/libsodium.cmake
@@ -6,7 +6,6 @@ if (WIN32)
            FetchContent_Declare (
                    libsodium
                    URL	https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip
-                   URL_HASH MD5=b68f2b60ea7436bfdc0260eaa2f60baf
 		   )
            if(CMAKE_EXE_LINKER_FLAGS MATCHES "/machine:x64")
               set(arch "x64")

--- a/deps/libsodium.cmake
+++ b/deps/libsodium.cmake
@@ -26,7 +26,6 @@ if (WIN32)
            FetchContent_Declare (
                    libsodium
                    URL	https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-mingw.tar.gz
-                   URL_HASH MD5=0ffb5948defc97edc4a75877ede26077
            )
            set(libsodium_include_path libsodium-win64/include)
            set(libsodium_lib_path libsodium-win64/lib/libsodium.a)


### PR DESCRIPTION
proper way to verify download is with `minisign` (todo it later)