### PR TITLE
simplify outbound FIN/ziti_close_write() handling

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -1,18 +1,16 @@
-/*
-Copyright 2019-2020 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2022.  NetFoundry, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef ZT_SDK_ZT_INTERNAL_H
 #define ZT_SDK_ZT_INTERNAL_H
@@ -114,6 +112,7 @@ struct ziti_write_req_s {
     struct ziti_conn *conn;
     uint8_t *buf;
     size_t len;
+    bool eof;
 
     uint8_t *payload; // internal buffer
     ziti_write_cb cb;

--- a/library/connect.c
+++ b/library/connect.c
@@ -245,11 +245,6 @@ void on_write_completed(struct ziti_conn *conn, struct ziti_write_req_s *req, in
     }
 
     free(req);
-
-    if (conn->write_reqs == 0 && conn->state == CloseWrite) {
-        CONN_LOG(DEBUG, "sending FIN");
-        send_fin_message(conn);
-    }
 }
 
 static int
@@ -510,10 +505,15 @@ static void process_connect(struct ziti_conn *conn) {
 }
 
 static int do_ziti_dial(ziti_connection conn, const char *service, ziti_dial_opts *dial_opts, ziti_conn_cb conn_cb, ziti_data_cb data_cb) {
-    if (!conn->ziti_ctx->enabled) return ZITI_DISABLED;
+    if (!conn->ziti_ctx->enabled) { return ZITI_DISABLED; }
 
     if (conn->state != Initial) {
         CONN_LOG(ERROR, "can not dial in state[%s]", ziti_conn_state(conn));
+        return ZITI_INVALID_STATE;
+    }
+
+    if (conn_cb == NULL) {
+        CONN_LOG(ERROR, "connect_cb is NULL");
         return ZITI_INVALID_STATE;
     }
 
@@ -582,27 +582,36 @@ static void ziti_write_req(struct ziti_write_req_s *req) {
         CONN_LOG(WARN, "got write req in closed/disconnected sate");
         conn->write_reqs--;
 
-        req->cb(conn, ZITI_CONN_CLOSED, req->ctx);
-        free(req);
-    } else {
         if (req->cb) {
-            req->timeout = calloc(1, sizeof(uv_timer_t));
-            uv_timer_init(conn->ziti_ctx->loop, req->timeout);
-            req->timeout->data = req;
-            uv_timer_start(req->timeout, ziti_write_timeout, conn->timeout, 0);
+            req->cb(conn, ZITI_CONN_CLOSED, req->ctx);
         }
+        free(req);
+        return;
+    }
+    if (req->eof) {
+        conn_set_state(conn, CloseWrite);
+        send_fin_message(conn);
+        conn->write_reqs--;
+        free(req);
+        return;
+    }
 
-        if (conn->encrypted) {
-            uint32_t crypto_len = req->len + crypto_secretstream_xchacha20poly1305_abytes();
-            unsigned char *cipher_text = malloc(crypto_len);
-            crypto_secretstream_xchacha20poly1305_push(&conn->crypt_o, cipher_text, NULL, req->buf, req->len, NULL, 0,
-                                                       0);
-            send_message(conn, ContentTypeData, cipher_text, crypto_len, req);
-            free(cipher_text);
-        }
-        else {
-            send_message(conn, ContentTypeData, req->buf, req->len, req);
-        }
+    if (req->cb) {
+        req->timeout = calloc(1, sizeof(uv_timer_t));
+        uv_timer_init(conn->ziti_ctx->loop, req->timeout);
+        req->timeout->data = req;
+        uv_timer_start(req->timeout, ziti_write_timeout, conn->timeout, 0);
+    }
+
+    if (conn->encrypted) {
+        uint32_t crypto_len = req->len + crypto_secretstream_xchacha20poly1305_abytes();
+        unsigned char *cipher_text = malloc(crypto_len);
+        crypto_secretstream_xchacha20poly1305_push(&conn->crypt_o, cipher_text, NULL, req->buf, req->len, NULL, 0,
+                                                   0);
+        send_message(conn, ContentTypeData, cipher_text, crypto_len, req);
+        free(cipher_text);
+    } else {
+        send_message(conn, ContentTypeData, req->buf, req->len, req);
     }
 }
 
@@ -746,7 +755,9 @@ static void flush_connection (ziti_connection conn) {
 
 static bool flush_to_service(ziti_connection conn) {
 
-    if (conn->state == Connected || conn->state == CloseWrite) {
+    if (conn->channel == NULL) { return false; }
+
+    if (conn->state == Connected) {
         int count = 0;
         while (!TAILQ_EMPTY(&conn->wreqs)) {
             struct ziti_write_req_s *req = TAILQ_FIRST(&conn->wreqs);
@@ -1234,6 +1245,11 @@ int ziti_accept(ziti_connection conn, ziti_conn_cb cb, ziti_data_cb data_cb) {
 }
 
 int ziti_write(ziti_connection conn, uint8_t *data, size_t length, ziti_write_cb write_cb, void *write_ctx) {
+    if (conn->fin_sent) {
+        CONN_LOG(ERROR, "attempted write after ziti_close_write()");
+        return ZITI_INVALID_STATE;
+    }
+
     if (conn->state != Connected && conn->state != Connecting) {
         CONN_LOG(ERROR, "attempted write in invalid state[%s]", ziti_conn_state(conn));
         return ZITI_INVALID_STATE;
@@ -1255,6 +1271,7 @@ int ziti_write(ziti_connection conn, uint8_t *data, size_t length, ziti_write_cb
 }
 
 static int send_fin_message(ziti_connection conn) {
+    CONN_LOG(DEBUG, "sending FIN");
     ziti_channel_t *ch = conn->channel;
     int32_t conn_id = htole32(conn->conn_id);
     int32_t msg_seq = htole32(conn->edge_msg_seq++);
@@ -1292,13 +1309,18 @@ int ziti_close(ziti_connection conn, ziti_close_cb close_cb) {
 
 
 int ziti_close_write(ziti_connection conn) {
-    if (conn->fin_sent || conn->state >= Disconnected) {
+    if (conn->fin_sent || conn->state >= CloseWrite) {
         return ZITI_OK;
     }
-    conn_set_state(conn, CloseWrite);
-    if (conn->write_reqs == 0 && TAILQ_EMPTY(&conn->wreqs)) {
-        return send_fin_message(conn);
-    }
+
+    NEWP(req, struct ziti_write_req_s);
+    req->conn = conn;
+    req->eof = true;
+
+    TAILQ_INSERT_TAIL(&conn->wreqs, req, _next);
+    conn->fin_sent = true;
+
+    flush_connection(conn);
     return ZITI_OK;
 }
 


### PR DESCRIPTION
add CloseWrite(FIN) message to outbound queue.

This change also simplifies usage patterns for simple connections:
```C
void dial_and_send(ziti_context ztx) {
        ziti_connection conn;
        ziti_conn_init(ztx, &conn, NULL);
        ziti_dial(conn, service_name, on_ziti_connect, on_ziti_data);
        const char *msg = "this is a message!";
        ziti_write(conn, msg, strlen(msg), NULL, NULL);
        ziti_close_write(conn);
}

```