### PR TITLE
same commit but should be signed. see https://github.com/openziti/zit…

### DIFF
--- a/includes/ziti/ziti_log.h
+++ b/includes/ziti/ziti_log.h
@@ -101,11 +101,6 @@ ZITI_FUNC extern const char* ziti_log_level_label();
  */
 ZITI_FUNC void uv_mbed_logger(int level, const char *file, unsigned int line, const char *msg);
 
-// don't use this function. it's a temporary function to support logging on windows.it will be
-// removed in a future release
-ZITI_FUNC void ziti_enable_uv_mbed_logger(int enabled);
-
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
closes #430 previous PR had an unsigned commit somehow :/ 

* use PROCESS_QUERY_LIMITED_INFORMATION instead of PROCESS_QUERY_INFORMATION
* remove unused `ziti_enable_uv_mbed_logger`
* change posture checks to fire 1s after startup instead of 20
* fix some %d -> %lu warnings
* Add a WARN message when the process cannot be enumerated
* change `%FT%T` to `%Y-%m-%dT%H:%M:%S` - this was constantly throwing warnings when observed in gdb and apparently doesn't work on windows with mingw