### PR TITLE
allow application to force service refresh

### DIFF
--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -444,11 +444,11 @@ extern int ziti_context_run(ziti_context ztx, uv_loop_t *loop);
  * \brief Trigger refresh ahead of normal refresh cycle.
  *
  * This method will force ziti context to update its internal model from ziti controller.
- * Appropriate events will be triggers as needed
- * (just like during normal refresh cycle [ziti_options.refresh_interval]):
+ * Appropriate events will be triggered as needed
+ * (just like during normal refresh cycle [#ziti_options.refresh_interval]):
  * - Service Added/Removed, etc.
  * @param ztx
- * @return 0 on success, or error code
+ * @return #ZITI_OK on success, or error code
  */
 ZITI_FUNC
 extern int ziti_refresh(ziti_context ztx);

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -441,6 +441,19 @@ ZITI_FUNC
 extern int ziti_context_run(ziti_context ztx, uv_loop_t *loop);
 
 /**
+ * \brief Trigger refresh ahead of normal refresh cycle.
+ *
+ * This method will force ziti context to update its internal model from ziti controller.
+ * Appropriate events will be triggers as needed
+ * (just like during normal refresh cycle [ziti_options.refresh_interval]):
+ * - Service Added/Removed, etc.
+ * @param ztx
+ * @return 0 on success, or error code
+ */
+ZITI_FUNC
+extern int ziti_refresh(ziti_context ztx);
+
+/**
  * return if context is enabled
  * @param ztx ziti context
  * @return

--- a/includes/ziti/ziti_events.h
+++ b/includes/ziti/ziti_events.h
@@ -130,7 +130,7 @@ struct ziti_auth_event {
     enum ziti_auth_action action;
     const char *type;
     const char *detail;
-    model_list providers;
+    ziti_jwt_signer_array providers;
 };
 
 /**

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1616,7 +1616,7 @@ int ziti_context_run(ziti_context ztx, uv_loop_t *loop) {
 int ziti_refresh(ziti_context ztx) {
     if (!ztx->enabled) return ZITI_DISABLED;
 
-    ZTX_LOG(INFO, "application requested service refresh");
+    ZTX_LOG(DEBUG, "application requested service refresh");
     ziti_services_refresh(ztx, true);
     return ZITI_OK;
 }

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1613,6 +1613,15 @@ int ziti_context_run(ziti_context ztx, uv_loop_t *loop) {
     return ZITI_OK;
 }
 
+int ziti_refresh(ziti_context ztx) {
+    if (!ztx->enabled) return ZITI_DISABLED;
+
+    ZTX_LOG(INFO, "application requested service refresh");
+    ziti_services_refresh(ztx, true);
+    return ZITI_OK;
+}
+
+
 static void pre_auth_retry(uv_timer_t *t) {
     ziti_context ztx = t->data;
     ziti_re_auth(ztx);


### PR DESCRIPTION
- appropriate events will be triggered
- allows mobile clients to reduce polling and still present up-to-date info to the user