### PR TITLE
avoid creating waiter if send fails

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -8,7 +8,7 @@ else ()
 
     FetchContent_Declare(tlsuv
             GIT_REPOSITORY https://github.com/openziti/tlsuv.git
-            GIT_TAG v0.28.0
+            GIT_TAG v0.28.1
             )
     FetchContent_MakeAvailable(tlsuv)
 

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -112,7 +112,9 @@ typedef struct ziti_channel {
 
     // map[id->msg_receiver]
     model_map receivers;
-    LIST_HEAD(waiter, waiter_s) waiters;
+
+    // map[msg_seq->waiter_s]
+    model_map waiters;
 
     ch_notify_state notify_cb;
     void *notify_ctx;


### PR DESCRIPTION
it was possible to hand invalid waiter reference to the caller of `ziti_channel_send_for_reply`, this would cause invalid memory access at some later time

this fix only creates a waiter if message was successfully written/queued