### PR TITLE
Ziti_resolve faults if host is NULL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ else()
     string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
 endif()
 
+include(cmake/check-headers.cmake)
+
 add_subdirectory(library)
 
 if (PROJECT_IS_TOP_LEVEL)

--- a/cmake/check-headers.cmake
+++ b/cmake/check-headers.cmake
@@ -1,0 +1,5 @@
+include(CheckStructHasMember)
+
+CHECK_STRUCT_HAS_MEMBER("struct sockaddr_in" "sin_len" "sys/types.h;netinet/in.h" HAVE_SOCKADDR_IN_SIN_LEN)
+ 
+CHECK_STRUCT_HAS_MEMBER("struct sockaddr_in6" "sin6_len" "sys/types.h;netinet/in.h" HAVE_SOCKADDR_IN6_SIN6_LEN)

--- a/library/zitilib.c
+++ b/library/zitilib.c
@@ -1287,12 +1287,18 @@ int Ziti_resolve(const char *host, const char *port, const struct addrinfo *hint
             case AF_INET:
             case AF_UNSPEC:
                 salen = sizeof addr->in4;
+#ifdef HAVE_SOCKADDR_IN_SIN_LEN
+                addr->in4.sin_len = salen;
+#endif /* HAVE_SOCKADDR_IN_SIN_LEN */
                 addr->in4.sin_family = AF_INET;
                 addr->in4.sin_port = htons(portnum);
                 addr->in4.sin_addr.s_addr = INADDR_LOOPBACK;
                 break;
             case AF_INET6:
                 salen = sizeof addr->in6;
+#ifdef HAVE_SOCKADDR_IN6_SIN6_LEN
+                addr->in6.sin6_len = salen;
+#endif /* HAVE_SOCKADDR_IN6_SIN6_LEN */
                 addr->in6.sin6_family = AF_INET6;
                 addr->in6.sin6_port = htons(portnum);
                 addr->in6.sin6_addr = in6addr_loopback;
@@ -1362,6 +1368,9 @@ int Ziti_resolve(const char *host, const char *port, const struct addrinfo *hint
     if (err != 0)
         goto error;
 
+#ifdef HAVE_SOCKADDR_IN_SIN_LEN
+    addr->in4.sin_len = sizeof addr->in4;
+#endif /* HAVE_SOCKADDR_IN_SIN_LEN */
     addr->in4.sin_family = AF_INET;
     addr->in4.sin_port = htons(portnum);
     addr->in4.sin_addr.s_addr = (in_addr_t)(uintptr_t)f->result;


### PR DESCRIPTION
The fix addresses a `Ziti_resolve` defects that  triggers segfault. The `getaddrinfo` interface contract permits `host == NULL`, but `Ziti_resolve` assumes `host != NULL`. Additionally, `Ziti_resolve` leaks `res` and `addr` if error is signaled.

 
```
ubuntu@jammy:~$ zitify -i tomc.json -b 9999:zitify-nc-service nc -l 9999
b = 9999:zitify-nc-service
bindings = 
/usr/local/bin/zitify: line 101: 457642 Segmentation fault      (core dumped) LD_PRELOAD="$preload_lib" ZITI_BINDINGS="${bindings}" "$@"
ubuntu@jammy:~$ zitify -i tomc.json -b 9999:zitify-nc-service gdb nc
b = 9999:zitify-nc-service
bindings = 
GNU gdb (Ubuntu 12.1-0ubuntu1~22.04) 12.1
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from nc...
(No debugging symbols found in nc)
(gdb) r -l 9999
Starting program: /usr/bin/nc -l 9999
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff73ff640 (LWP 457774)]
[New Thread 0x7ffff6bfe640 (LWP 457775)]
[New Thread 0x7ffff63fd640 (LWP 457776)]
[New Thread 0x7ffff5bfc640 (LWP 457777)]
[New Thread 0x7ffff53fb640 (LWP 457778)]

Thread 1 "nc" received signal SIGSEGV, Segmentation fault.
__strchr_avx2 () at ../sysdeps/x86_64/multiarch/strchr-avx2.S:65
65	../sysdeps/x86_64/multiarch/strchr-avx2.S: No such file or directory.
(gdb) bt
#0  __strchr_avx2 () at ../sysdeps/x86_64/multiarch/strchr-avx2.S:65
#1  0x00007ffff7c94e5d in uv_ip6_addr (ip=0x0, port=9999, addr=0x5555555f16a0)
    at /home/tomc/Projects/ZT/vcpkg/buildtrees/libuv/src/1ba00a27b8-94fcdf9fd7.clean/src/uv-common.c:244
#2  0x00007ffff7c4431e in Ziti_resolve (host=0x0, port=0x7fffffffe239 "9999", hints=0x7fffffffcb70, addrlist=0x7fffffffcb10)
    at /home/tomc/Projects/ZT/zitify/build/_deps/ziti-src/library/zitilib.c:1257
#3  0x00007ffff7c3d1be in getaddrinfo(const char * __restrict__, const char * __restrict__, const addrinfo * __restrict__, addrinfo ** __restrict__) (name=0x0, service=0x7fffffffe239 "9999", hints=0x7fffffffcb70, pai=0x7fffffffcb10) at /home/tomc/Projects/ZT/zitify/src/zitify.cpp:113
#4  0x0000555555557c13 in ?? ()
#5  0x00007ffff7829d90 in __libc_start_call_main (main=main@entry=0x5555555567e0, argc=argc@entry=3, argv=argv@entry=0x7fffffffdea8)
    at ../sysdeps/nptl/libc_start_call_main.h:58
#6  0x00007ffff7829e40 in __libc_start_main_impl (main=0x5555555567e0, argc=3, argv=0x7fffffffdea8, init=<optimized out>, fini=<optimized out>, 
    rtld_fini=<optimized out>, stack_end=0x7fffffffde98) at ../csu/libc-start.c:392
#7  0x0000555555558af5 in ?? ()
(gdb) quit
A debugging session is active.

	Inferior 1 [process 457764] will be killed.

Quit anyway? (y or n) y
```

