### PR TITLE
Inspection support

### DIFF
--- a/inc_internal/edge_protocol.h
+++ b/inc_internal/edge_protocol.h
@@ -18,6 +18,8 @@ limitations under the License.
 #ifndef ZITI_SDK_EDGE_PROTOCOL_H
 #define ZITI_SDK_EDGE_PROTOCOL_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,6 +44,11 @@ enum content_type {
     ContentTypeStateSessionEnded = 60792,
 	ContentTypeProbe             = 60793,
 	ContentTypeUpdateBind        = 60794,
+    ContentTypeHealthEvent         = 60795,
+    ContentTypeTraceRoute          = 60796,
+    ContentTypeTraceRouteResponse  = 60797,
+    ContentTypeConnInspectRequest  = 60798,
+    ContentTypeConnInspectResponse = 60799,
 };
 
 enum header_id {
@@ -84,6 +91,14 @@ enum header_id {
     SupportsInspectHeader = 1023,
     SupportsBindSuccessHeader = 1024,
     ConnectionMarkerHeader = 1025,
+};
+
+typedef uint8_t connection_type_t;
+enum connection_type {
+    ConnTypeInvalid,
+    ConnTypeDial = 1,
+    ConnTypeBind = 2,
+    ConnTypeUnknown = 3,
 };
 
 enum crypto_method {

--- a/inc_internal/message.h
+++ b/inc_internal/message.h
@@ -16,6 +16,7 @@
 #define ZITI_SDK_MESSAGE_H
 
 #include "pool.h"
+#include "edge_protocol.h"
 
 #include <stdlib.h>
 #include <stdint.h>
@@ -101,6 +102,7 @@ message *message_new(pool_t *pool, uint32_t content, const hdr_t *headers, int n
 
 void message_set_seq(message *m, uint32_t *seq);
 
+message* new_inspect_result(uint32_t req_seq, uint32_t conn_id, connection_type_t type, const char *msg, size_t msglen);
 
 #ifdef __cplusplus
 };

--- a/library/bind.c
+++ b/library/bind.c
@@ -308,7 +308,7 @@ static void process_inspect(struct binding_s *b, message *msg) {
                              "closed[%s] encrypted[%s]",
                              conn->conn_id, conn->service, listener_id,
                              BOOL_STR(conn->close), BOOL_STR(conn->encrypted));
-    CONN_LOG(INFO, "processing inspect: %.*s", (int)ci_len, conn_info);
+    CONN_LOG(DEBUG, "processing inspect: %.*s", (int)ci_len, conn_info);
     message *reply = new_inspect_result(msg->header.seq, conn->conn_id, ConnTypeBind, conn_info, ci_len);
     ziti_channel_send_message(b->ch, reply, NULL);
 }

--- a/library/bind.c
+++ b/library/bind.c
@@ -338,7 +338,7 @@ static void process_dial(struct binding_s *b, message *msg) {
     }
     client->start = uv_now(conn->ziti_ctx->loop);
 
-    if (peer_key_sent) {
+    if (conn->encrypted) {
         client->encrypted = true;
         if (init_crypto(&client->key_ex, &b->key_pair, peer_key, true) != 0) {
             reject_dial_request(0, b->ch, msg->header.seq, "failed to establish crypto");

--- a/library/bind.c
+++ b/library/bind.c
@@ -215,6 +215,7 @@ static void session_cb(ziti_net_session *session, const ziti_error *err, void *c
 static void get_service_cb(ziti_context ztx, ziti_service *service, int status, void *ctx) {
     struct ziti_conn *conn = ctx;
     if (status == ZITI_OK) {
+        conn->encrypted = service->encryption;
         if (ziti_service_has_permission(service, ziti_session_types.Bind)) {
             ziti_ctrl_create_session(&ztx->controller, service->id, ziti_session_types.Bind, session_cb, conn);
         } else {
@@ -295,6 +296,23 @@ static int dispose(ziti_connection server) {
     return 1;
 }
 
+#define BOOL_STR(v) ((v) ? "Y" : "N")
+
+static void process_inspect(struct binding_s *b, message *msg) {
+    struct ziti_conn *conn = b->conn;
+    char conn_info[256];
+    char listener_id[sodium_base64_ENCODED_LEN(sizeof(conn->server.listener_id), sodium_base64_VARIANT_URLSAFE)];
+    sodium_bin2base64(listener_id, sizeof(listener_id), conn->server.listener_id, sizeof(conn->server.listener_id), sodium_base64_VARIANT_URLSAFE);
+    size_t ci_len = snprintf(conn_info, sizeof(conn_info),
+                             "id[%d] serviceName[%s] listenerId[%s] "
+                             "closed[%s] encrypted[%s]",
+                             conn->conn_id, conn->service, listener_id,
+                             BOOL_STR(conn->close), BOOL_STR(conn->encrypted));
+    CONN_LOG(INFO, "processing inspect: %.*s", (int)ci_len, conn_info);
+    message *reply = new_inspect_result(msg->header.seq, conn->conn_id, ConnTypeBind, conn_info, ci_len);
+    ziti_channel_send_message(b->ch, reply, NULL);
+}
+
 static void process_dial(struct binding_s *b, message *msg) {
     struct ziti_conn *conn = b->conn;
 
@@ -371,6 +389,9 @@ static void on_message(struct binding_s *b, message *msg, int code) {
             case ContentTypeDial:
                 process_dial(b, msg);
                 break;
+            case ContentTypeConnInspectRequest:
+                process_inspect(b, msg);
+                break;
             default:
                 ZITI_LOG(ERROR, "unexpected msg[%X] for bound conn[%d]", msg->header.content, conn->conn_id);
         }
@@ -405,6 +426,7 @@ void start_binding(struct binding_s *b, ziti_channel_t *ch) {
 
     b->ch = ch;
 
+    uint8_t true_val = 1;
     int32_t conn_id = htole32(conn->conn_id);
     int32_t msg_seq = htole32(0);
 
@@ -420,14 +442,19 @@ void start_binding(struct binding_s *b, ziti_channel_t *ch) {
                     .value = (uint8_t *) &msg_seq
             },
             {
-                    .header_id = PublicKeyHeader,
-                    .length = sizeof(b->key_pair.pk),
-                    .value = b->key_pair.pk,
-            },
-            {
                     .header_id = ListenerId,
                     .length = sizeof(b->conn->server.listener_id),
                     .value = (uint8_t*)b->conn->server.listener_id,
+            },
+            {
+                    .header_id = SupportsInspectHeader,
+                    .length = 1,
+                    .value = &true_val,
+            },
+            {
+                    .header_id = PublicKeyHeader,
+                    .length = sizeof(b->key_pair.pk),
+                    .value = b->key_pair.pk,
             },
             // blank hdr_t's to be filled in if needed by options
             {
@@ -447,6 +474,10 @@ void start_binding(struct binding_s *b, ziti_channel_t *ch) {
             }
     };
     int nheaders = 4;
+    if (conn->encrypted) {
+        nheaders++;
+    }
+
     if (conn->server.identity != NULL) {
         headers[nheaders].header_id = TerminatorIdentityHeader;
         headers[nheaders].value = (uint8_t *) conn->server.identity;

--- a/library/message.c
+++ b/library/message.c
@@ -237,3 +237,29 @@ void message_set_seq(message *m, uint32_t *seq) {
     }
     header_to_buffer(&m->header, m->msgbufp);
 }
+
+
+message* new_inspect_result(uint32_t req_seq, uint32_t conn_id, connection_type_t type, const char *msg, size_t msglen) {
+    const hdr_t hdrs[] = {
+            {
+                    .header_id = ConnIdHeader,
+                    .length = sizeof(conn_id),
+                    .value = (uint8_t *) &conn_id,
+            },
+            {
+                    .header_id = ConnTypeHeader,
+                    .length = sizeof(type),
+                    .value = &type,
+            },
+            {
+                    .header_id = ReplyForHeader,
+                    .length = sizeof(req_seq),
+                    .value = (uint8_t *) &(req_seq),
+            }
+    };
+    message *reply = message_new(NULL, ContentTypeConnInspectResponse, hdrs, 3, msglen);
+    if (msglen > 0) {
+        strncpy((char *) reply->body, msg, msglen);
+    }
+    return reply;
+}

--- a/tests/integ/CMakeLists.txt
+++ b/tests/integ/CMakeLists.txt
@@ -22,7 +22,7 @@ else ()
     set_property(TARGET integ-tests PROPERTY CXX_STANDARD 14)
 endif ()
 
-set(ZITI_CLI_VER "v0.31.0" CACHE STRING "ziti version for integration tests")
+set(ZITI_CLI_VER "v0.31.4" CACHE STRING "ziti version for integration tests")
 add_custom_target(ziti-cli ALL
         COMMAND ${CMAKE_COMMAND} -E env GOBIN=${CMAKE_CURRENT_BINARY_DIR}
         ${GOLANG_EXE} install github.com/openziti/ziti/ziti@${ZITI_CLI_VER}


### PR DESCRIPTION
respond to connection inspection requests from ER

sample output:
```
% ziti fabric validate terminators
started validation of 1 terminators
id: 3Oe7jqtG6w2PoQyrsRd97O, binding: edge, hostId: Nc7oL3eVc6, routerId: -B39LaeWd6, state: Valid, fixed: false, detail: id[0] serviceName[test-service] listenerId[PGqP-8LxjVZFRgYOcf90PuIkQuG-4KVj0sNL2efA1zw=] closed[N] encrypted[Y]
```

[fixes #578]