### PR TITLE
Keychain support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,14 @@ project(ziti-sdk
 )
 
 set(PROJECT_VERSION ${GIT_VERSION})
-include(cmake/project-is-top-level.cmake)
 include(cmake/variables.cmake)
 
 set(tlsuv_DIR "" CACHE FILEPATH "developer option: use local tlsuv checkout")
 
-option(HAVE_LIBSODIUM "use and link installed shared libsodium library" OFF)
-
 message("project version: ${PROJECT_VERSION}")
 message("git info:")
-message("   branch : ${GIT_BRANCH}")
-message("     hash : ${GIT_COMMIT_HASH}")
+message(" branch : ${GIT_BRANCH}")
+message("   hash : ${GIT_COMMIT_HASH}")
 
 message("")
 message("using ${CMAKE_GENERATOR}")
@@ -105,7 +102,7 @@ if (ziti_DEVELOPER_MODE AND NOT CMAKE_CROSSCOMPILING)
     add_subdirectory(tests)
 endif ()
 
-if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/local.cmake")
+if (ziti-sdk_IS_TOP_LEVEL AND EXISTS "${CMAKE_CURRENT_LIST_DIR}/local.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/local.cmake")
 endif ()
 

--- a/cmake/project-is-top-level.cmake
+++ b/cmake/project-is-top-level.cmake
@@ -1,6 +1,0 @@
-# This variable is set by project() in CMake 3.21+
-string(
-        COMPARE EQUAL
-        "${CMAKE_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}"
-        PROJECT_IS_TOP_LEVEL
-)

--- a/cmake/variables.cmake
+++ b/cmake/variables.cmake
@@ -21,10 +21,10 @@ set(warning_guard "")
 if (NOT PROJECT_IS_TOP_LEVEL)
     option(
             ziti_INCLUDES_WITH_SYSTEM
-            "Use SYSTEM modifier for tlsuv's includes, disabling warnings"
+            "Use SYSTEM modifier for ziti's includes, disabling warnings"
             ON
     )
-    mark_as_advanced(tlsuv_INCLUDES_WITH_SYSTEM)
+    mark_as_advanced(ziti_INCLUDES_WITH_SYSTEM)
     if (ziti_INCLUDES_WITH_SYSTEM)
         set(warning_guard SYSTEM)
     endif ()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT TARGET tlsuv)
     else ()
         FetchContent_Declare(tlsuv
             GIT_REPOSITORY https://github.com/openziti/tlsuv.git
-                GIT_TAG v0.31.0
+                GIT_TAG v0.31.1
         )
         FetchContent_MakeAvailable(tlsuv)
     endif (tlsuv_DIR)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -14,17 +14,6 @@ else ()
 
 endif (tlsuv_DIR)
 
-FetchContent_Declare(subcommand
-        GIT_REPOSITORY https://github.com/openziti/subcommands.c.git
-        GIT_TAG main
-        )
-FetchContent_GetProperties(subcommand)
-if (NOT subcommand_POPULATED)
-    FetchContent_Populate(subcommand)
-endif ()
-add_library(subcommand INTERFACE)
-target_include_directories(subcommand INTERFACE ${subcommand_SOURCE_DIR})
-
 
 
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,18 +1,19 @@
 
 include(FetchContent)
 
-if (tlsuv_DIR)
-    add_subdirectory(${tlsuv_DIR}
-            ${CMAKE_CURRENT_BINARY_DIR}/tlsuv)
-else ()
-
-    FetchContent_Declare(tlsuv
+# allow downstream projects to pull tlsuv on their own
+if (NOT TARGET tlsuv)
+    if (tlsuv_DIR)
+        add_subdirectory(${tlsuv_DIR}
+                ${CMAKE_CURRENT_BINARY_DIR}/tlsuv)
+    else ()
+        FetchContent_Declare(tlsuv
             GIT_REPOSITORY https://github.com/openziti/tlsuv.git
-            GIT_TAG v0.30.1
-            )
-    FetchContent_MakeAvailable(tlsuv)
-
-endif (tlsuv_DIR)
+                GIT_TAG v0.31.0
+        )
+        FetchContent_MakeAvailable(tlsuv)
+    endif (tlsuv_DIR)
+endif () # tlsuv TARGET
 
 
 

--- a/inc_internal/ziti_enroll.h
+++ b/inc_internal/ziti_enroll.h
@@ -42,6 +42,7 @@ typedef struct enroll_cfg_s {
 
     char *CA;
 
+    bool use_keychain;
     const char *private_key;
     tlsuv_private_key_t pk;
     const char *own_cert;

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -258,6 +258,7 @@ typedef struct ziti_enroll_opts_s {
     const char *enroll_cert;
     const char *enroll_name;
     const char *jwt_content;
+    bool use_keychain; // use keychain if generating new key
 } ziti_enroll_opts;
 
 typedef struct ziti_dial_opts_s {

--- a/library/utils.c
+++ b/library/utils.c
@@ -572,6 +572,16 @@ int load_key_internal(tls_context *tls, tlsuv_private_key_t *key, const char *ke
         return 0;
     }
 
+    if (strncmp(keystr, "keychain:", strlen("keychain:")) == 0) {
+        const char *keyname = strchr(keystr, ':') + 1;
+        rc = tls->load_keychain_key(key, keyname);
+        if (rc != 0) {
+            ZITI_LOG(WARN, "failed to load keychain key[%s]", keyname);
+            return ZITI_INVALID_CONFIG;
+        }
+        return 0;
+    }
+
     if (tlsuv_parse_url(&uri, keystr) == 0) {
         if (uri.scheme_len == strlen("file") && strncmp(uri.scheme, "file", uri.scheme_len) == 0) {
             rc = tls->load_key(key, uri.path, uri.path_len);

--- a/programs/ziti-prox-c/CMakeLists.txt
+++ b/programs/ziti-prox-c/CMakeLists.txt
@@ -1,6 +1,18 @@
 
 add_executable(ziti-prox-c proxy.c)
 
+FetchContent_Declare(subcommand
+        GIT_REPOSITORY https://github.com/openziti/subcommands.c.git
+        GIT_TAG main
+)
+FetchContent_GetProperties(subcommand)
+if (NOT subcommand_POPULATED)
+    FetchContent_Populate(subcommand)
+endif ()
+add_library(subcommand INTERFACE)
+target_include_directories(subcommand INTERFACE ${subcommand_SOURCE_DIR})
+
+
 if(WIN32)
     target_include_directories(ziti-prox-c PRIVATE win32/include)
     target_sources(ziti-prox-c PRIVATE win32/src/getopt.c)


### PR DESCRIPTION
if platform supports keychains or application provided keychain driver(via `tlsuv_set_keychain()`)

- allow loading private keys from keychain using key ref `keychain:<name>`
- allow generating identity keys right inside keychain `ziti_enroll_opts.use_keychain = true`

