### PR TITLE
Ziti Connection bridge

### DIFF
--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -311,7 +311,7 @@ typedef struct ziti_listen_opts_s {
  * @return indicate how much data was consumed
  * @see ziti_dial(), ziti_accept(), ZITI_ERRORS
  */
-typedef ssize_t (*ziti_data_cb)(ziti_connection conn, uint8_t *data, ssize_t length);
+typedef ssize_t (*ziti_data_cb)(ziti_connection conn, const uint8_t *data, ssize_t length);
 
 /**
  * @brief Connection callback.
@@ -638,6 +638,17 @@ ZITI_FUNC
 extern void ziti_conn_set_data(ziti_connection conn, void *data);
 
 /**
+ * @brief Set new data callback on ziti connection.
+ * This allows application to defer setting callback until connection is established (inside [ziti_conn_cb]),
+ * or change processing at any time.
+ *
+ * @param conn
+ * @param cb
+ */
+ZITI_FUNC
+extern void ziti_conn_set_data_cb(ziti_connection conn, ziti_data_cb cb);
+
+/**
  * @brief Get the identity of the client that initiated the #ziti_connection.
  *
  * @return identity of the client that requested the connection.
@@ -800,7 +811,34 @@ extern int ziti_close_write(ziti_connection conn);
 ZITI_FUNC
 extern int ziti_write(ziti_connection conn, uint8_t *data, size_t length, ziti_write_cb write_cb, void *write_ctx);
 
+/**
+ * @brief Bridge [ziti_connection] to a given IO stream
+ *
+ * This sets up the connection bridge: all bytes read from ziti_connection are forwarded to the IO stream, and vice a versa.
+ * Both ziti_connection and stream have to be established prior to this call.
+ *
+ * [on_close] is called after the bridge is terminated and ziti_connection was closed.
+ *
+ * @param conn
+ * @param stream
+ * @param on_close
+ * @return
+ */
+ZITI_FUNC
+extern int ziti_conn_bridge(ziti_connection conn, uv_stream_t *stream, uv_close_cb on_close);
 
+/**
+ * @brief Bridge [ziti_connection] to given IO file descriptors.
+ *
+ * All bytes read from ziti_connection are written to output fd, all bytes read from input fd are sent to ziti_connection.
+ *
+ * @param conn
+ * @param input
+ * @param output
+ * @return
+ */
+ZITI_FUNC
+extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd_t output);
 
 /**
  * @brief Callback called after ziti_mfa_enroll()

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -835,10 +835,12 @@ extern int ziti_conn_bridge(ziti_connection conn, uv_stream_t *stream, uv_close_
  * @param conn
  * @param input
  * @param output
+ * @param close_cb
+ * @param ctx
  * @return
  */
 ZITI_FUNC
-extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd_t output);
+extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd_t output, void (*close_cb)(void *ctx), void *ctx);
 
 /**
  * @brief Callback called after ziti_mfa_enroll()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(ZITI_SRC_FILES
         metrics.c
         posture.c
         auth_queries.c
+        conn_bridge.c
 )
 
 SET(ZITI_INCLUDE_DIRS

--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -94,6 +94,8 @@ extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd
     uv_pipe_init(l, (uv_pipe_t *) br->output, 0);
     uv_pipe_open((uv_pipe_t *) br->input, input);
     uv_pipe_open((uv_pipe_t *) br->output, output);
+    br->input->data = br;
+    br->output->data = br;
 
     br->close_cb = on_pipes_close;
     NEWP(fdbr, struct fd_bridge_s);
@@ -123,6 +125,7 @@ static void on_ziti_close(ziti_connection conn) {
 }
 
 static void close_bridge(struct ziti_bridge_s *br) {
+    // if (br)
     ziti_close(br->conn, on_ziti_close);
 }
 

--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -1,0 +1,131 @@
+/*
+Copyright (c) 2022 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "zt_internal.h"
+#include "utils.h"
+
+struct ziti_bridge_s {
+    ziti_connection conn;
+    uv_stream_t *input;
+    uv_stream_t *output;
+    uv_close_cb close_cb;
+    void *data;
+};
+
+static ssize_t on_ziti_data(ziti_connection conn, const uint8_t *data, ssize_t len);
+
+static void bridge_alloc(uv_handle_t *h, size_t req, uv_buf_t *b);
+
+static void on_input(uv_stream_t *s, ssize_t len, const uv_buf_t *b);
+
+
+extern int ziti_conn_bridge(ziti_connection conn, uv_stream_t *stream, uv_close_cb on_close) {
+    NEWP(br, struct ziti_bridge_s);
+    br->conn = conn;
+    br->input = stream;
+    br->output = stream;
+    br->close_cb = on_close;
+    br->data = uv_handle_get_data((const uv_handle_t *) stream);
+
+    uv_handle_set_data((uv_handle_t *) stream, br);
+    ziti_conn_set_data(conn, br);
+
+    ziti_conn_set_data_cb(conn, on_ziti_data);
+    uv_read_start(br->input, bridge_alloc, on_input);
+
+    return ZITI_OK;
+}
+
+
+extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd_t output) {
+    // TODO
+    return ZITI_WTF;
+}
+
+static void on_ziti_close(ziti_connection conn) {
+    struct ziti_bridge_s *br = ziti_conn_data(conn);
+
+    uv_handle_set_data((uv_handle_t *) br->input, br->data);
+    br->close_cb((uv_handle_t *) br->input);
+    free(br);
+}
+
+static void close_bridge(struct ziti_bridge_s *br) {
+    ziti_close(br->conn, on_ziti_close);
+}
+
+static void on_output(uv_write_t *wr, int status) {
+    if (status != 0) {
+        struct ziti_bridge_s *br = wr->handle->data;
+        ZITI_LOG(WARN, "write failed: %d(%s)", status, uv_strerror(status));
+        close_bridge(br);
+    }
+    free(wr->data);
+    free(wr);
+}
+
+static void on_shutdown(uv_shutdown_t *sr, int status) {
+    if (status != 0) {
+        ZITI_LOG(WARN, "shutdown failed: %d(%s)", status, uv_strerror(status));
+        close_bridge(sr->handle->data);
+    }
+    free(sr);
+}
+
+ssize_t on_ziti_data(ziti_connection conn, const uint8_t *data, ssize_t len) {
+    struct ziti_bridge_s *br = ziti_conn_data(conn);
+    if (len > 0) {
+        NEWP(wr, uv_write_t);
+        uv_buf_t b = uv_buf_init(malloc(len), len);
+        memcpy(b.base, data, len);
+        wr->data = b.base;
+        uv_write(wr, br->output, &b, 1, on_output);
+        return len;
+    } else if (len == ZITI_EOF) {
+        NEWP(sr, uv_shutdown_t);
+        uv_shutdown(sr, br->output, on_shutdown);
+    } else {
+        close_bridge(br);
+    }
+    return 0;
+}
+
+void bridge_alloc(uv_handle_t *h, size_t req, uv_buf_t *b) {
+    b->base = malloc(req);
+    b->len = b->base ? req : 0;
+}
+
+static void on_ziti_write(ziti_connection conn, ssize_t status, void *ctx) {
+    FREE(ctx);
+    if (status < ZITI_OK) {
+        close_bridge(ziti_conn_data(conn));
+    }
+}
+
+void on_input(uv_stream_t *s, ssize_t len, const uv_buf_t *b) {
+    struct ziti_bridge_s *br = s->data;
+    if (len == 0) {
+        free(b->base);
+    } else if (len > 0) {
+        ziti_write(br->conn, b->base, len, on_ziti_write, b->base);
+    } else if (len == UV_EOF) {
+        free(b->base);
+        ziti_close_write(br->conn);
+    } else {
+        free(b->base);
+        close_bridge(br);
+    }
+}

--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -111,7 +111,7 @@ extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd
     ziti_conn_set_data_cb(conn, on_ziti_data);
     uv_read_start(br->input, bridge_alloc, on_input);
 
-    return ZITI_WTF;
+    return ZITI_OK;
 }
 
 static void on_ziti_close(ziti_connection conn) {

--- a/library/connect.c
+++ b/library/connect.c
@@ -744,6 +744,7 @@ static bool flush_to_service(ziti_connection conn) {
 
             conn->write_reqs++;
             ziti_write_req(req);
+            count++;
         }
         CONN_LOG(TRACE, "flushed %d messages", count);
     }

--- a/library/connect.c
+++ b/library/connect.c
@@ -736,7 +736,7 @@ static void flush_connection (ziti_connection conn) {
 
 static bool flush_to_service(ziti_connection conn) {
 
-    if (conn->state == Connected) {
+    if (conn->state == Connected || conn->state == CloseWrite) {
         int count = 0;
         while (!TAILQ_EMPTY(&conn->wreqs)) {
             struct ziti_write_req_s *req = TAILQ_FIRST(&conn->wreqs);
@@ -1257,7 +1257,7 @@ int ziti_close_write(ziti_connection conn) {
         return ZITI_OK;
     }
     conn_set_state(conn, CloseWrite);
-    if (conn->write_reqs == 0) {
+    if (conn->write_reqs == 0 && TAILQ_EMPTY(&conn->wreqs)) {
         return send_fin_message(conn);
     }
     return ZITI_OK;

--- a/library/utils.c
+++ b/library/utils.c
@@ -284,7 +284,7 @@ static void default_log_writer(int level, const char *loc, const char *msg, size
 }
 
 void uv_mbed_logger(int level, const char *file, unsigned int line, const char *msg) {
-    ziti_logger(level, "uv-mbed", file, line, NULL, msg);
+    ziti_logger(level, "uv-mbed", file, line, NULL, "%s", msg);
 }
 
 void ziti_enable_uv_mbed_logger(int enabled) {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -667,6 +667,12 @@ void ziti_conn_set_data(ziti_connection conn, void *data) {
     }
 }
 
+void ziti_conn_set_data_cb(ziti_connection conn, ziti_data_cb cb) {
+    if (conn) {
+        conn->data_cb = cb;
+    }
+}
+
 const char *ziti_conn_source_identity(ziti_connection conn) {
     return conn != NULL ? conn->source_identity : NULL;
 }

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1153,6 +1153,11 @@ static void edge_routers_cb(ziti_edge_router_array ers, const ziti_error *err, v
         return;
     }
 
+    if (ztx->closing) {
+        free_ziti_edge_router_array(&ers);
+        return;
+    }
+
     model_map curr_routers = {0};
     const char *er_name;
     ziti_channel_t *ch;

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -223,9 +223,9 @@ static void ctrl_version_cb(ziti_version *v, ziti_error *e, struct ctrl_resp *re
 }
 
 void ziti_ctrl_clear_api_session(ziti_controller *ctrl) {
-    CTRL_LOG(DEBUG, "clearing api session token for ziti_controller");
     FREE(ctrl->api_session_token);
     if (ctrl->client) {
+        CTRL_LOG(DEBUG, "clearing api session token for ziti_controller");
         um_http_header(ctrl->client, "zt-session", NULL);
     }
 }

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -8,3 +8,5 @@ add_subdirectory(sample_http_link)
 add_subdirectory(sample-host)
 add_subdirectory(sample_enroll)
 add_subdirectory(wzcat)
+
+add_subdirectory(sample-bridge)

--- a/programs/sample-bridge/CMakeLists.txt
+++ b/programs/sample-bridge/CMakeLists.txt
@@ -1,0 +1,4 @@
+project(sample-socket)
+
+add_executable(ziti-ncat ziti-ncat.c)
+target_link_libraries(ziti-ncat PUBLIC ziti)

--- a/programs/sample-bridge/ziti-ncat.c
+++ b/programs/sample-bridge/ziti-ncat.c
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2022 NetFoundry, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#include <ziti/ziti.h>
+
+
+typedef struct {
+    uv_loop_t *loop;
+    const char *service;
+} zcat_opts;
+
+void on_connect(ziti_connection conn, int status) {
+    if (status == ZITI_OK) {
+        ziti_conn_bridge_fds(conn, 0, 1, ziti_shutdown, ziti_conn_context(conn));
+    } else {
+        fprintf(stderr, "ziti connection failed: %s", ziti_errorstr(status));
+        ziti_shutdown(ziti_conn_context(conn));
+    }
+}
+
+void on_ziti_event(ziti_context ztx, const ziti_event_t *ev) {
+    if (ev->type == ZitiContextEvent && ev->event.ctx.ctrl_status == ZITI_OK) {
+        zcat_opts *opts = ziti_app_ctx(ztx);
+        ziti_connection zconn;
+        ziti_conn_init(ztx, &zconn, NULL);
+        ziti_dial(zconn, opts->service, on_connect, NULL);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    uv_loop_t *l = uv_loop_new();
+    zcat_opts opts = {
+            .loop = l,
+            .service = argv[2]
+    };
+    ziti_options zopts = {
+            .config = argv[1],
+            .event_cb = on_ziti_event,
+            .events = ZitiContextEvent,
+            .app_ctx = &opts
+    };
+
+    ziti_init_opts(&zopts, l);
+
+    uv_run(l, UV_RUN_DEFAULT);
+}
+

--- a/programs/sample-bridge/ziti-ncat.c
+++ b/programs/sample-bridge/ziti-ncat.c
@@ -16,16 +16,20 @@ limitations under the License.
 
 
 #include <ziti/ziti.h>
+#include <stdio.h>
 
+#define STDIN 0
+#define STDOUT 1
 
 typedef struct {
     uv_loop_t *loop;
     const char *service;
 } zcat_opts;
 
+// on successful connect bridge Ziti connection to standard input and output
 void on_connect(ziti_connection conn, int status) {
     if (status == ZITI_OK) {
-        ziti_conn_bridge_fds(conn, 0, 1, ziti_shutdown, ziti_conn_context(conn));
+        ziti_conn_bridge_fds(conn, STDIN, STDOUT, ziti_shutdown, ziti_conn_context(conn));
     } else {
         fprintf(stderr, "ziti connection failed: %s", ziti_errorstr(status));
         ziti_shutdown(ziti_conn_context(conn));

--- a/programs/sample-host/sample-host.c
+++ b/programs/sample-host/sample-host.c
@@ -43,7 +43,7 @@ static ssize_t on_client_data(ziti_connection clt, uint8_t *data, ssize_t len) {
     }
     else if (len == ZITI_EOF) {
         printf("client disconnected\n");
-        ziti_close(clt, NULL);
+        ziti_close_write(clt);
     }
     else {
         fprintf(stderr, "error: %zd(%s)", len, ziti_errorstr(len));


### PR DESCRIPTION
Ziti Connection bridge functions (see ziti.h) are utilities to simplify handling of application streams and IO file descriptors