### PR TITLE
Improve model map clear

### DIFF
--- a/library/model_collections.c
+++ b/library/model_collections.c
@@ -100,7 +100,7 @@ void *model_map_setl(model_map *m, long key, void *val) {
 }
 
 void *model_map_set(model_map *m, const char *key, void *val) {
-    return model_map_set_key(m, key, strlen(key) + 1, val);
+    return model_map_set_key(m, key, strlen(key), val);
 }
 
 void *model_map_set_key(model_map *m, const void *key, size_t key_len, void *val) {

--- a/library/model_collections.c
+++ b/library/model_collections.c
@@ -24,6 +24,7 @@
 
 struct model_map_entry {
     void *key;
+    char key_pad[2];
     size_t key_len;
     uint32_t key_hash;
     void *value;
@@ -118,11 +119,11 @@ void *model_map_set_key(model_map *m, const void *key, size_t key_len, void *val
         return old_val;
     }
 
-    el = malloc(sizeof(struct model_map_entry));
+    el = calloc(1, sizeof(*el));
     el->value = val;
     el->key_len = key_len;
     if (key_len > sizeof(el->key)) {
-        el->key = malloc(key_len);
+        el->key = calloc(1, key_len + 1);
         memcpy(el->key, key, key_len);
     } else {
         memcpy(&el->key, key, key_len);
@@ -148,7 +149,7 @@ void *model_map_getl(const model_map *m, long key) {
 }
 
 void *model_map_get(const model_map *m, const char *key) {
-    return model_map_get_key(m, key, strlen(key) + 1);
+    return model_map_get_key(m, key, strlen(key));
 }
 
 void *model_map_get_key(const model_map *m, const void *key, size_t key_len) {
@@ -165,7 +166,7 @@ void *model_map_removel(model_map *m, long key) {
 }
 
 void *model_map_remove(model_map *m, const char *key) {
-    return model_map_remove_key(m, key, strlen(key) + 1);
+    return model_map_remove_key(m, key, strlen(key));
 }
 
 void *model_map_remove_key(model_map *m, const void *key, size_t key_len) {
@@ -205,7 +206,6 @@ void model_map_clear(model_map *map, void (*val_free_func)(void *)) {
         if (val_free_func) {
             val_free_func(el->value);
         }
-        FREE(el->value);
         FREE(el);
     }
     FREE(map->impl->table);

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -500,6 +500,7 @@ void model_free(void *obj, type_meta *meta) {
                     fm->meta()->destroyer(str_type ? &el : el);
                 } else {
                     model_free(el, fm->meta());
+                    free(el);
                 }
             }
         } else if (fm->mod == map_mod) {
@@ -649,10 +650,7 @@ static int parse_map(void *mapp, const char *json, jsmntok_t *tok, type_meta *el
         }
         tok += rc;
         tokens_processed += rc;
-        char *k = calloc(1, keylen + 1);
-        strncpy(k, key, keylen);
-        model_map_set(map, k, value);
-        free(k);
+        model_map_set_key(map, key, keylen, value);
     }
     return tokens_processed;
 }
@@ -1210,16 +1208,13 @@ static int _parse_map(model_map *m, const char *json, jsmntok_t *tok) {
         }
         tok += rc;
         tokens_processed += rc;
-        char *k = calloc(1, keylen + 1);
-        strncpy(k, key, keylen);
-        model_map_set(m, k, value);
-        free(k);
+        model_map_set_key(m, key, keylen, value);
     }
     return tokens_processed;
 }
 
 static void _free_map(model_map *m) {
-    model_map_clear(m, NULL);
+    model_map_clear(m, free);
 }
 
 static type_meta bool_META = {

--- a/library/posture.c
+++ b/library/posture.c
@@ -107,6 +107,7 @@ static bool check_running(uv_loop_t *loop, const char *path);
 static void ziti_pr_free_pr_info_members(pr_info *info) {
     FREE(info->id);
     FREE(info->obj);
+    free(info);
 }
 
 
@@ -376,7 +377,7 @@ void ziti_send_posture_data(ziti_context ztx) {
         }
     }
 
-    model_map_clear(&processes, NULL);
+    model_map_clear(&processes, free);
 
     free(domainInfo);
     free(osInfo);
@@ -723,7 +724,7 @@ static void default_pq_mac(ziti_context ztx, const char *id, ziti_pr_mac_cb resp
 
     response_cb(ztx, id, addresses, (int) addr_count);
     free(addresses);
-    model_map_clear(&addrs, NULL);
+    model_map_clear(&addrs, free);
     uv_free_interface_addresses(info, count);
 }
 

--- a/library/zitilib.c
+++ b/library/zitilib.c
@@ -925,7 +925,7 @@ void do_shutdown(void *args, future_t *f, uv_loop_t *l) {
         ztx_wrap_t *w = model_map_it_value(it);
         it = model_map_it_remove(it);
         ziti_shutdown(w->ztx);
-        model_map_clear(&w->intercepts, (void (*)(void *)) free_ziti_intercept_cfg_v1);
+        model_map_clear(&w->intercepts, (void (*)(void *)) free_ziti_intercept_cfg_v1_ptr);
     }
     uv_close((uv_handle_t *) &q_async, NULL);
     uv_loop_close(l);

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -1,18 +1,16 @@
-/*
-Copyright 2019-2020 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2022.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 #define _GNU_SOURCE
 
 #include <uv.h>
@@ -107,6 +105,7 @@ static void shutdown_timer_cb(uv_timer_t *t) {
 
 static void free_listener(struct listener *l) {
     free(l->service_name);
+    free(l);
 }
 
 static void process_stop(uv_loop_t *loop, struct proxy_app_ctx *app_ctx) {

--- a/tests/enum_tests.cpp
+++ b/tests/enum_tests.cpp
@@ -1,18 +1,16 @@
-/*
-Copyright (c) 2021 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2021-2022.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include "catch2/catch.hpp"
@@ -144,4 +142,5 @@ TEST_CASE("parse enum array", "[model]") {
     CHECK_THAT(js, Catch::Contains(R"("states":["Ugly","Bad"])"));
 
     free_FooWithEnumArray(&f1);
+    free(js);
 }

--- a/tests/model_tests.cpp
+++ b/tests/model_tests.cpp
@@ -341,7 +341,7 @@ TEST_CASE("model map test", "[model]") {
     std::cout << j << std::endl;
     free(j);
 
-    model_map_clear(&o.map, nullptr);
+    free_ObjMap(&o);
 }
 
 TEST_CASE("model compare", "[model]") {
@@ -764,10 +764,11 @@ TEST_CASE("lists model", "[model]") {
     CHECK_THAT(fruit->color, Catch::Equals("red"));
     CHECK(model_list_it_next(it) == nullptr);
 
-    const char *json_out = ListsObj_to_json(&lists, 0, nullptr);
+    char *json_out = ListsObj_to_json(&lists, 0, nullptr);
     printf("%s\n", json_out);
 
     free_ListsObj(&lists);
+    free(json_out);
 }
 
 #define DURATION_MODEL(XX, ...) \


### PR DESCRIPTION
model_map_clear() should not automatically de-allocated values (they are owned by the application)

it makes it possible to call model_map_clear() on maps containing numeric or static values