### PR TITLE
use %.* for full path

### DIFF
--- a/library/posture.c
+++ b/library/posture.c
@@ -938,7 +938,7 @@ static bool check_running(uv_loop_t *loop, const char *path) {
         fullPathSize = sizeof(fullPath);
         QueryFullProcessImageNameA(ph, 0, fullPath, &fullPathSize);
 
-        ZITI_LOG(VERBOSE, "comparing process: %s to: %s", pe32.szExeFile, fullPath);
+        ZITI_LOG(VERBOSE, "comparing process: %s to: %.*s", pe32.szExeFile, fullPathSize, fullPath);
         if (strnicmp(path, fullPath, fullPathSize) == 0) {
             result = true;
             break;


### PR DESCRIPTION
full path is not null terminated. need to pass the size to the log statement