### PR TITLE
provide ER name and address on connect failure

### DIFF
--- a/library/channel.c
+++ b/library/channel.c
@@ -850,7 +850,7 @@ static void on_channel_connect_internal(uv_connect_t *req, int status) {
             reconnect_channel(ch, false);
         }
     } else {
-        CH_LOG(ERROR, "failed to connect [%d/%s]", status, uv_strerror(status));
+        CH_LOG(ERROR, "failed to connect to ER[%s@%s:%d] [%d/%s]", ch->name, ch->host, ch->port, status, uv_strerror(status));
 
         while (!LIST_EMPTY(&ch->conn_reqs)) {
             struct ch_conn_req *r = LIST_FIRST(&ch->conn_reqs);


### PR DESCRIPTION
sample output
```
(59823)[       20.239]   ERROR ziti-sdk:channel.c:853 on_channel_connect_internal() ch[0] failed to connect to ER[Zeds Fabric Router Azure@tls://dd9dc8aa-b8c6-4423-b4d2-3d80b15f5f49.production.netfoundry.io:443] [-125/operation canceled]
```