### PR TITLE
Message handling refactor

### DIFF
--- a/inc_internal/message.h
+++ b/inc_internal/message.h
@@ -64,13 +64,23 @@ typedef struct message_s {
     int nhdrs;
 
     size_t msgbuflen;
+    uint8_t *msgbufp;
     uint8_t msgbuf[];
 } message;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 void header_init(header_t *h, uint32_t seq);
+
 void header_to_buffer(header_t *h, uint8_t *buf);
+
 void header_from_buffer(header_t *h, uint8_t *buf);
+
 void message_init(message *m);
+
 void message_free(message *m);
 
 bool message_get_bool_header(message *m, int header_id, bool *v);
@@ -90,5 +100,10 @@ message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]);
 message *message_new(pool_t *pool, uint32_t content, const hdr_t *headers, int nheaders, size_t body_len);
 
 void message_set_seq(message *m, uint32_t seq);
+
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif //ZITI_SDK_MESSAGE_H

--- a/inc_internal/message.h
+++ b/inc_internal/message.h
@@ -1,21 +1,21 @@
-/*
-Copyright 2019-2020 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2023.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef ZITI_SDK_MESSAGE_H
 #define ZITI_SDK_MESSAGE_H
+
+#include "pool.h"
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -62,6 +62,9 @@ typedef struct message_s {
     uint8_t *body;
     hdr_t *hdrs;
     int nhdrs;
+
+    size_t msgbuflen;
+    uint8_t msgbuf[];
 } message;
 
 void header_init(header_t *h, uint32_t seq);
@@ -81,5 +84,11 @@ bool message_get_bytes_header(message *m, int header_id, uint8_t **ptr, size_t *
 uint8_t *write_hdr(const hdr_t *h, uint8_t *buf);
 
 int parse_hdrs(uint8_t *buf, uint32_t len, hdr_t **hp);
+
+message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]);
+
+message *message_new(pool_t *pool, uint32_t content, const hdr_t *headers, int nheaders, size_t body_len);
+
+void message_set_seq(message *m, uint32_t seq);
 
 #endif //ZITI_SDK_MESSAGE_H

--- a/inc_internal/pool.h
+++ b/inc_internal/pool.h
@@ -36,7 +36,7 @@ void *pool_alloc_obj(pool_t *pool);
 
 // allocate object that can be freed by [pool_return_obj]
 // useful when you need alloc before pool is available or need an object larger that normal
-void *alloc_unpooled_obj(size_t size);
+void *alloc_unpooled_obj(size_t size, void (*clear_func)(void *));
 
 void pool_return_obj(void *obj);
 

--- a/inc_internal/pool.h
+++ b/inc_internal/pool.h
@@ -1,18 +1,16 @@
-/*
-Copyright (c) 2022 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2022-2023.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #ifndef ZITI_SDK_POOL_H
@@ -36,7 +34,13 @@ bool pool_has_available(pool_t *p);
 
 void *pool_alloc_obj(pool_t *pool);
 
+// allocate object that can be freed by [pool_return_obj]
+// useful when you need alloc before pool is available or need an object larger that normal
+void *alloc_unpooled_obj(size_t size);
+
 void pool_return_obj(void *obj);
+
+size_t pool_mem_size(pool_t *pool);
 
 size_t pool_obj_size(void *obj);
 

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -118,7 +118,7 @@ struct ziti_write_req_s {
     size_t len;
     bool eof;
 
-    message *message;
+    struct message_s *message;
     ziti_write_cb cb;
     uv_timer_t *timeout;
 

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -113,11 +113,12 @@ typedef struct ziti_channel {
 
 struct ziti_write_req_s {
     struct ziti_conn *conn;
+    struct ziti_channel *ch;
     uint8_t *buf;
     size_t len;
     bool eof;
 
-    uint8_t *payload; // internal buffer
+    message *message;
     ziti_write_cb cb;
     uv_timer_t *timeout;
 
@@ -274,6 +275,8 @@ int ziti_channel_close(ziti_channel_t *ch, int err);
 void ziti_channel_add_receiver(ziti_channel_t *ch, int id, void *receiver, void (*receive_f)(void *, message *, int));
 
 void ziti_channel_rem_receiver(ziti_channel_t *ch, int id);
+
+int ziti_channel_send_message(ziti_channel_t *ch, message *msg, struct ziti_write_req_s *ziti_write);
 
 int ziti_channel_send(ziti_channel_t *ch, uint32_t content, const hdr_t *hdrs, int nhdrs, const uint8_t *body,
                       uint32_t body_len,

--- a/library/connect.c
+++ b/library/connect.c
@@ -411,7 +411,8 @@ static int ziti_connect(struct ziti_ctx *ztx, const ziti_net_session *session, s
     }
 
     if (best_ch) {
-        CONN_LOG(DEBUG, "selected ch[%s] for best latency(%llu ms)", best_ch->name, best_ch->latency);
+        CONN_LOG(DEBUG, "selected ch[%s] for best latency(%llu ms)", best_ch->name,
+                 (unsigned long long) best_ch->latency);
         on_channel_connected(best_ch, conn, ZITI_OK);
     }
 

--- a/library/connect.c
+++ b/library/connect.c
@@ -1332,7 +1332,8 @@ static int send_fin_message(ziti_connection conn) {
             },
     };
     NEWP(wr, struct ziti_write_req_s);
-    return ziti_channel_send(ch, ContentTypeData, headers, 3, NULL, 0, wr);
+    message *m = message_new(NULL, ContentTypeData, headers, 3, 0);
+    return ziti_channel_send_message(ch, m, wr);
 }
 
 int ziti_close(ziti_connection conn, ziti_close_cb close_cb) {
@@ -1390,7 +1391,10 @@ void reject_dial_request(ziti_connection conn, message *req, const char *reason)
             },
     };
 
-    ziti_channel_send(ch, content_type, headers, 3, (const uint8_t *)reason, strlen(reason), NULL);
+    message *m = message_new(NULL, ContentTypeDialFailed, headers, 3, strlen(reason));
+    memcpy(m->body, reason, strlen(reason));
+
+    ziti_channel_send_message(ch, m, NULL);
 }
 
 static void queue_edge_message(struct ziti_conn *conn, message *msg, int code) {

--- a/library/connect.c
+++ b/library/connect.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2022.  NetFoundry Inc.
+// Copyright (c) 2022-2023.  NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -249,9 +249,7 @@ void on_write_completed(struct ziti_conn *conn, struct ziti_write_req_s *req, in
     free(req);
 }
 
-static int
-send_message(struct ziti_conn *conn, uint32_t content, uint8_t *body, uint32_t body_len, struct ziti_write_req_s *wr) {
-    ziti_channel_t *ch = conn->channel;
+static message *create_message(struct ziti_conn *conn, uint32_t content, size_t body_len) {
     int32_t conn_id = htole32(conn->conn_id);
     int32_t msg_seq = htole32(conn->edge_msg_seq++);
     hdr_t headers[] = {
@@ -266,7 +264,12 @@ send_message(struct ziti_conn *conn, uint32_t content, uint8_t *body, uint32_t b
                     .value = (uint8_t *) &msg_seq
             }
     };
-    return ziti_channel_send(ch, content, headers, 2, body, body_len, wr);
+    return message_new(NULL, content, headers, 2, body_len);
+}
+
+static int send_message(struct ziti_conn *conn, message *m, struct ziti_write_req_s *wr) {
+    ziti_channel_t *ch = conn->channel;
+    return ziti_channel_send_message(ch, m, wr);
 }
 
 static void on_channel_connected(ziti_channel_t *ch, void *ctx, int status) {
@@ -619,16 +622,17 @@ static void ziti_write_req(struct ziti_write_req_s *req) {
         uv_timer_start(req->timeout, ziti_write_timeout, conn->timeout, 0);
     }
 
+    size_t total_len = req->len + (conn->encrypted ? crypto_secretstream_xchacha20poly1305_abytes() : 0);
+    message *m = create_message(conn, ContentTypeData, total_len);
+
     if (conn->encrypted) {
-        uint32_t crypto_len = req->len + crypto_secretstream_xchacha20poly1305_abytes();
-        unsigned char *cipher_text = malloc(crypto_len);
-        crypto_secretstream_xchacha20poly1305_push(&conn->crypt_o, cipher_text, NULL, req->buf, req->len, NULL, 0,
-                                                   0);
-        send_message(conn, ContentTypeData, cipher_text, crypto_len, req);
-        free(cipher_text);
-    } else {
-        send_message(conn, ContentTypeData, req->buf, req->len, req);
+        crypto_secretstream_xchacha20poly1305_push(&conn->crypt_o, m->body, NULL, req->buf, req->len, NULL, 0, 0);
     }
+    else {
+        memcpy(m->body, req->buf, req->len);
+    }
+
+    send_message(conn, m, req);
 }
 
 static void ziti_disconnect_cb(ziti_connection conn, ssize_t status, void *ctx) {
@@ -648,11 +652,12 @@ static void ziti_disconnect_async(struct ziti_conn *conn) {
         case Connected:
         case CloseWrite:
         case Timedout: {
+            message *m = create_message(conn, ContentTypeStateClosed, 0);
             NEWP(wr, struct ziti_write_req_s);
             wr->conn = conn;
             wr->cb = ziti_disconnect_cb;
             conn->write_reqs++;
-            send_message(conn, ContentTypeStateClosed, NULL, 0, wr);
+            send_message(conn, m, wr);
             break;
         }
 
@@ -730,16 +735,14 @@ int establish_crypto(ziti_connection conn, message *msg) {
 
 static int send_crypto_header(ziti_connection conn) {
     if (conn->encrypted) {
+        size_t crypto_header_len = crypto_secretstream_xchacha20poly1305_headerbytes();
+        message *m = create_message(conn, ContentTypeData, crypto_header_len);
+        crypto_secretstream_xchacha20poly1305_init_push(&conn->crypt_o, m->body, conn->tx);
         NEWP(wr, struct ziti_write_req_s);
         wr->conn = conn;
-        uint8_t *header = calloc(1, crypto_secretstream_xchacha20poly1305_headerbytes());
-        wr->buf = header;
         wr->cb = crypto_wr_cb;
-
-        crypto_secretstream_xchacha20poly1305_init_push(&conn->crypt_o, header, conn->tx);
         conn->write_reqs++;
-        send_message(conn, ContentTypeData, header, crypto_secretstream_xchacha20poly1305_headerbytes(), wr);
-        free(header);
+        send_message(conn, m, wr);
         memset(conn->tx, 0, crypto_secretstream_xchacha20poly1305_KEYBYTES);
         FREE(conn->tx);
     }

--- a/library/message.c
+++ b/library/message.c
@@ -189,7 +189,8 @@ message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]) {
 message *message_new(pool_t *pool, uint32_t content, const hdr_t *hdrs, int nhdrs, size_t body_len) {
     uint32_t hdrs_len = 0;
     for (int i = 0; i < nhdrs; i++) {
-        hdrs_len += sizeof(uint32_t) * 2 + hdrs[i].length; // header id + val(length) + length
+        // wire format length: header id + val(length) + length
+        hdrs_len += sizeof(hdrs[i].header_id) + sizeof(hdrs[i].length) + hdrs[i].length;
     }
 
     size_t msgbuflen = HEADER_SIZE + hdrs_len + body_len;

--- a/library/message.c
+++ b/library/message.c
@@ -166,7 +166,7 @@ message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]) {
     header_t h;
     header_from_buffer(&h, buf);
 
-    size_t msgbuflen = HEADER_SIZE + h.headers_len + h.content_len;
+    size_t msgbuflen = HEADER_SIZE + h.headers_len + h.body_len;
     message *m = pool ? pool_alloc_obj(pool) : alloc_unpooled_obj(sizeof(message) + msgbuflen,
                                                                   (void (*)(void *)) message_free);
 
@@ -182,7 +182,7 @@ message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]) {
 
     memcpy(&m->header, &h, sizeof(h));
     m->headers = m->msgbufp + HEADER_SIZE;
-    m->content = m->headers + h.headers_len;
+    m->body = m->headers + h.headers_len;
     return m;
 }
 
@@ -203,9 +203,9 @@ message *message_new(pool_t *pool, uint32_t content, const hdr_t *hdrs, int nhdr
     }
 
     memcpy(&m->header, &EMPTY_HEADER, sizeof(EMPTY_HEADER));
-    m->header.ct = content;
+    m->header.content = content;
     m->header.headers_len = hdrs_len;
-    m->header.content_len = body_len;
+    m->header.body_len = body_len;
     m->msgbuflen = msgbuflen;
 
     if (msgsize > pool_obj_size(m)) {
@@ -220,7 +220,7 @@ message *message_new(pool_t *pool, uint32_t content, const hdr_t *hdrs, int nhdr
 
     // write headers
     m->headers = m->msgbufp + HEADER_SIZE;
-    m->content = m->headers + m->header.headers_len;
+    m->body = m->headers + m->header.headers_len;
     uint8_t *p = m->headers;
     for (int i = 0; i < nhdrs; i++) {
         p = write_hdr(&hdrs[i], p);

--- a/library/message.c
+++ b/library/message.c
@@ -1,18 +1,16 @@
-/*
-Copyright 2019-2020 NetFoundry, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright (c) 2023.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "message.h"
 #include <stdlib.h>
@@ -62,9 +60,11 @@ void header_init(header_t *h, uint32_t seq) {
 void message_init(message* m) {
     memset(m, 0, sizeof(message));
 }
+
 void message_free(message* m) {
-    FREE(m->headers);
-    FREE(m->hdrs);
+    if (m != NULL) {
+        FREE(m->hdrs);
+    }
 }
 
 uint8_t *write_hdr(const hdr_t *h, uint8_t *buf) {
@@ -157,4 +157,64 @@ bool message_get_bytes_header(message *m, int header_id, uint8_t **v, size_t *le
         return true;
     }
     return false;
+}
+
+message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]) {
+    message *m;
+    header_t h;
+    header_from_buffer(&h, buf);
+    size_t msgbuflen = HEADER_SIZE + h.headers_len + h.body_len;
+    size_t msgsize = sizeof(message) + msgbuflen;
+    if (msgsize > pool_mem_size(pool)) {
+        m = alloc_unpooled_obj(msgsize);
+    }
+    else {
+        m = pool_alloc_obj(pool);
+    }
+    memcpy(&m->header, &h, sizeof(h));
+    m->headers = m->msgbuf + h.headers_len;
+    m->body = m->headers + h.headers_len;
+    m->msgbuflen = m->msgbuflen;
+    return m;
+}
+
+message *message_new(pool_t *pool, uint32_t content, const hdr_t *hdrs, int nhdrs, size_t body_len) {
+    uint32_t hdrs_len = 0;
+    for (int i = 0; i < nhdrs; i++) {
+        hdrs_len += sizeof(uint32_t) * 2 + hdrs[i].length; // header id + val(length) + length
+    }
+
+    size_t msgbuflen = HEADER_SIZE + hdrs_len + body_len;
+    size_t msgsize = sizeof(message) + msgbuflen;
+    message *m;
+    if (msgsize > pool_mem_size(pool)) {
+        m = alloc_unpooled_obj(msgsize);
+    }
+    else {
+        m = pool_alloc_obj(pool);
+    }
+
+    memcpy(&m->header, &EMPTY_HEADER, sizeof(EMPTY_HEADER));
+    m->header.content = content;
+    m->header.headers_len = hdrs_len;
+    m->header.body_len = body_len;
+    m->msgbuflen = msgbuflen;
+
+    // write header
+    header_to_buffer(&m->header, m->msgbuf);
+
+    // write headers
+    m->headers = m->msgbuf + HEADER_SIZE;
+    m->body = m->headers + m->header.headers_len;
+    uint8_t *p = m->headers;
+    for (int i = 0; i < nhdrs; i++) {
+        p = write_hdr(&hdrs[i], p);
+    }
+
+    return m;
+}
+
+void message_set_seq(message *m, uint32_t seq) {
+    m->header.seq = seq;
+    header_to_buffer(&m->header, m->msgbuf);
 }

--- a/library/pool.c
+++ b/library/pool.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2022.  NetFoundry Inc.
+// Copyright (c) 2022-2023.  NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,23 +56,38 @@ void pool_destroy(pool_t *pool) {
         free(m);
     }
 
-    if (pool->out == 0)
+    if (pool->out == 0) {
         free(pool);
+    }
 }
 
 bool pool_has_available(pool_t *pool) {
+    assert(pool);
     assert(!pool->is_closed);
     return !LIST_EMPTY(&pool->pool) || pool->capacity > pool->out;
 }
 
+void *alloc_unpooled_obj(size_t size) {
+    struct pool_obj_s *obj = calloc(1, sizeof(struct pool_obj_s) + size);
+    if (obj) {
+        obj->size = size;
+        obj->pool = NULL;
+    }
+    return obj->obj;
+}
+
 void *pool_alloc_obj(pool_t *pool) {
+    if (pool == NULL) {
+        return NULL;
+    }
     assert(!pool->is_closed);
 
     struct pool_obj_s *member = NULL;
     if (!LIST_EMPTY(&pool->pool)) {
         member = LIST_FIRST(&pool->pool);
         LIST_REMOVE(member, _next);
-    } else if (pool->capacity > pool->out) {
+    }
+    else if (pool->capacity > pool->out) {
         member = calloc(1, sizeof(struct pool_obj_s) + pool->memsize);
         member->size = pool->memsize;
         member->pool = pool;
@@ -84,6 +99,10 @@ void *pool_alloc_obj(pool_t *pool) {
     }
 
     return NULL;
+}
+
+size_t pool_mem_size(pool_t *pool) {
+    return pool ? pool->memsize : 0;
 }
 
 size_t pool_obj_size(void *o) {
@@ -98,6 +117,11 @@ void pool_return_obj(void *o) {
 
     struct pool_obj_s *m = container_of((char *) o, struct pool_obj_s, obj);
     pool_t *pool = m->pool;
+    if (pool == NULL) {
+        free(m);
+        return;
+    }
+
     if (pool->clear_func) { pool->clear_func(o); }
     memset(o, 0, m->size);
     pool->out--;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(all_tests
         pool_tests.cpp
         catch2_includes.hpp
         ziti_src_tests.cpp
-        )
+        message_tests.cpp)
 
 if (WIN32)
     set_property(TARGET all_tests PROPERTY CXX_STANDARD 20)

--- a/tests/message_tests.cpp
+++ b/tests/message_tests.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2023.  NetFoundry Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "catch2_includes.hpp"
+
+#include "message.h"
+#include "edge_protocol.h"
+
+TEST_CASE("simple", "[model]") {
+    auto p = pool_new(sizeof(message) + 200, 3, (void (*)(void *)) message_free);
+
+    hdr_t headers[] = {
+            {
+                    .header_id = 1,
+                    .length = 3,
+                    .value = (uint8_t *) "foo"
+            },
+            {
+                    .header_id = 2,
+                    .length = 3,
+                    .value = (uint8_t *) "bar"
+            },
+    };
+    auto content1 = "this is a message";
+    auto m1 = message_new(p, ContentTypeData, headers, 2, strlen(content1));
+    strncpy(reinterpret_cast<char *>(m1->body), content1, strlen(content1));
+    message_set_seq(m1, 3333);
+
+    auto m2 = message_new_from_header(p, m1->msgbufp);
+    CHECK(m2->header.seq == 3333);
+    CHECK(m2->msgbuflen == m1->msgbuflen);
+    memcpy(m2->msgbufp, m1->msgbufp, m1->msgbuflen);
+    m2->nhdrs = parse_hdrs(m2->headers, m2->header.headers_len, &m2->hdrs);
+    CHECK(m2->nhdrs == 2);
+
+    uint8_t *hdrval;
+    size_t hdrlen;
+    CHECK(message_get_bytes_header(m2, 1, &hdrval, &hdrlen));
+    CHECK(strncmp((const char *) headers[0].value, (const char *) hdrval, hdrlen) == 0);
+
+    CHECK(message_get_bytes_header(m2, 2, &hdrval, &hdrlen));
+    CHECK(strncmp((const char *) headers[1].value, (const char *) hdrval, hdrlen) == 0);
+    CHECK(strncmp(content1, (const char *) m2->body, m2->header.body_len) == 0);
+
+    pool_return_obj(m1);
+    pool_return_obj(m2);
+
+    pool_destroy(p);
+}
+
+TEST_CASE("large", "[model]") {
+    auto p = pool_new(sizeof(message) + 20, 3, (void (*)(void *)) message_free);
+
+    hdr_t headers[] = {
+            {
+                    .header_id = 1,
+                    .length = 3,
+                    .value = (uint8_t *) "foo"
+            },
+            {
+                    .header_id = 2,
+                    .length = 3,
+                    .value = (uint8_t *) "bar"
+            },
+    };
+    auto content1 = "this is a very long message, it won't fint into the pooled message structure";
+    auto m1 = message_new(p, ContentTypeData, headers, 2, strlen(content1));
+    strncpy(reinterpret_cast<char *>(m1->body), content1, strlen(content1));
+    message_set_seq(m1, 3333);
+
+    auto m2 = message_new_from_header(p, m1->msgbufp);
+    CHECK(m2->header.seq == 3333);
+    CHECK(m2->msgbuflen == m1->msgbuflen);
+    memcpy(m2->msgbufp, m1->msgbufp, m1->msgbuflen);
+    m2->nhdrs = parse_hdrs(m2->headers, m2->header.headers_len, &m2->hdrs);
+    CHECK(m2->nhdrs == 2);
+
+    uint8_t *hdrval;
+    size_t hdrlen;
+    CHECK(message_get_bytes_header(m2, 1, &hdrval, &hdrlen));
+    CHECK(strncmp((const char *) headers[0].value, (const char *) hdrval, hdrlen) == 0);
+
+    CHECK(message_get_bytes_header(m2, 2, &hdrval, &hdrlen));
+    CHECK(strncmp((const char *) headers[1].value, (const char *) hdrval, hdrlen) == 0);
+
+    pool_return_obj(m1);
+    pool_return_obj(m2);
+
+    pool_destroy(p);
+}
+
+TEST_CASE("large unpooled", "[model]") {
+    auto p = pool_new(sizeof(message) + 20, 3, (void (*)(void *)) message_free);
+
+    hdr_t headers[] = {
+            {
+                    .header_id = 1,
+                    .length = 3,
+                    .value = (uint8_t *) "foo"
+            },
+            {
+                    .header_id = 2,
+                    .length = 3,
+                    .value = (uint8_t *) "bar"
+            },
+    };
+    auto content1 = "this is a very long message, it won't fint into the pooled message structure";
+    auto m1 = message_new(p, ContentTypeData, headers, 2, strlen(content1));
+    strncpy(reinterpret_cast<char *>(m1->body), content1, strlen(content1));
+    message_set_seq(m1, 3333);
+
+    auto m2 = message_new_from_header(nullptr, m1->msgbufp);
+    CHECK(m2->header.seq == 3333);
+    CHECK(m2->msgbuflen == m1->msgbuflen);
+    memcpy(m2->msgbufp, m1->msgbufp, m1->msgbuflen);
+    m2->nhdrs = parse_hdrs(m2->headers, m2->header.headers_len, &m2->hdrs);
+    CHECK(m2->nhdrs == 2);
+
+    uint8_t *hdrval;
+    size_t hdrlen;
+    CHECK(message_get_bytes_header(m2, 1, &hdrval, &hdrlen));
+    CHECK(strncmp((const char *) headers[0].value, (const char *) hdrval, hdrlen) == 0);
+
+    CHECK(message_get_bytes_header(m2, 2, &hdrval, &hdrlen));
+    CHECK(strncmp((const char *) headers[1].value, (const char *) hdrval, hdrlen) == 0);
+
+    pool_return_obj(m1);
+    pool_return_obj(m2);
+
+    pool_destroy(p);
+}


### PR DESCRIPTION
this change improves memory management:
- reduces number of per message memory allocation from 3 to 1 in most cases
- allows future improvement by using memory pool for messages going up to fabric