### PR TITLE
Implement authentication with Ext JWT Signer 

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT TARGET tlsuv)
     else ()
         FetchContent_Declare(tlsuv
             GIT_REPOSITORY https://github.com/openziti/tlsuv.git
-                GIT_TAG v0.31.2
+                GIT_TAG v0.31.3
         )
         FetchContent_MakeAvailable(tlsuv)
     endif (tlsuv_DIR)

--- a/inc_internal/auth_method.h
+++ b/inc_internal/auth_method.h
@@ -23,8 +23,8 @@ enum AuthenticationMethod {
 };
 
 static const ziti_auth_query_mfa ziti_mfa = {
-        .provider = "ziti",
-        .type_id = "MFA"
+        .type_id = (char*)"MFA",
+        .provider = (char*)"ziti",
 };
 
 typedef enum {

--- a/inc_internal/auth_method.h
+++ b/inc_internal/auth_method.h
@@ -22,6 +22,11 @@ enum AuthenticationMethod {
     HA
 };
 
+static const ziti_auth_query_mfa ziti_mfa = {
+        .provider = "ziti",
+        .type_id = "MFA"
+};
+
 typedef enum {
     ZitiAuthStateUnauthenticated,
     ZitiAuthStateAuthStarted,
@@ -39,6 +44,7 @@ typedef void (*auth_mfa_cb)(void *ctx, int status);
 
 struct ziti_auth_method_s {
     enum AuthenticationMethod kind;
+    int (*set_ext_jwt)(ziti_auth_method_t *self, const char *token);
     int (*start)(ziti_auth_method_t *self, auth_state_cb cb, void *ctx);
     int (*force_refresh)(ziti_auth_method_t *self);
     int (*submit_mfa)(ziti_auth_method_t *self, const char *code, auth_mfa_cb);

--- a/inc_internal/oidc.h
+++ b/inc_internal/oidc.h
@@ -25,7 +25,8 @@ extern "C" {
 #endif
 
 #define OIDC_TOKEN_OK (0)
-#define OIDC_TOPT_NEEDED (1)
+#define OIDC_TOTP_NEEDED (1)
+#define OIDC_TOTP_FAILED (2)
 
 typedef struct oidc_client_s oidc_client_t;
 typedef void (*oidc_config_cb)(oidc_client_t *, int, const char *);

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -83,8 +83,16 @@ void ziti_ctrl_clear_api_session(ziti_controller *ctrl);
 
 void ziti_ctrl_get_version(ziti_controller *ctrl, ctrl_version_cb cb, void *ctx);
 
-void ziti_ctrl_login(ziti_controller *ctrl, model_list *cfg_types, void (*cb)(ziti_api_session *, const ziti_error *, void *),
+void ziti_ctrl_login(ziti_controller *ctrl, model_list *cfg_types,
+                     void (*cb)(ziti_api_session *, const ziti_error *, void *),
                      void *ctx);
+
+void ziti_ctrl_login_ext_jwt(ziti_controller *ctrl, const char *jwt,
+                             void (*cb)(ziti_api_session *, const ziti_error *, void *), void *ctx);
+
+void ziti_ctrl_list_ext_jwt_signers(ziti_controller *ctrl,
+                                    void (*cb)(ziti_jwt_signer_array, const ziti_error*, void*),
+                                    void *ctx);
 
 void ziti_ctrl_list_controllers(ziti_controller *ctrl,
                                 void (*cb)(ziti_controller_detail_array, const ziti_error*, void *ctx), void *ctx);

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -237,6 +237,11 @@ struct ztx_work_s {
 
 typedef STAILQ_HEAD(work_q, ztx_work_s) ztx_work_q;
 
+struct tls_credentials {
+    tlsuv_private_key_t key;
+    tlsuv_certificate_t cert;
+};
+
 struct ziti_ctx {
     ziti_config config;
     ziti_options opts;
@@ -245,10 +250,10 @@ struct ziti_ctx {
 
     model_map ctrl_details;
 
-    tlsuv_private_key_t sessionKey;
-    char *sessionCsr;
-    tlsuv_certificate_t sessionCert;
     tls_context *tlsCtx;
+    struct tls_credentials id_creds;
+    struct tls_credentials session_creds;
+    char *sessionCsr;
 
     bool closing;
     bool enabled;
@@ -259,6 +264,9 @@ struct ziti_ctx {
     ziti_auth_state auth_state;
     ziti_mfa_cb mfa_cb;
     void *mfa_ctx;
+
+    struct oidc_client_s *ext_auth;
+    void (*ext_launch_cb)(ziti_context, const char*);
 
     // HA access_token(JWT) or legacy ziti_api_session.token
     char *session_token;
@@ -359,7 +367,7 @@ int load_jwt(const char *filename, struct enroll_cfg_s *ecfg, ziti_enrollment_jw
 
 int load_jwt_content(struct enroll_cfg_s *ecfg, ziti_enrollment_jwt_header **zejh, ziti_enrollment_jwt **zej);
 
-int load_tls(ziti_config *cfg, tls_context **tls);
+int load_tls(ziti_config *cfg, tls_context **tls, struct tls_credentials *creds);
 
 int ziti_bind(ziti_connection conn, const char *service, const ziti_listen_opts *listen_opts,
               ziti_listen_cb listen_cb, ziti_client_cb on_clt_cb);
@@ -400,6 +408,9 @@ int conn_bridge_info(ziti_connection conn, char *buf, size_t buflen);
 
 void process_connect(struct ziti_conn *conn, ziti_session *session);
 
+void ztx_init_external_auth(ziti_context ztx);
+
+void ztx_auth_state_cb(void *, ziti_auth_state , const void *);
 
 #ifdef __cplusplus
 }

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -266,7 +266,8 @@ struct ziti_ctx {
     void *mfa_ctx;
 
     struct oidc_client_s *ext_auth;
-    void (*ext_launch_cb)(ziti_context, const char*);
+    void (*ext_launch_cb)(ziti_context, const char*, void*);
+    void *ext_launch_ctx;
 
     // HA access_token(JWT) or legacy ziti_api_session.token
     char *session_token;

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -957,7 +957,9 @@ extern void ziti_mfa_new_recovery_codes(ziti_context ztx, char *code, ziti_mfa_r
 ZITI_FUNC
 extern void ziti_mfa_auth(ziti_context ztx, const char *code, ziti_mfa_cb auth_cb, void *ctx);
 
-extern int ziti_ext_auth(ziti_context ztx, void (*ziti_ext_launch)(ziti_context, const char* url));
+extern int ziti_ext_auth(ziti_context ztx,
+                         void (*ziti_ext_launch)(ziti_context, const char* url, void*),
+                         void *ctx);
 
 extern int ziti_ext_auth_token(ziti_context ztx, const char *token);
 

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -957,6 +957,10 @@ extern void ziti_mfa_new_recovery_codes(ziti_context ztx, char *code, ziti_mfa_r
 ZITI_FUNC
 extern void ziti_mfa_auth(ziti_context ztx, const char *code, ziti_mfa_cb auth_cb, void *ctx);
 
+extern int ziti_ext_auth(ziti_context ztx, void (*ziti_ext_launch)(ziti_context, const char* url));
+
+extern int ziti_ext_auth_token(ziti_context ztx, const char *token);
+
 /**
  * @brief Alerts that the host running the `ziti_context` has undergone a state change.
  *

--- a/includes/ziti/ziti_buffer.h
+++ b/includes/ziti/ziti_buffer.h
@@ -73,6 +73,11 @@ ZITI_FUNC void delete_string_buf(string_buf_t *wb);
 ZITI_FUNC int string_buf_append(string_buf_t *wb, const char *str);
 
 /**
+ * @brief Appends [str] to [wb] converting to urlsafe encoding.
+ */
+ ZITI_FUNC int string_buf_append_urlsafe(string_buf_t *wb, const char *str);
+
+/**
  * Append `len` bytes from `str` to the string buffer.
  * @param wb string buffer
  * @param str string

--- a/includes/ziti/ziti_events.h
+++ b/includes/ziti/ziti_events.h
@@ -16,6 +16,8 @@
 #ifndef ZITI_SDK_ZITI_EVENTS_H
 #define ZITI_SDK_ZITI_EVENTS_H
 
+#include "ziti_model.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/includes/ziti/ziti_events.h
+++ b/includes/ziti/ziti_events.h
@@ -31,7 +31,7 @@ typedef enum {
     ZitiContextEvent = 1,
     ZitiRouterEvent = 1 << 1,
     ZitiServiceEvent = 1 << 2,
-    ZitiMfaAuthEvent = 1 << 3,
+    ZitiAuthEvent = 1 << 3,
     ZitiAPIEvent = 1 << 4,
 } ziti_event_type;
 
@@ -103,16 +103,31 @@ struct ziti_service_event {
     ziti_service_array added;
 };
 
+enum ziti_auth_action {
+    ziti_auth_prompt_totp,
+    ziti_auth_prompt_pin,
+    ziti_auth_login_external
+};
 /**
- * \brief Ziti Authentication Query MFA Event
+ * \brief Event notifying the app that additional action is required to continue authentication or normal operation.
  *
- * Event notifying the app that an active API Session requires
- * its identity's current MFA one-time-code (TOTP) to be
- * submitted. All MFA codes can be provided via
- * `ziti_mfa_auth(...)`
+ * The app may request that information from the user and then submit it
+ * to ziti_context.
+ *
+ * the following authentication actions are supported:
+ *
+ * [ziti_auth_prompt_totp] - request for MFA code, application must call [ziti_mfa_auth()] when it acquires TOTP code
+ *
+ * [ziti_auth_login_external] - request for that app to launch external program (web browser)
+ *                 that can authenticate with provided url ([detail] field)
+ *
+ * TODO: future
+ * [ziti_auth_prompt_pin] - request for HSM/TPM key pin, application must call [TBD method] when it acquires PIN
  */
-struct ziti_mfa_auth_event {
-    const ziti_auth_query_mfa *auth_query_mfa;
+struct ziti_auth_event {
+    enum ziti_auth_action action;
+    const char *type;
+    const char *detail;
 };
 
 /**
@@ -127,7 +142,7 @@ typedef struct ziti_event_s {
         struct ziti_context_event ctx;
         struct ziti_router_event router;
         struct ziti_service_event service;
-        struct ziti_mfa_auth_event mfa_auth_event;
+        struct ziti_auth_event auth;
         struct ziti_api_event api;
     };
 } ziti_event_t;

--- a/includes/ziti/ziti_events.h
+++ b/includes/ziti/ziti_events.h
@@ -130,6 +130,7 @@ struct ziti_auth_event {
     enum ziti_auth_action action;
     const char *type;
     const char *detail;
+    model_list providers;
 };
 
 /**

--- a/includes/ziti/ziti_model.h
+++ b/includes/ziti/ziti_model.h
@@ -48,7 +48,8 @@ XX(id, string, none, id, __VA_ARGS__) \
 XX(name, string, none, name, __VA_ARGS__) \
 XX(enabled, bool, none, enabled, __VA_ARGS__) \
 XX(provider_url, string, none, externalAuthUrl, __VA_ARGS__) \
-XX(client_id, string, none, audience, __VA_ARGS__)           \
+XX(client_id, string, none, clientId, __VA_ARGS__)           \
+XX(audience, string, none, audience, __VA_ARGS__)           \
 XX(claim, string, none, claimProperty, __VA_ARGS__)
 
 #define ZITI_ID_CFG_MODEL(XX, ...) \

--- a/includes/ziti/ziti_model.h
+++ b/includes/ziti/ziti_model.h
@@ -43,10 +43,19 @@ XX(min_length, int, none, minLength, __VA_ARGS__) \
 XX(max_length, int, none, maxLength, __VA_ARGS__) \
 XX(format, string, none, format, __VA_ARGS__)
 
+#define ZITI_JWT_SIGNER_MODEL(XX, ...) \
+XX(id, string, none, id, __VA_ARGS__) \
+XX(name, string, none, name, __VA_ARGS__) \
+XX(enabled, bool, none, enabled, __VA_ARGS__) \
+XX(provider_url, string, none, externalAuthUrl, __VA_ARGS__) \
+XX(client_id, string, none, audience, __VA_ARGS__)           \
+XX(claim, string, none, claimProperty, __VA_ARGS__)
+
 #define ZITI_ID_CFG_MODEL(XX, ...) \
 XX(cert, string, none, cert, __VA_ARGS__) \
 XX(key, string, none, key, __VA_ARGS__) \
-XX(ca, string, none, ca, __VA_ARGS__)
+XX(ca, string, none, ca, __VA_ARGS__)     \
+XX(oidc, ziti_jwt_signer, ptr, oidc, __VA_ARGS__)
 
 #define ZITI_CONFIG_MODEL(XX, ...) \
 XX(controller_url, string, none, ztAPI, __VA_ARGS__) \
@@ -227,6 +236,8 @@ DECLARE_MODEL(api_path, ZITI_API_PATH_MODEL)
 DECLARE_MODEL(ziti_api_versions, ZITI_API_VERSIONS_MODEL)
 
 DECLARE_MODEL(ziti_version, ZITI_VERSION_MODEL)
+
+DECLARE_MODEL(ziti_jwt_signer, ZITI_JWT_SIGNER_MODEL)
 
 DECLARE_MODEL(ziti_id_cfg, ZITI_ID_CFG_MODEL)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -85,6 +85,7 @@ SET(ZITI_SRC_FILES
         legacy_auth.c
         ha_auth.c
         util/future.c
+        external_auth.c
         )
 
 SET(ZITI_INCLUDE_DIRS

--- a/library/auth_queries.c
+++ b/library/auth_queries.c
@@ -113,9 +113,11 @@ void ziti_auth_query_mfa_process(ziti_mfa_auth_ctx *mfa_auth_ctx) {
         mfa_auth_ctx->ztx->auth_queries->outstanding_auth_query_ctx = mfa_auth_ctx;
 
         ziti_event_t ev = {
-                .type = ZitiMfaAuthEvent,
-                .mfa_auth_event = {
-                        .auth_query_mfa = mfa_auth_ctx->auth_query_mfa,
+                .type = ZitiAuthEvent,
+                .auth = {
+                        .action = ziti_auth_prompt_totp,
+                        .type = mfa_auth_ctx->auth_query_mfa->type_id,
+                        .detail = mfa_auth_ctx->auth_query_mfa->provider,
                 }
         };
 

--- a/library/buffer.c
+++ b/library/buffer.c
@@ -182,6 +182,29 @@ int string_buf_appendn(string_buf_t *wb, const char *str, size_t len) {
     return 0;
 }
 
+int string_buf_append_urlsafe(string_buf_t *wb, const char *str) {
+    static const char unsafe[] = " /:\"<>%{}|\\^`";
+
+    if (str == NULL) {
+        return 0;
+    }
+
+    const char *p = str;
+    int rc = 0;
+    while(*p && rc == 0) {
+        char c = *p++;
+        if (strchr(unsafe, c) == NULL) {
+            rc = string_buf_append_byte(wb, c);
+            continue;
+        }
+
+        char buf[4];
+        snprintf(buf, sizeof(buf), "%%%02X", (int)c);
+        rc = string_buf_appendn(wb, buf, 3);
+    }
+    return rc;
+}
+
 int string_buf_append(string_buf_t *wb, const char *str) {
     const char *s = str;
 

--- a/library/config.c
+++ b/library/config.c
@@ -72,9 +72,5 @@ int ziti_load_config(ziti_config *cfg, const char* cfgstr) {
         cfg->controller_url = NULL;
     }
 
-    if (cfg->id.key == NULL) {
-        return ZITI_INVALID_CONFIG;
-    }
-
     return ZITI_OK;
 }

--- a/library/external_auth.c
+++ b/library/external_auth.c
@@ -1,0 +1,81 @@
+//
+// 	Copyright NetFoundry Inc.
+//
+// 	Licensed under the Apache License, Version 2.0 (the "License");
+// 	you may not use this file except in compliance with the License.
+// 	You may obtain a copy of the License at
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// 	Unless required by applicable law or agreed to in writing, software
+// 	distributed under the License is distributed on an "AS IS" BASIS,
+// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// 	See the License for the specific language governing permissions and
+// 	limitations under the License.
+//
+
+#include <ziti/ziti_events.h>
+#include "zt_internal.h"
+#include "oidc.h"
+
+static void ext_oath_cfg_cb(oidc_client_t *oidc, int status, const char *err) {
+    ziti_context ztx = oidc->data;
+    if (status == 0) {
+        ziti_event_t ev = {
+                .type = ZitiAuthEvent,
+                .auth = {
+                        .action = ziti_auth_login_external,
+                        .type = "oidc",
+                        .detail = oidc->http.host,
+                }
+        };
+
+        ziti_send_event(ztx, &ev);
+    }
+}
+
+void ztx_init_external_auth(ziti_context ztx) {
+    ziti_jwt_signer *oidc_cfg = ztx->config.id.oidc;
+    if (oidc_cfg != NULL) {
+        NEWP(oidc, oidc_client_t);
+        oidc_client_init(ztx->loop, oidc, oidc_cfg, NULL);
+        oidc->data = ztx;
+        ztx->ext_auth = oidc;
+        oidc_client_configure(oidc, ext_oath_cfg_cb);
+    }
+}
+
+static void internal_link_cb(oidc_client_t *oidc, const char *url, void *ctx) {
+    ziti_context ztx = oidc->data;
+    ZITI_LOG(INFO, "received link request: %s", url);
+    if (ztx->ext_launch_cb) {
+        ztx->ext_launch_cb(ztx, url);
+    }
+}
+
+static void ext_token_cb(oidc_client_t *oidc, int status, const char *token) {
+    ziti_context ztx = oidc->data;
+    ZITI_LOG(INFO, "received access token: %d\n%s", status, token);
+    ztx->auth_method->set_ext_jwt(ztx->auth_method, token);
+    ztx->auth_method->start(ztx->auth_method, ztx_auth_state_cb, ztx);
+}
+
+extern int ziti_ext_auth(ziti_context ztx, void (*ziti_ext_launch)(ziti_context, const char* url)) {
+    if (ztx->ext_auth == NULL) {
+        return ZITI_INVALID_STATE;
+    }
+
+    ztx->ext_launch_cb = ziti_ext_launch;
+    oidc_client_set_link_cb(ztx->ext_auth, internal_link_cb, NULL);
+    oidc_client_start(ztx->ext_auth, ext_token_cb);
+    return ZITI_OK;
+}
+
+extern int ziti_ext_auth_token(ziti_context ztx, const char *token) {
+    if (ztx->auth_method) {
+        ztx->auth_method->set_ext_jwt(ztx->auth_method, token);
+        return 0;
+    }
+
+    return ZITI_INVALID_STATE;
+}

--- a/library/internal_model.c
+++ b/library/internal_model.c
@@ -73,6 +73,8 @@ IMPL_MODEL(ziti_host_cfg_v1, ZITI_HOST_CFG_V1_MODEL)
 
 IMPL_MODEL(ziti_host_cfg_v2, ZITI_HOST_CFG_V2_MODEL)
 
+IMPL_MODEL(ziti_jwt_signer, ZITI_JWT_SIGNER_MODEL)
+
 IMPL_MODEL(ziti_id_cfg, ZITI_ID_CFG_MODEL)
 
 IMPL_MODEL(ziti_config, ZITI_CONFIG_MODEL)

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -459,7 +459,7 @@ int oidc_client_start(oidc_client_t *clt, oidc_token_cb cb) {
     }
 
     const char *path = get_endpoint_path(clt, "authorization_endpoint");
-    tlsuv_http_pair query[] = (tlsuv_http_pair[]) {
+    tlsuv_http_pair query[] = {
             {"client_id",             clt->signer_cfg->client_id},
             {"scope",                 scope},
             {"response_type",         "code"},

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -16,16 +16,23 @@
 #include <assert.h>
 #include <json.h>
 #include <sodium.h>
+#include <ctype.h>
 #include "ziti/ziti_log.h"
 #include "utils.h"
 #include "ziti/errors.h"
+#include "ziti/ziti_buffer.h"
+#include "ziti/ziti_model.h"
 
-#define code_len 8
+#define code_len 40
 #define code_verifier_len sodium_base64_ENCODED_LEN(code_len, sodium_base64_VARIANT_URLSAFE_NO_PADDING)
 #define code_challenge_len sodium_base64_ENCODED_LEN(crypto_hash_sha256_BYTES, sodium_base64_VARIANT_URLSAFE_NO_PADDING)
 
-#define default_cb_url "http://localhost:18889/auth/callback"
-#define default_client_id "native"
+#define _str(x) #x
+#define auth_cb_port 20314 /* 'OZ' */
+#define auth_url_path "/auth/callback"
+#define cb_url(host,port,path) "http://" host ":" _str(port) path
+#define default_cb_url cb_url("localhost",auth_cb_port,auth_url_path)
+#define default_scope "openid offline_access"
 #define default_auth_header "Basic bmF0aXZlOg==" /* native: */
 
 typedef struct oidc_req oidc_req;
@@ -49,7 +56,10 @@ typedef struct auth_req {
     oidc_client_t *clt;
     char code_verifier[code_verifier_len];
     char code_challenge[code_challenge_len];
+    char state[16];
     json_tokener *json_parser;
+    char *id;
+    bool totp;
 } auth_req;
 
 static oidc_req *new_oidc_req(oidc_client_t *clt, oidc_cb cb, void *ctx) {
@@ -100,7 +110,13 @@ static void dump_cb(tlsuv_http_req_t *r, char *data, ssize_t len) {
         complete_oidc_req(req, (int)len, NULL);
     }
 }
-
+static void dump_resp(tlsuv_http_resp_t *resp) {
+    printf("%s %d %s\n", resp->http_version, resp->code, resp->status);
+    tlsuv_http_hdr *h;
+    LIST_FOREACH(h, &resp->headers, _next) {
+        printf("%s: %s\n", h->name, h->value);
+    }
+}
 static void parse_cb(tlsuv_http_resp_t *resp, void *ctx) {
     tlsuv_http_req_t *http_req = resp->req;
     oidc_req *req = http_req->data;
@@ -115,7 +131,7 @@ static void parse_cb(tlsuv_http_resp_t *resp, void *ctx) {
     }
 
     const char *ct = tlsuv_http_resp_header(resp, "Content-Type");
-    if (ct && strcmp(ct, "application/json") == 0) {
+    if (ct && strncmp(ct, "application/json", strlen("application/json")) == 0) {
         resp->body_cb = json_parse_cb;
         return;
     }
@@ -124,22 +140,26 @@ static void parse_cb(tlsuv_http_resp_t *resp, void *ctx) {
     resp->body_cb = dump_cb;
 }
 
-int oidc_client_init(uv_loop_t *loop, oidc_client_t *clt, const char *url, tls_context *tls) {
+int oidc_client_init(uv_loop_t *loop, oidc_client_t *clt,
+                     const ziti_jwt_signer *cfg, tls_context *tls) {
     assert(clt != NULL);
-    assert(url != NULL);
+    assert(cfg != NULL);
+    assert(cfg->provider_url != NULL);
 
     clt->config = NULL;
     clt->tokens = NULL;
     clt->config_cb = NULL;
     clt->token_cb = NULL;
     clt->close_cb = NULL;
-    clt->client_id = default_client_id;
+    clt->link_cb = NULL;
+    clt->link_ctx = NULL;
 
-    int rc = tlsuv_http_init(loop, &clt->http, url);
+    clt->signer_cfg = cfg;
+
+    int rc = tlsuv_http_init(loop, &clt->http, clt->signer_cfg->provider_url);
     if (rc != 0) {
         return rc;
     }
-    tlsuv_http_set_path_prefix(&clt->http, "");
     tlsuv_http_set_ssl(&clt->http, tls);
 
     clt->timer = calloc(1, sizeof(*clt->timer));
@@ -150,10 +170,16 @@ int oidc_client_init(uv_loop_t *loop, oidc_client_t *clt, const char *url, tls_c
     return 0;
 }
 
-int oidc_client_set_url(oidc_client_t *clt, const char *url) {
-    tlsuv_http_set_url(&clt->http, url);
-    tlsuv_http_set_path_prefix(&clt->http, "");
+int oidc_client_set_cfg(oidc_client_t *clt, const ziti_jwt_signer *cfg) {
+    clt->signer_cfg = cfg;
+    tlsuv_http_set_url(&clt->http, clt->signer_cfg->provider_url);
     return 0;
+}
+
+void oidc_client_set_link_cb(oidc_client_t *clt, oidc_ext_link_cb cb, void *ctx) {
+    clt->mode = oidc_external;
+    clt->link_cb = cb;
+    clt->link_ctx = ctx;
 }
 
 static void internal_config_cb(oidc_req *req, int status, json_object *resp) {
@@ -182,7 +208,7 @@ static auth_req *new_auth_req(oidc_client_t *clt) {
     auth_req *req = calloc(1, sizeof(*req));
     req->clt = clt;
 
-    uint8_t code[8];
+    uint8_t code[code_len];
     uv_random(NULL, NULL, code, sizeof(code), 0, NULL);
     sodium_bin2base64(req->code_verifier, sizeof(req->code_verifier),
                       code, sizeof(code), sodium_base64_VARIANT_URLSAFE_NO_PADDING);
@@ -247,8 +273,25 @@ static void token_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
         req->json_parser = json_tokener_new();
         http_resp->body_cb = parse_token_cb;
     } else {
-        failed_auth_req(req, http_resp->status);
+        dump_resp(http_resp);
+        http_resp->body_cb = dump_cb;
+        // failed_auth_req(req, http_resp->status);
     }
+}
+
+static void request_token(auth_req *req, const char *auth_code) {
+    ZITI_LOG(INFO, "requesting token auth[%s]", auth_code);
+    const char *path = get_endpoint_path(req->clt, "token_endpoint");
+    tlsuv_http_req_t *token_req = tlsuv_http_req(&req->clt->http, "POST", path, token_cb, req);
+    token_req->data = req;
+    tlsuv_http_req_form(token_req, 6, (tlsuv_http_pair[]) {
+            {"code",          auth_code},
+            {"grant_type",    "authorization_code"},
+            {"code_verifier", req->code_verifier},
+            {"client_id",     req->clt->signer_cfg->client_id},
+            {"redirect_uri",  default_cb_url},
+            {"state",         req->state},
+    });
 }
 
 static void code_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
@@ -260,28 +303,25 @@ static void code_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
         char *code = strstr(uri.query, "code=");
         code += strlen("code=");
 
-        ZITI_LOG(DEBUG, "requesting token");
-        const char *path = get_endpoint_path(req->clt, "token_endpoint");
-        tlsuv_http_req_t *token_req = tlsuv_http_req(&req->clt->http, "POST", path, token_cb, req);
-        token_req->data = req;
-        tlsuv_http_req_form(token_req, 8, (tlsuv_http_pair[]) {
-                {"code",                  code},
-                {"grant_type",            "authorization_code"},
-                {"code_verifier",         req->code_verifier},
-                {"code_challenge",        req->code_challenge},
-                {"code_challenge_method", "S256"},
-                {"client_id",             req->clt->client_id},
-                {"scopes",                "openid offline_access"},
-                {"redirect_uri", default_cb_url}
-        });
+        request_token(req, code);
     } else {
         failed_auth_req(req, http_resp->status);
     }
 }
 
+static void login_parse_cb(tlsuv_http_req_t *hr, char *data, ssize_t len) {
+    printf("%zd: %.*s\n", len, (int)len, data);
+}
 static void login_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
     auth_req *req = ctx;
-    if (http_resp->code / 100 == 3) {
+    if (http_resp->code / 100 == 2) {
+        const char *totp = tlsuv_http_resp_header(http_resp, "totp-required");
+        if (totp && tolower(totp[0]) == 't') {
+            req->totp = true;
+            req->clt->request = req;
+            req->clt->token_cb(req->clt, OIDC_TOPT_NEEDED, NULL);
+        }
+    } else if (http_resp->code / 100 == 3) {
         const char *redirect = tlsuv_http_resp_header(http_resp, "Location");
         struct tlsuv_url_s uri;
         tlsuv_parse_url(&uri, redirect);
@@ -300,13 +340,112 @@ static void auth_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
         tlsuv_parse_url(&uri, redirect);
         char *p = strstr(uri.query, "authRequestID=");
         p += strlen("authRequestID=");
+        req->id = strdup(p);
 
         ZITI_LOG(DEBUG, "logging in with cert auth");
-        tlsuv_http_req_t *login_req = tlsuv_http_req(&req->clt->http, "POST", "/oidc/login/cert", login_cb, req);
+        tlsuv_http_req_t *login_req = tlsuv_http_req(&req->clt->http, "POST", redirect, login_cb, req);
         tlsuv_http_req_form(login_req, 1, &(tlsuv_http_pair) {"id", p});
     } else {
         failed_auth_req(req, http_resp->status);
     }
+}
+
+struct ext_link_req {
+    uv_work_t wr;
+    uv_os_sock_t sock;
+    auth_req *req;
+    char *code;
+};
+
+static void ext_accept(uv_work_t *wr) {
+    struct ext_link_req *elr = (struct ext_link_req *) wr;
+    uv_os_sock_t clt = accept(elr->sock, NULL, NULL);
+    char buf[1024];
+    ssize_t c = read(clt, buf, sizeof(buf) - 1);
+    buf[c] = 0;
+
+    char *cs = strstr(buf, "code=");
+    if (!cs) {
+        ZITI_LOG(WARN, "no code parameter found: %s", buf);
+        char resp[] = "HTTP/1.1 400 Invalid Request\r\n"
+                      "Content-Type: text/html\r\n"
+                      "Connection: close\r\n"
+                      "\r\n"
+                      "<body>Unexpected auth request:<pre>";
+        write(clt, resp, sizeof(resp));
+        write(clt, buf, c);
+        close(clt);
+        return;
+    }
+    cs += strlen("code=");
+    char *ce = strchr(cs, ' ');
+    *ce = 0;
+    char *amp = strchr(cs, '&');
+    if (amp) {
+        ce = amp;
+    }
+
+    char *code = calloc(1, ce - cs + 1);
+    memcpy(code, cs, ce - cs);
+    elr->code = code;
+
+    char resp[] = "HTTP/1.1 200 OK\r\n"
+                  "Content-Type: text/html\r\n"
+                  "\r\n"
+                  "<script type=\"text/javascript\">window.close()</script>"
+                  "<body onload=\"window.close()\">You may close this window</body>";
+    write(clt, resp, sizeof(resp));
+    close(clt);
+}
+
+static void ext_done(uv_work_t *wr, int status) {
+    struct ext_link_req *elr = (struct ext_link_req *) wr;
+    close(elr->sock);
+
+    if (elr->code) {
+        request_token(elr->req, elr->code);
+    } else {
+        failed_auth_req(elr->req, "code not received");
+    }
+
+    free(elr->code);
+    free(elr);
+}
+
+static void start_ext_auth(auth_req *req, const char *ep, int qc, tlsuv_http_pair q[]) {
+    string_buf_t *buf = new_string_buf();
+    string_buf_append(buf, ep);
+    for (int i = 0; i < qc; i++) {
+        string_buf_append_byte(buf, (i == 0) ? '?' : '&');
+        string_buf_append_urlsafe(buf, q[i].name);
+        string_buf_append_byte(buf, '=');
+        string_buf_append_urlsafe(buf, q[i].value);
+    }
+
+    char *url = string_buf_to_string(buf, NULL);
+    struct ext_link_req *elr = calloc(1, sizeof(*elr));
+    uv_loop_t *loop = req->clt->timer->loop;
+    struct sockaddr_in addr = {
+            .sin_addr = INADDR_ANY,
+            .sin_port = htons(auth_cb_port),
+    };
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    printf("sock = %d\n", sock);
+    if (bind(sock, (const struct sockaddr *) &addr, sizeof(addr))) {
+        perror("bind");
+    }
+    if (listen(sock, 1)) {
+        perror("listen");
+    }
+
+    req->clt->link_cb(req->clt, url, req->clt->link_ctx);
+
+    elr->sock = sock;
+    elr->req = req;
+    uv_queue_work(loop, &elr->wr, ext_accept, ext_done);
+
+    free(url);
+    delete_string_buf(buf);
 }
 
 int oidc_client_start(oidc_client_t *clt, oidc_token_cb cb) {
@@ -314,16 +453,32 @@ int oidc_client_start(oidc_client_t *clt, oidc_token_cb cb) {
     ZITI_LOG(DEBUG, "requesting authentication code");
     auth_req *req = new_auth_req(clt);
 
+    char scope[256] = default_scope;
+    if (clt->signer_cfg->claim) {
+        snprintf(scope, sizeof(scope), "%s " default_scope, clt->signer_cfg->claim);
+    }
+
     const char *path = get_endpoint_path(clt, "authorization_endpoint");
-    tlsuv_http_req_t *http_req = tlsuv_http_req(&clt->http, "POST", path, auth_cb, req);
-    int rc = tlsuv_http_req_form(http_req, 6, (tlsuv_http_pair[]) {
-            {"client_id",             "native"},
-            {"scope",                 "openid offline_access"},
+    tlsuv_http_pair query[] = (tlsuv_http_pair[]) {
+            {"client_id",             clt->signer_cfg->client_id},
+            {"scope",                 scope},
             {"response_type",         "code"},
-            {"redirect_uri", default_cb_url},
+            {"redirect_uri",          default_cb_url},
             {"code_challenge",        req->code_challenge},
             {"code_challenge_method", "S256"},
-    });
+            {"audience",              clt->signer_cfg->audience ?
+                                      clt->signer_cfg->audience : "openziti"},
+    };
+
+    if (clt->mode == oidc_external) {
+        struct json_object *cfg = (struct json_object *) clt->config;
+        struct json_object *auth = json_object_object_get(cfg, "authorization_endpoint");
+        start_ext_auth(req, json_object_get_string(auth), sizeof(query)/sizeof(query[0]), query);
+        return 0;
+    }
+
+    tlsuv_http_req_t *http_req = tlsuv_http_req(&clt->http, "POST", path, auth_cb, req);
+    int rc = tlsuv_http_req_query(http_req, sizeof(query)/sizeof(query[0]), query);
     return rc;
 }
 
@@ -336,6 +491,22 @@ static void http_close_cb(tlsuv_http_t *h) {
     if (cb) {
         cb(clt);
     }
+}
+static void on_topt(tlsuv_http_resp_t *resp, void *ctx) {
+    dump_resp(resp);
+    resp->body_cb =  dump_cb;
+}
+
+int oidc_client_mfa(oidc_client_t *clt, const char *code) {
+    struct auth_req *req = clt->request;
+    assert(req);
+
+    tlsuv_http_req_t *r = tlsuv_http_req(&clt->http, "POST", "/oidc/login/totp", on_topt, req);
+    tlsuv_http_req_form(r, 2, (tlsuv_http_pair[]){
+        {"id", "req->id"},
+        {"code", code},
+    });
+    return 0;
 }
 
 int oidc_client_refresh(oidc_client_t *clt) {
@@ -368,7 +539,7 @@ static void oidc_client_set_tokens(oidc_client_t *clt, json_object *tok_json) {
     if (clt->token_cb) {
         struct json_object *access_token = json_object_object_get(clt->tokens, "access_token");
         if (access_token) {
-            clt->token_cb(clt, ZITI_OK, json_object_get_string(access_token));
+            clt->token_cb(clt, OIDC_TOKEN_OK, json_object_get_string(access_token));
         }
     }
     struct json_object *refresher = json_object_object_get(clt->tokens, "refresh_token");
@@ -391,7 +562,6 @@ static void refresh_cb(oidc_req *req, int status, json_object *resp) {
         uv_timer_start(clt->timer, refresh_time_cb, 5 * 1000, 0);
     } else {
         ZITI_LOG(WARN, "OIDC token refresh failed: %d[%s]", status, json_object_to_json_string(resp));
-        clt->token_cb(clt, ZITI_AUTHENTICATION_FAILED, NULL);
         oidc_client_start(clt, clt->token_cb);
         if (resp) {
             json_object_put(resp);

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -275,7 +275,7 @@ static void token_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
     } else {
         dump_resp(http_resp);
         http_resp->body_cb = dump_cb;
-        // failed_auth_req(req, http_resp->status);
+        failed_auth_req(req, http_resp->status);
     }
 }
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -222,9 +222,11 @@ void ziti_set_partially_authenticated(ziti_context ztx, const ziti_auth_query_mf
     update_ctrl_status(ztx, ZITI_PARTIALLY_AUTHENTICATED, NULL);
 
     ziti_event_t ev = {
-            .type = ZitiMfaAuthEvent,
-            .mfa_auth_event = {
-                    .auth_query_mfa = mfa_q,
+            .type = ZitiAuthEvent,
+            .auth = {
+                    .action = ziti_auth_prompt_totp,
+                    .type = mfa_q->type_id,
+                    .detail = mfa_q->provider,
             }
     };
 

--- a/programs/mfa_tester/ziti_mfa.cpp
+++ b/programs/mfa_tester/ziti_mfa.cpp
@@ -17,7 +17,6 @@
 #include <CLI/CLI.hpp>
 
 #include <cassert>
-#include <format>
 #include <iostream>
 #include <mutex>
 
@@ -189,7 +188,7 @@ static void test_mfa() {
             }
             case ZitiAuthEvent: {
                 const ziti_auth_event &e = ev->auth;
-                auto prompt = std::format("enter {}/{} code", e.type, e.detail);
+                auto prompt = std::string("enter ") + e.type + '/' + e.detail + " code";
                 ztx_prompt(ztx, prompt, [](ziti_context z, const char *code) {
                     ziti_mfa_auth(z, code, [](ziti_context z, int status, void *) {
                         if (status == ZITI_OK) {
@@ -229,7 +228,7 @@ static void enroll_mfa() {
             }
             case ZitiAuthEvent: {
                 const ziti_auth_event &e = ev->auth;
-                std::cout << std::format("details: {}/{}", e.type, e.detail) << std::endl;
+                std::cout << "details: " << e.type << '/' << e.detail << std::endl;
                 ziti_shutdown(ztx);
                 break;
             }
@@ -262,7 +261,7 @@ static void delete_mfa() {
             case ZitiAuthEvent: {
                 const ziti_auth_event &e = ev->auth;
                 if (e.action == ziti_auth_prompt_totp) {
-                    auto prompt = std::format("enter {}/{} code", e.type, e.detail);
+                    auto prompt = std::string("enter ") + e.type + '/' + e.detail + " code";
                     ztx_prompt(ztx, prompt, [](ziti_context z, const char *code) {
                         ziti_mfa_auth(z, code, [](ziti_context z, int status, void *) {
                             if (status == ZITI_OK) {

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -609,14 +609,14 @@ static void ext_auth_prompt(uv_work_t *wr) {
     prompt_stdin(resp, 1);
 }
 
-static void ext_url_launch(ziti_context ztx, const char *url) {
+static void ext_url_launch(ziti_context ztx, const char *url, void *ctx) {
     char cmd[1024];
     snprintf(cmd, sizeof(cmd), "/usr/bin/open '%s'", url);
     system(cmd);
 }
 static void ext_auth_done(uv_work_t *wr, int status) {
     ziti_context ztx = wr->data;
-    ziti_ext_auth(ztx, ext_url_launch);
+    ziti_ext_auth(ztx, ext_url_launch, NULL);
     free(wr);
 }
 

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -508,8 +508,14 @@ static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
                     break;
             }
             break;
-        case ZitiMfaAuthEvent:
-            mfa_auth_event_handler(ztx);
+        case ZitiAuthEvent:
+            if (event->auth.action == ziti_auth_prompt_totp) {
+                ZITI_LOG(INFO, "ziti requires MFA %s/%s", event->auth.type, event->auth.detail);
+                mfa_auth_event_handler(ztx);
+            } else {
+                ZITI_LOG(ERROR, "unhandled auth event %d/%s", event->auth.action, event->auth.type);
+            }
+            break;
 
         default:
             break;

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -99,6 +99,7 @@ uv_loop_t *global_loop;
 static int process_args(int argc, char *argv[]);
 
 void mfa_auth_event_handler(ziti_context ztx);
+void ext_auth_event_handler(ziti_context ztx);
 
 int main(int argc, char *argv[]) {
     process_args(argc, argv);
@@ -512,6 +513,8 @@ static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
             if (event->auth.action == ziti_auth_prompt_totp) {
                 ZITI_LOG(INFO, "ziti requires MFA %s/%s", event->auth.type, event->auth.detail);
                 mfa_auth_event_handler(ztx);
+            } else if (event->auth.action == ziti_auth_login_external) {
+                ext_auth_event_handler(ztx);
             } else {
                 ZITI_LOG(ERROR, "unhandled auth event %d/%s", event->auth.action, event->auth.type);
             }
@@ -598,6 +601,31 @@ void mfa_auth_event_handler(ziti_context ztx) {
     uv_queue_work(global_loop, &mfa_wr->w, mfa_worker, mfa_worker_done);
 }
 
+static void ext_auth_prompt(uv_work_t *wr) {
+    printf("continue with external signer[Y/n]? ");
+    fflush(stdout);
+
+    char resp[1];
+    prompt_stdin(resp, 1);
+}
+
+static void ext_url_launch(ziti_context ztx, const char *url) {
+    char cmd[1024];
+    snprintf(cmd, sizeof(cmd), "/usr/bin/open '%s'", url);
+    system(cmd);
+}
+static void ext_auth_done(uv_work_t *wr, int status) {
+    ziti_context ztx = wr->data;
+    ziti_ext_auth(ztx, ext_url_launch);
+    free(wr);
+}
+
+void ext_auth_event_handler(ziti_context ztx) {
+    NEWP(ext_wr, uv_work_t);
+    ext_wr->data = ztx;
+    uv_queue_work(global_loop, ext_wr, ext_auth_prompt, ext_auth_done);
+}
+
 static struct proxy_app_ctx app_ctx = {0};
 
 static void stopper_alloc(uv_handle_t *h, size_t i, uv_buf_t *pBuf) {
@@ -627,8 +655,8 @@ void run(int argc, char **argv) {
     struct sockaddr_in stopper_addr;
     uv_udp_init(loop, &stopper);
     uv_ip4_addr("127.0.0.1", 12345, &stopper_addr);
-    uv_udp_bind(&stopper, (const struct sockaddr *) &stopper_addr, 0);
-    uv_udp_recv_start(&stopper, stopper_alloc, stopper_recv);
+    int rc = uv_udp_bind(&stopper, (const struct sockaddr *) &stopper_addr, 0);
+    rc = uv_udp_recv_start(&stopper, stopper_alloc, stopper_recv);
     uv_unref((uv_handle_t *) &stopper);
 
     for (int i = 0; i < argc; i++) {

--- a/tests/integ/legacy-auth.cpp
+++ b/tests/integ/legacy-auth.cpp
@@ -133,9 +133,10 @@ TEST_CASE("invalid_controller", "[controller][GH-44]") {
 TEST_CASE("controller_test","[integ]") {
     const char *conf = TEST_CLIENT;
 
-    ziti_config config;
-    tls_context *tls;
-    ziti_controller ctrl;
+    ziti_config config{};
+    tls_credentials creds{};
+    tls_context *tls = nullptr;
+    ziti_controller ctrl{};
     uv_loop_t *loop = uv_default_loop();
 
     resp_capture<ziti_version> version;
@@ -145,7 +146,7 @@ TEST_CASE("controller_test","[integ]") {
 
     PREP(ziti);
     TRY(ziti, ziti_load_config(&config, conf));
-    TRY(ziti, load_tls(&config, &tls));
+    TRY(ziti, load_tls(&config, &tls, &creds));
     TRY(ziti, ziti_ctrl_init(loop, &ctrl, &config.controllers, tls));
 
     WHEN("get version and login") {

--- a/tests/integ/oidc-tests.cpp
+++ b/tests/integ/oidc-tests.cpp
@@ -35,8 +35,15 @@ TEST_CASE_METHOD(LoopTestCase, "ha-oidc", "[integ]") {
     tls->load_key(&key, cfg.id.key, strlen(cfg.id.key));
     tls->set_own_cert(tls, key, cert);
 
+    const ziti_jwt_signer ha_oidc = {
+            .name = "ziti-internal-oidc",
+            .enabled = true,
+            .provider_url = (char*) model_list_head(&cfg.controllers),
+            .client_id = "native",
+    };
+
     oidc_client_t oidcClient;
-    oidc_client_init(l, &oidcClient, (const char*)model_list_head(&cfg.controllers), tls);
+    oidc_client_init(l, &oidcClient, &ha_oidc, tls);
     struct oidc_cfg_result {
         bool called;
         int status;


### PR DESCRIPTION
Identity configuration JSON can have external OIDC provider instead of key/cert pair:

```
{
        "ztAPI":"https://XXXX.production.netfoundry.io:443",
        "id":{
                "oidc": {
                        "externalAuthUrl": "https://XXXX.us.auth0.com",
                        "clientId": "<provider client_id>",
                        "claimProperty": "email"
                },
                "ca":"-----BEGIN CERTIFICATE-----\
...
}
```

SDK notifies the app that external auth is required via `ZitiAuthEvent`
User/app then may initiate external authentication via `ziti_ext_auth()`
also enables MFA support on HA networks