### PR TITLE
stops posture submission from occurring during partial auth

### DIFF
--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -97,7 +97,8 @@ ZITI_FUNC extern int ziti_log_level();
  */
 ZITI_FUNC void uv_mbed_logger(int level, const char *file, unsigned int line, const char *msg);
 
-// enabled the uv_mbed_logger. windows is stupid.
+// don't use this function. it's a temporary function to support logging on windows.it will be
+// removed in a future release
 ZITI_FUNC void ziti_enable_uv_mbed_logger();
 
 

--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -99,7 +99,7 @@ ZITI_FUNC void uv_mbed_logger(int level, const char *file, unsigned int line, co
 
 // don't use this function. it's a temporary function to support logging on windows.it will be
 // removed in a future release
-ZITI_FUNC void ziti_enable_uv_mbed_logger(bool enabled);
+ZITI_FUNC void ziti_enable_uv_mbed_logger(int enabled);
 
 
 #ifdef __cplusplus

--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -99,7 +99,7 @@ ZITI_FUNC void uv_mbed_logger(int level, const char *file, unsigned int line, co
 
 // don't use this function. it's a temporary function to support logging on windows.it will be
 // removed in a future release
-ZITI_FUNC void ziti_enable_uv_mbed_logger();
+ZITI_FUNC void ziti_enable_uv_mbed_logger(bool enabled);
 
 
 #ifdef __cplusplus

--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -97,6 +97,9 @@ ZITI_FUNC extern int ziti_log_level();
  */
 ZITI_FUNC void uv_mbed_logger(int level, const char *file, unsigned int line, const char *msg);
 
+// enabled the uv_mbed_logger. windows is stupid.
+ZITI_FUNC void ziti_enable_uv_mbed_logger();
+
 
 #ifdef __cplusplus
 }

--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -95,7 +95,7 @@ ZITI_FUNC extern int ziti_log_level();
  * can be used to turn on logging of uv-mbed library and send log messages into the ziti_log
  * Usage: <code>uv_mbed_set_debug(level, uv_mbed_logger);</code>
  */
-void uv_mbed_logger(int level, const char *file, unsigned int line, const char *msg);
+ZITI_FUNC void uv_mbed_logger(int level, const char *file, unsigned int line, const char *msg);
 
 
 #ifdef __cplusplus

--- a/library/posture.c
+++ b/library/posture.c
@@ -176,7 +176,12 @@ static pr_info *get_resp_info(ziti_context ztx, const char *id) {
 
 void ziti_send_posture_data(ziti_context ztx) {
     if (ztx->api_session == NULL || ztx->api_session->id == NULL) {
-        ZTX_LOG(DEBUG, "no api_session, can't submit posture checks");
+        ZTX_LOG(DEBUG, "no api_session, can't submit posture responses");
+        return;
+    }
+
+    if(ztx->api_session_state != ZitiApiSessionStateFullyAuthenticated) {
+        ZTX_LOG(DEBUG, "api_session is partially authenticated, can't submit posture responses");
         return;
     }
 

--- a/library/utils.c
+++ b/library/utils.c
@@ -261,6 +261,10 @@ void uv_mbed_logger(int level, const char *file, unsigned int line, const char *
     ziti_logger(level, "uv-mbed", file, line, NULL, msg);
 }
 
+void ziti_enable_uv_mbed_logger() {
+    uv_mbed_set_debug(9, uv_mbed_logger);
+}
+
 static void flush_log(uv_prepare_t *p) {
     fflush(ziti_debug_out);
 }

--- a/library/utils.c
+++ b/library/utils.c
@@ -261,7 +261,7 @@ void uv_mbed_logger(int level, const char *file, unsigned int line, const char *
     ziti_logger(level, "uv-mbed", file, line, NULL, msg);
 }
 
-void ziti_enable_uv_mbed_logger(bool enabled) {
+void ziti_enable_uv_mbed_logger(int enabled) {
     if(enabled) {
         uv_mbed_set_debug(9, uv_mbed_logger);
     } else {

--- a/library/utils.c
+++ b/library/utils.c
@@ -261,8 +261,12 @@ void uv_mbed_logger(int level, const char *file, unsigned int line, const char *
     ziti_logger(level, "uv-mbed", file, line, NULL, msg);
 }
 
-void ziti_enable_uv_mbed_logger() {
-    uv_mbed_set_debug(9, uv_mbed_logger);
+void ziti_enable_uv_mbed_logger(bool enabled) {
+    if(enabled) {
+        uv_mbed_set_debug(9, uv_mbed_logger);
+    } else {
+        uv_mbed_set_debug(1, NULL);
+    }
 }
 
 static void flush_log(uv_prepare_t *p) {


### PR DESCRIPTION
This was causing posture responses to be submitted when it was not possible to. This would then confuse the posture engine to think it had submitted posture data when it had not.