### PR TITLE
Reset last_uptime timestamp when unable to retreive services

### DIFF
--- a/library/ziti.c
+++ b/library/ziti.c
@@ -982,6 +982,7 @@ static void update_services(ziti_service_array services, const ziti_error *error
             ZTX_LOG(VERBOSE, "api session partially authenticated, waiting for api session state change");
             return;
         } else {
+            FREE(ztx->last_update);
             update_ctrl_status(ztx, ZITI_CONTROLLER_UNAVAILABLE, error->message);
         }
         return;


### PR DESCRIPTION
When the controller becomes available again, services are retrieved, the controller status is reset to OK, and ContextEvent is generated.

closes #404 