### PR TITLE
avoid concurrent api-session requests

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -252,6 +252,7 @@ struct ziti_ctx {
     bool enabled;
     int ctrl_status;
 
+    bool active_session_request;
     ziti_api_session *api_session;
     uv_timeval64_t api_session_expires_at;
     ziti_api_session_state api_session_state;

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -129,20 +129,15 @@ static int parse_getopt(const char *q, const char *opt, char *out, size_t maxout
     return ZITI_INVALID_CONFIG;
 }
 
-int load_tls(ziti_config *cfg, tls_context **ctx) {
+static int init_tls_from_config(tls_context *tls, ziti_config *cfg) {
     PREP(ziti);
 
-    // load ca from ziti config if present
-    const char *ca;
-    size_t ca_len = parse_ref(cfg->id.ca, &ca);
-    tls_context *tls = default_tls_context(ca, ca_len);
     tlsuv_private_key_t pk;
 
-    if (cfg->id.key == NULL) {
-        TRY(ziti, ("TLS key should be provided", ZITI_INVALID_CONFIG));
-    }
+    TRY(ziti, cfg->id.key == NULL ? ZITI_INVALID_CONFIG : ZITI_OK);
 
     TRY(ziti, load_key_internal(tls, &pk, cfg->id.key));
+
     tls_cert c = NULL;
     if (cfg->id.cert) {
         const char *cert;
@@ -154,9 +149,25 @@ int load_tls(ziti_config *cfg, tls_context **ctx) {
     CATCH(ziti) {
         return ERR(ziti);
     }
-
-    *ctx = tls;
     return ZITI_OK;
+}
+
+int load_tls(ziti_config *cfg, tls_context **ctx) {
+
+    // load ca from ziti config if present
+    const char *ca;
+    size_t ca_len = parse_ref(cfg->id.ca, &ca);
+    tls_context *tls = default_tls_context(ca, ca_len);
+
+    int rc = init_tls_from_config(tls, cfg);
+
+    if (rc == ZITI_OK) {
+        *ctx = tls;
+    } else {
+        tls->free_ctx(tls);
+        *ctx = NULL;
+    }
+    return rc;
 }
 
 int ziti_set_client_cert(ziti_context ztx, const char *cert_buf, size_t cert_len, const char *key_buf, size_t key_len) {
@@ -263,6 +274,17 @@ void ziti_set_unauthenticated(ziti_context ztx) {
     free_ziti_api_session(ztx->api_session);
     FREE(ztx->api_session);
     ztx->api_session_state = ZitiApiSessionStateUnauthenticated;
+
+    if (ztx->sessionKey) {
+        init_tls_from_config(ztx->tlsCtx, &ztx->config);
+        if (ztx->sessonCert) {
+            ztx->tlsCtx->free_cert(&ztx->sessonCert);
+            ztx->sessonCert = NULL;
+        }
+
+        ztx->sessionKey->free(ztx->sessionKey);
+        ztx->sessionKey = NULL;
+    }
 
     ziti_ctrl_clear_api_session(&ztx->controller);
 }

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1470,6 +1470,8 @@ static void session_post_auth_query_cb(ziti_context ztx, int status, void *ctx) 
             ziti_ctrl_current_api_session(&ztx->controller, update_session_data, ztx);
         }
 
+        // disable this until we figure out expiration and rolling requirements
+#if ENABLE_SESSION_CERTIFICATES
         if (ztx->sessionKey == NULL) {
             char common_name[128];
             snprintf(common_name, sizeof(common_name), "%s-%u-%" PRIu64,
@@ -1487,6 +1489,7 @@ static void session_post_auth_query_cb(ziti_context ztx, int status, void *ctx) 
 
             ziti_ctrl_create_api_certificate(&ztx->controller, ztx->sessionCsr, on_create_cert, ztx);
         }
+#endif
 
 
         ziti_services_refresh(ztx, true);

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -889,7 +889,7 @@ static void api_session_refresh(uv_timer_t *t) {
             struct ziti_init_req *req = calloc(1, sizeof(struct ziti_init_req));
             req->ztx = ztx;
             if (ztx->active_session_request) {
-                ZTX_LOG(WARN, "active refresh request: skipping");
+                ZTX_LOG(DEBUG, "active refresh request: skipping");
             } else {
                 ztx->active_session_request = true;
                 ZTX_LOG(DEBUG, "api_session_refresh refreshing api session by querying controller");


### PR DESCRIPTION
do not use session certs for now