### PR TITLE
Ziti bridge throttling

### DIFF
--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -52,7 +52,7 @@ extern int ziti_conn_bridge(ziti_connection conn, uv_stream_t *stream, uv_close_
     br->output = stream;
     br->close_cb = on_close;
     br->data = uv_handle_get_data((const uv_handle_t *) stream);
-    br->input_pool = pool_new(BRIDGE_MSG_SIZE, 16, NULL);
+    br->input_pool = pool_new(BRIDGE_MSG_SIZE, BRIDGE_POOL_SIZE, NULL);
 
     uv_handle_set_data((uv_handle_t *) stream, br);
     ziti_conn_set_data(conn, br);

--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2022.  NetFoundry, Inc.
+// Copyright (c) 2022.  NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
 
 #include "zt_internal.h"
 #include "utils.h"
+
+#define BRIDGE_MSG_SIZE (32 * 1024)
+#define BRIDGE_POOL_SIZE 16
 
 struct fd_bridge_s {
     uv_os_fd_t in;
@@ -32,6 +35,7 @@ struct ziti_bridge_s {
     uv_close_cb close_cb;
     void *data;
     struct fd_bridge_s *fdbr;
+    pool_t *input_pool;
 };
 
 static ssize_t on_ziti_data(ziti_connection conn, const uint8_t *data, ssize_t len);
@@ -48,6 +52,7 @@ extern int ziti_conn_bridge(ziti_connection conn, uv_stream_t *stream, uv_close_
     br->output = stream;
     br->close_cb = on_close;
     br->data = uv_handle_get_data((const uv_handle_t *) stream);
+    br->input_pool = pool_new(BRIDGE_MSG_SIZE, 16, NULL);
 
     uv_handle_set_data((uv_handle_t *) stream, br);
     ziti_conn_set_data(conn, br);
@@ -88,6 +93,7 @@ extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd
     br->conn = conn;
     br->input = calloc(1, sizeof(uv_pipe_t));
     br->output = calloc(1, sizeof(uv_pipe_t));
+    br->input_pool = pool_new(BRIDGE_MSG_SIZE, BRIDGE_POOL_SIZE, NULL);
 
     uv_pipe_init(l, (uv_pipe_t *) br->input, 0);
     uv_pipe_init(l, (uv_pipe_t *) br->output, 0);
@@ -117,6 +123,7 @@ extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd
 
 static void on_ziti_close(ziti_connection conn) {
     struct ziti_bridge_s *br = ziti_conn_data(conn);
+    pool_destroy(br->input_pool);
     free(br);
 }
 
@@ -171,12 +178,13 @@ ssize_t on_ziti_data(ziti_connection conn, const uint8_t *data, ssize_t len) {
 }
 
 void bridge_alloc(uv_handle_t *h, size_t req, uv_buf_t *b) {
-    b->base = malloc(req);
-    b->len = b->base ? req : 0;
+    struct ziti_bridge_s *br = h->data;
+    b->base = pool_alloc_obj(br->input_pool);
+    b->len = pool_obj_size(b->base);
 }
 
 static void on_ziti_write(ziti_connection conn, ssize_t status, void *ctx) {
-    FREE(ctx);
+    pool_return_obj(ctx);
     if (status < ZITI_OK) {
         close_bridge(ziti_conn_data(conn));
     }
@@ -184,15 +192,17 @@ static void on_ziti_write(ziti_connection conn, ssize_t status, void *ctx) {
 
 void on_input(uv_stream_t *s, ssize_t len, const uv_buf_t *b) {
     struct ziti_bridge_s *br = s->data;
-    if (len == 0) {
-        free(b->base);
-    } else if (len > 0) {
+    if (len > 0) {
         ziti_write(br->conn, b->base, len, on_ziti_write, b->base);
-    } else if (len == UV_EOF) {
-        free(b->base);
-        ziti_close_write(br->conn);
     } else {
-        free(b->base);
-        close_bridge(br);
+        pool_return_obj(b->base);
+        ZITI_LOG(WARN, "err = %zd", len);
+        if (len == UV_ENOBUFS) {
+            ZITI_LOG(TRACE, "stalled");
+        } else if (len == UV_EOF) {
+            ziti_close_write(br->conn);
+        } else if (len < 0) {
+            close_bridge(br);
+        }
     }
 }

--- a/library/pool.c
+++ b/library/pool.c
@@ -1,18 +1,16 @@
-/*
-Copyright (c) 2022 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2022.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "pool.h"
 #include "utils.h"
@@ -82,11 +80,15 @@ void *pool_alloc_obj(pool_t *pool) {
 }
 
 size_t pool_obj_size(void *o) {
+    if (o == NULL) { return 0; }
+
     struct pool_obj_s *m = container_of((char *) o, struct pool_obj_s, obj);
     return m->size;
 }
 
 void pool_return_obj(void *o) {
+    if (o == NULL) { return; }
+
     struct pool_obj_s *m = container_of((char *) o, struct pool_obj_s, obj);
     pool_t *pool = m->pool;
     if (pool->clear_func) { pool->clear_func(o); }

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2022.  NetFoundry, Inc.
+// Copyright (c) 2022.  NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -358,10 +358,6 @@ static void ziti_stop_internal(ziti_context ztx, void *data) {
         // logout
         ziti_ctrl_logout(&ztx->controller, logout_cb, ztx);
 
-        ev.type = ZitiContextEvent;
-        ev.event.ctx.ctrl_status = ZITI_DISABLED;
-
-        ziti_send_event(ztx, &ev);
     }
 }
 
@@ -500,6 +496,13 @@ static void free_ztx(uv_handle_t *h) {
     free_ziti_identity_data(ztx->identity_data);
     FREE(ztx->identity_data);
     FREE(ztx->last_update);
+
+    ziti_event_t ev = {0};
+    ev.type = ZitiContextEvent;
+    ev.event.ctx.ctrl_status = ZITI_DISABLED;
+
+    ziti_send_event(ztx, &ev);
+
 
     ZTX_LOG(INFO, "shutdown is complete\n");
     free(ztx);

--- a/library/zitilib.c
+++ b/library/zitilib.c
@@ -186,6 +186,7 @@ static void on_ctx_event(ziti_context ztx, const ziti_event_t *ev) {
                 fail_future(f, err);
             }
             if (err == ZITI_DISABLED) {
+                destroy_future(wrap->services_loaded);
                 free(wrap);
             }
         }
@@ -472,9 +473,10 @@ int Ziti_connect(ziti_socket_t socket, ziti_context ztx, const char *service) {
 }
 
 void Ziti_lib_shutdown(void) {
-    schedule_on_loop(do_shutdown, NULL, true);
+    future_t *f = schedule_on_loop(do_shutdown, NULL, true);
     uv_thread_join(&lib_thread);
     uv_key_delete(&err_key);
+    destroy_future(f);
 #if _WIN32
     closesocket(ziti_sock_server);
     if (!DeleteFile(ziti_sock_name.sun_path)) {


### PR DESCRIPTION
make sure we don't overwhelm the loop if bridge receives too much data
avoid crypto failures (due to fragmentation) on older networks with large message sizes