### PR TITLE
ziti bridge: use uv_try_write(send) to push data from ziti to uv output

### DIFF
--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -225,7 +225,7 @@ static void on_bridge_close(uv_handle_t *handle) {
 }
 
 void on_ziti_connect(ziti_connection conn, int status) {
-    uv_stream_t *clt = ziti_conn_data(conn);
+    uv_handle_t *clt = ziti_conn_data(conn);
 
     if (status == ZITI_OK) {
         ziti_conn_bridge(conn, clt, on_bridge_close);


### PR DESCRIPTION
- if data cannot be written we better keep it buffered in ziti
- remove an extra copy of data
- no need to keep track of pending write/send requests