### PR TITLE
Ziti dump connection stats

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,216 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,7 +1,7 @@
 
 function(get_version version_file version_var branch_var commit_var)
     execute_process(
-            COMMAND git describe --tags HEAD
+            COMMAND git describe --tags --match=[0-9]* HEAD
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
             OUTPUT_VARIABLE GIT_INFO
             OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/inc_internal/edge_protocol.h
+++ b/inc_internal/edge_protocol.h
@@ -80,6 +80,10 @@ enum header_id {
     TraceSourceRequestIdHeader = 1019,
     TraceError = 1020,
     ListenerId = 1021,
+    ConnTypeHeader = 1022,
+    SupportsInspectHeader = 1023,
+    SupportsBindSuccessHeader = 1024,
+    ConnectionMarkerHeader = 1025,
 };
 
 enum crypto_method {

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -39,6 +39,9 @@
 #define UUID_STR_LEN 37
 #endif
 
+#define MARKER_BIN_LEN 6
+#define MARKER_CHAR_LEN sodium_base64_ENCODED_LEN(MARKER_BIN_LEN, sodium_base64_VARIANT_URLSAFE_NO_PADDING)
+
 #define ZTX_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "ztx[%u] " fmt, ztx->id, ##__VA_ARGS__)
 
 extern const char *APP_ID;
@@ -191,8 +194,7 @@ struct ziti_conn {
             struct key_pair key_pair;
             struct ziti_conn_req *conn_req;
 
-            // 8-byte string
-            char marker[sodium_base64_ENCODED_LEN(6, sodium_base64_VARIANT_URLSAFE_NO_PADDING)];
+            char marker[MARKER_CHAR_LEN];
 
             uint32_t edge_msg_seq;
 

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -191,6 +191,9 @@ struct ziti_conn {
             struct key_pair key_pair;
             struct ziti_conn_req *conn_req;
 
+            // 8-byte string
+            char marker[sodium_base64_ENCODED_LEN(6, sodium_base64_VARIANT_URLSAFE_NO_PADDING)];
+
             uint32_t edge_msg_seq;
 
             ziti_channel_t *channel;
@@ -220,6 +223,8 @@ struct ziti_conn {
             uint64_t start;
             uint64_t connect_time;
             uint64_t last_activity;
+            uint64_t sent;
+            uint64_t received;
         };
     };
 
@@ -396,6 +401,8 @@ void reject_dial_request(uint32_t conn_id, ziti_channel_t *ch, int32_t req_id, c
 const ziti_env_info* get_env_info();
 
 extern uv_timer_t *new_ztx_timer(ziti_context ztx);
+
+int conn_bridge_info(ziti_connection conn, char *buf, size_t buflen);
 
 #ifdef __cplusplus
 }

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -307,6 +307,7 @@ struct ziti_ctx {
     int ziti_timeout;
 
     /* context wide metrics */
+    uint64_t start;
     rate_t up_rate;
     rate_t down_rate;
 

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -1,9 +1,9 @@
-// Copyright (c) 2022-2023.  NetFoundry Inc.
+// Copyright (c) 2022-2023. NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
 //
+// You may obtain a copy of the License at
 // https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -214,6 +214,12 @@ struct ziti_conn {
 
             crypto_secretstream_xchacha20poly1305_state crypt_o;
             crypto_secretstream_xchacha20poly1305_state crypt_i;
+
+            // stats
+            bool bridged;
+            uint64_t start;
+            uint64_t connect_time;
+            uint64_t last_activity;
         };
     };
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -1,9 +1,9 @@
-// Copyright (c) 2023.  NetFoundry Inc.
+// Copyright (c) 2023. NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
 //
+// You may obtain a copy of the License at
 // https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -311,6 +311,7 @@ static void process_dial(struct binding_s *b, message *msg) {
     ziti_connection client;
     ziti_conn_init(conn->ziti_ctx, &client, NULL);
     init_transport_conn(client);
+    client->start = uv_now(conn->ziti_ctx->loop);
 
     if (peer_key_sent) {
         client->encrypted = true;

--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -1,9 +1,9 @@
-// Copyright (c) 2022-2023.  NetFoundry Inc.
+// Copyright (c) 2022-2023. NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
 //
+// You may obtain a copy of the License at
 // https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -82,6 +82,7 @@ extern int ziti_conn_bridge(ziti_connection conn, uv_handle_t *handle, uv_close_
 
     uv_handle_set_data(handle, br);
     ziti_conn_set_data(conn, br);
+    conn->bridged = true;
 
     ziti_conn_set_data_cb(conn, on_ziti_data);
     int rc = (br->input->type == UV_UDP) ?
@@ -175,6 +176,7 @@ extern int ziti_conn_bridge_fds(ziti_connection conn, uv_os_fd_t input, uv_os_fd
 
     uv_handle_set_data(br->input, br);
     ziti_conn_set_data(conn, br);
+    conn->bridged = true;
 
     ziti_conn_set_data_cb(conn, on_ziti_data);
     int rc = uv_read_start((uv_stream_t *) br->input, bridge_alloc, on_input);

--- a/library/connect.c
+++ b/library/connect.c
@@ -519,7 +519,7 @@ static int do_ziti_dial(ziti_connection conn, const char *service, ziti_dial_opt
         return ZITI_INVALID_STATE;
     }
 
-    char marker[6];
+    char marker[MARKER_BIN_LEN];
     uv_random(NULL, NULL, marker, sizeof(marker), 0, NULL);
     sodium_bin2base64(conn->marker, sizeof(conn->marker), marker, sizeof(marker),
                       sodium_base64_VARIANT_URLSAFE_NO_PADDING);
@@ -876,6 +876,7 @@ void conn_inbound_data_msg(ziti_connection conn, message *msg) {
         memcpy(plain_text, msg->body, msg->header.body_len);
         buffer_append(conn->inbound, plain_text, msg->header.body_len);
         metrics_rate_update(&conn->ziti_ctx->down_rate, msg->header.body_len);
+        conn->received += msg->header.body_len;
     }
 
     int32_t flags;

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1,9 +1,9 @@
-// Copyright (c) 2022-2023.  NetFoundry Inc.
+// Copyright (c) 2022-2023. NetFoundry Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
 //
+// You may obtain a copy of the License at
 // https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
@@ -622,6 +622,7 @@ int ziti_get_appdata(ziti_context ztx, const char *key, void *data,
 
 
 void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...), void *ctx) {
+    uint64_t now = uv_now(ztx->loop);
     printer(ctx, "\n=================\nZiti Context:\n");
     printer(ctx, "ID:\t%d\n", ztx->id);
     printer(ctx, "Enabled:\t%s\n", ziti_is_enabled(ztx) ? "true" : "false");
@@ -707,6 +708,8 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
                     FIELD_OR_ELSE(conn->channel, id, -1),
                     FIELD_OR_ELSE(conn->channel, name, "(none)")
             );
+            printer(ctx, "\tconnect_time[%" PRIu64 "], idle_time[%" PRIu64 "ms]\n",
+                    conn->connect_time, now - conn->last_activity);
         }
 
         if (conn->type == Server) {
@@ -722,6 +725,8 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
                         FIELD_OR_ELSE(child->channel, id, -1),
                         FIELD_OR_ELSE(child->channel, name, "(none)")
                 );
+                printer(ctx, "\t\taccept_time[%" PRIu64 "], idle_time[%" PRIu64 "ms]\n",
+                        child->connect_time, now - child->last_activity);
                 it = model_map_it_next(it);
             }
         }

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -711,7 +711,7 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
                     FIELD_OR_ELSE(conn->channel, id, -1),
                     FIELD_OR_ELSE(conn->channel, name, "(none)")
             );
-            printer(ctx, "\tconnect_time[%" PRIu64 "] idle_time[%" PRIu64 "ms] "
+            printer(ctx, "\tconnect_time[%" PRIu64 "] idle_time[%" PRIu64 "] "
                          "sent[%" PRIu64 "] recv[%" PRIu64 "] recv_buff[%" PRIu64 "]\n",
                     conn->connect_time, now - conn->last_activity, conn->sent, conn->received,
                     buffer_available(conn->inbound));
@@ -734,7 +734,7 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
                         FIELD_OR_ELSE(child->channel, id, -1),
                         FIELD_OR_ELSE(child->channel, name, "(none)")
                 );
-                printer(ctx, "\t\taccept_time[%" PRIu64 "] idle_time[%" PRIu64 "ms] "
+                printer(ctx, "\t\taccept_time[%" PRIu64 "] idle_time[%" PRIu64 "] "
                              "sent[%" PRIu64 "] recv[%" PRIu64 "] recv_buff[%" PRIu64 "]\n",
                         child->connect_time, now - child->last_activity, child->sent, child->received,
                         buffer_available(child->inbound));

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -739,7 +739,7 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
                         child->connect_time, now - child->last_activity, child->sent, child->received,
                         buffer_available(child->inbound));
                 if (conn_bridge_info(child, bridge_info, sizeof(bridge_info)) == ZITI_OK) {
-                    printer(ctx, "\tbridge: %s\n", bridge_info);
+                    printer(ctx, "\t\tbridge: %s\n", bridge_info);
                 }
                 it = model_map_it_next(it);
             }


### PR DESCRIPTION
add connection marker in ziti log and dump
new data in dump:
- marker
- time to connect
- idle time
- bytes sent/received
- underlay info if connection is bridged

sample dump output:
```
conn[1/hTz4t7n2]: state[Connected] service[test1] using ch[0/quickstart-router]
	connect_time[64] idle_time[8671ms] sent[21] recv[0] recv_buff[0]
	bridge: tcp: 127.0.0.1:18000 -> 127.0.0.1:52180
conn[0]: server service[test1] terminators[1]
	child[2/hTz4t7n2]: state[Connected] caller_id[tester] ch[0/quickstart-router]
		accept_time[1] idle_time[8670ms] sent[0] recv[21] recv_buff[0]
	        bridge: tcp: 127.0.0.1:52182 -> 127.0.0.1:19000
```
