### PR TITLE
Match of cidr /0 fails as a result of left shift undefined behavior.

### DIFF
--- a/library/internal_model.c
+++ b/library/internal_model.c
@@ -281,7 +281,7 @@ int ziti_address_match(const ziti_address *addr, const ziti_address *range) {
         if (addr->addr.cidr.bits < range->addr.cidr.bits) { return -1; }
 
         if (addr->addr.cidr.af == AF_INET) {
-            in_addr_t mask = htonl((-1) << (32 - range->addr.cidr.bits));
+            in_addr_t mask = range->addr.cidr.bits == 0 ? 0 : htonl(-1UL << (32 - range->addr.cidr.bits));
             return (((struct in_addr *) &addr->addr.cidr.ip)->s_addr & mask) == (((struct in_addr *) &range->addr.cidr.ip)->s_addr & mask) ?
                    (int) addr->addr.cidr.bits - (int) range->addr.cidr.bits : -1;
         } else if (addr->addr.cidr.af == AF_INET6) {


### PR DESCRIPTION
When the prefix length is 0, the expression -1UL << 32 is evaluated. A shift of 32 or more is undefined on a 32-bit integer, meaning the behavior is unpredictable (not prescribed by the standard) and is likely compiler and hardware dependent. See C17 SS 6.5.7 for clarity.  On amd64, the result of the shift expression is -1UL. This is reason that matches to ```0.0.0.0/0``` given the wrong. For example, the program

```c
int
main(void)
{
    ziti_address a1, a2, a3, a4;

    assert(parse_ziti_address_str(&a1, "0.0.0.0/0") >= 0);
    assert(parse_ziti_address_str(&a2, "0.0.0.0/1") >= 0);
    assert(parse_ziti_address_str(&a3, "100.64.0.1/32") >= 0);
    
    int rc = ziti_address_match(&a3, &a1);
    printf("ziti_address_match(a3,a1) = %d, should be 32\n", rc);

    rc = ziti_address_match(&a3, &a2);
    printf("ziti_address_match(a3,a2) = %d, should be 31\n", rc);

    return 0;
}
```
prints
```
ziti_address_match(a3,a1) = -1, should be 32
ziti_address_match(a3,a2) = 31, should be 31
```
which is unexpected, as all addresses should match ```0.0.0.0/0```.

Note that the ```(32 - range->addr.cidr.bits)``` [line](https://github.com/openziti/ziti-sdk-c/blob/d2b4402abd1390b6be7554341c4a692156b8543c/library/internal_model.c#L284) may become negative if ```addr.cidr.bits > 32```, another undefined behavior.  This maybe possible as ```parse_ziti_address_str``` does not validate the prefix length. PR #526 addresses this concern.