### PR TITLE
fix #404 Rest last_uptime timestamp to NULL when unable to retreive services d…

### DIFF
--- a/library/ziti.c
+++ b/library/ziti.c
@@ -982,6 +982,7 @@ static void update_services(ziti_service_array services, const ziti_error *error
             ZTX_LOG(VERBOSE, "api session partially authenticated, waiting for api session state change");
             return;
         } else {
+            FREE(ztx->last_update);
             update_ctrl_status(ztx, ZITI_CONTROLLER_UNAVAILABLE, error->message);
         }
         return;


### PR DESCRIPTION
…ue to ZITI_CONTROLLER_UNAVAILABLE

(cherry picked from commit f280e67e7972bc76e21e2f225b203e31ba5889c7)