### PR TITLE
Multipart traffic optimizations

### DIFF
--- a/inc_internal/buffer.h
+++ b/inc_internal/buffer.h
@@ -43,6 +43,7 @@ void buffer_cleanup(buffer *);
 ssize_t buffer_get_next(buffer *, size_t want, uint8_t **ptr);
 void buffer_push_back(buffer *, size_t);
 void buffer_append(buffer *, uint8_t *buf, size_t len);
+void buffer_append_copy(buffer *, const uint8_t *, size_t len);
 size_t buffer_available(buffer *);
 
 

--- a/inc_internal/connect.h
+++ b/inc_internal/connect.h
@@ -40,8 +40,6 @@ void init_transport_conn(struct ziti_conn *conn);
 
 int ziti_close_server(struct ziti_conn *conn);
 
-message *create_message(struct ziti_conn *conn, uint32_t content, size_t body_len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/inc_internal/edge_protocol.h
+++ b/inc_internal/edge_protocol.h
@@ -113,14 +113,18 @@ enum crypto_method {
 };
 
 enum edge_flag {
-    // half close connection no more data messages are expected after receipt of message with this flag
+    // half close connection no more data messages are expected
+    // after receipt of message with this flag
     EDGE_FIN = 1,
     // indicates that peer will send data messages with specially constructed UUID headers
     EDGE_TRACE_UUID = 1 << 1,
     // indicates that peer can accept multipart data messages
-    EDGE_ACCEPT_MULTIPART = 1 << 2,
+    EDGE_MULTIPART = 1 << 2,
+    // indicates connection with stream semantics
+    // this allows consolidation of payloads to lower overhead
+    EDGE_STREAM = 1 << 3,
     // set on data message with multiple payloads
-    EDGE_MULTIPART = 1 << 3,
+    EDGE_MULTIPART_MSG = 1 << 4,
 };
 
 #ifdef __cplusplus

--- a/inc_internal/edge_protocol.h
+++ b/inc_internal/edge_protocol.h
@@ -113,7 +113,14 @@ enum crypto_method {
 };
 
 enum edge_flag {
+    // half close connection no more data messages are expected after receipt of message with this flag
     EDGE_FIN = 1,
+    // indicates that peer will send data messages with specially constructed UUID headers
+    EDGE_TRACE_UUID = 1 << 1,
+    // indicates that peer can accept multipart data messages
+    EDGE_ACCEPT_MULTIPART = 1 << 2,
+    // set on data message with multiple payloads
+    EDGE_MULTIPART = 1 << 3,
 };
 
 #ifdef __cplusplus

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -191,7 +191,7 @@ struct ziti_conn {
 
             uint32_t edge_msg_seq;
             uint32_t in_msg_seq;
-            bool can_send_multipart;
+            uint32_t flags;
 
             ziti_channel_t *channel;
             ziti_data_cb data_cb;

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -189,6 +189,7 @@ struct ziti_conn {
 
             uint32_t edge_msg_seq;
             uint32_t in_msg_seq;
+            bool can_send_multipart;
 
             ziti_channel_t *channel;
             ziti_data_cb data_cb;
@@ -405,7 +406,7 @@ void ziti_services_refresh(ziti_context ztx, bool now);
 
 extern void ziti_send_event(ziti_context ztx, const ziti_event_t *e);
 
-void reject_dial_request(uint32_t conn_id, ziti_channel_t *ch, int32_t req_id, const char *reason);
+void reject_dial_request(uint32_t conn_id, ziti_channel_t *ch, uint32_t req_id, const char *reason);
 
 const ziti_env_info* get_env_info();
 

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -124,6 +124,8 @@ struct ziti_write_req_s {
     void *ctx;
 
     TAILQ_ENTRY(ziti_write_req_s) _next;
+    model_list chain;
+    size_t chain_len;
 };
 
 struct key_pair {

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -260,6 +260,10 @@ typedef struct ziti_enroll_opts_s {
 } ziti_enroll_opts;
 
 typedef struct ziti_dial_opts_s {
+    /** enable stream semantics
+     * this allows SDK to consolidate multiple write requests to lower overlay overhead
+     */
+    bool stream;
     int connect_timeout_seconds;
     char *identity;
     void *app_data;

--- a/library/buffer.c
+++ b/library/buffer.c
@@ -31,14 +31,14 @@
 /** incoming data chunk */
 typedef struct chunk_s {
     uint8_t *buf;
-    int len;
+    size_t len;
 
     STAILQ_ENTRY(chunk_s) next;
 } chunk_t;
 
 struct buffer_s {
     STAILQ_HEAD(incoming, chunk_s) chunks;
-    int head_offset;
+    size_t head_offset;
     size_t available;
 };
 
@@ -107,6 +107,12 @@ ssize_t buffer_get_next(buffer* b, size_t want, uint8_t** ptr) {
     b->available -= len;
 
     return len;
+}
+
+void buffer_append_copy(buffer *b, const uint8_t *buf, size_t len) {
+    uint8_t *copy = calloc(len, sizeof(uint8_t));
+    memcpy(copy, buf, len);
+    buffer_append(b, copy, len);
 }
 
 void buffer_append(buffer* b, uint8_t *buf, size_t len) {

--- a/library/connect.c
+++ b/library/connect.c
@@ -23,6 +23,7 @@
 static const char *INVALID_SESSION = "Invalid Session";
 static const int MAX_CONNECT_RETRY = 3;
 
+#define CONN_CAP_MASK (EDGE_MULTIPART | EDGE_TRACE_UUID | EDGE_STREAM)
 #define BOOL_STR(v) ((v) ? "Y" : "N")
 
 #define CONN_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "conn[%u.%u/%.*s/%s] " fmt, \
@@ -112,6 +113,7 @@ static void conn_set_state(struct ziti_conn *conn, enum conn_state state) {
 static void clone_ziti_dial_opts(ziti_dial_opts *dest, const ziti_dial_opts *dial_opts) {
     *dest = DEFAULT_DIAL_OPTS;
 
+    dest->stream = dial_opts->stream;
     dest->connect_timeout_seconds = dial_opts->connect_timeout_seconds;
     if (dial_opts->identity != NULL && dial_opts->identity[0] != '\0') {
         dest->identity = strdup(dial_opts->identity);
@@ -245,7 +247,11 @@ void on_write_completed(struct ziti_conn *conn, struct ziti_write_req_s *req, in
 message *create_message(struct ziti_conn *conn, uint32_t content, uint32_t flags, size_t body_len) {
 
     if (conn->edge_msg_seq == 0) {
-        flags |= EDGE_ACCEPT_MULTIPART;
+        flags |= EDGE_TRACE_UUID;
+        if (conn->flags & EDGE_STREAM)
+            flags |= EDGE_STREAM;
+        else
+            flags |= EDGE_MULTIPART;
     }
 
     int32_t conn_id = htole32(conn->conn_id);
@@ -571,7 +577,9 @@ static int do_ziti_dial(ziti_connection conn, const char *service, ziti_dial_opt
         // clone dial_opts to survive the async request
         clone_ziti_dial_opts(&req->dial_opts, dial_opts);
 
-        // override connection timeout if set in dial_opts
+        if (dial_opts->stream) {
+            conn->flags |= EDGE_STREAM;
+        }
     }
 
     conn->data_cb = data_cb;
@@ -614,10 +622,13 @@ static void ziti_write_req(struct ziti_write_req_s *req) {
         message *m = req->message;
         if (m == NULL) {
             bool multipart = model_list_size(&req->chain) > 0;
-            uint32_t flags = multipart ? EDGE_MULTIPART : 0;
+            bool stream = conn->flags & EDGE_STREAM;
+
+            uint32_t flags = multipart && !stream ? EDGE_MULTIPART_MSG : 0;
             size_t total_len = conn->encrypted ? crypto_secretstream_xchacha20poly1305_abytes() : 0;
             total_len += (multipart ? req->chain_len : req->len);
             m = create_message(conn, ContentTypeData, flags, total_len);
+
             if (multipart) {
                 uint8_t *p = m->body + conn->encrypted;
                 string_buf_t buf;
@@ -625,18 +636,22 @@ static void ziti_write_req(struct ziti_write_req_s *req) {
                 struct ziti_write_req_s *r = req;
                 model_list_iter it = model_list_iterator(&req->chain);
                 int count = 0;
+                size_t tot = 0;
                 do {
-                    uint16_t part_len = (uint16_t)r->len;
-                    part_len = htole16(part_len);
-                    string_buf_appendn(&buf, (char*)&part_len, sizeof(part_len));
+                    if (!stream) {
+                        uint16_t part_len = (uint16_t) r->len;
+                        part_len = htole16(part_len);
+                        string_buf_appendn(&buf, (char *) &part_len, sizeof(part_len));
+                    }
                     string_buf_appendn(&buf, (char*)r->buf, r->len);
-                    conn->sent += r->len;
+                    count++;
+                    tot += r->len;
 
                     r = model_list_it_element(it);
                     it = model_list_it_next(it);
-                    count++;
                 } while(r != NULL);
-                CONN_LOG(DEBUG, "consolidated %d payloads", count);
+                CONN_LOG(DEBUG, "consolidated %d payloads total_len[%zd]", count, tot);
+                conn->sent += tot;
 
                 if (conn->encrypted) {
                     crypto_secretstream_xchacha20poly1305_push(&conn->crypt_o, m->body, NULL,
@@ -786,24 +801,25 @@ void chain_data_requests(ziti_connection conn, struct ziti_write_req_s *req) {
     if (req->message)
         return;
 
+    int boundary_len = (conn->flags & EDGE_STREAM) ? 0 : 2;
 #define MAX_CHAIN_LEN (31 * 1024)
     size_t chain_len = 0;
-    if (req->len + 2 >= MAX_CHAIN_LEN)
+    if (req->len + boundary_len >= MAX_CHAIN_LEN)
         return;
 
-    chain_len += (req->len + 2);
+    chain_len += (req->len + boundary_len);
 
     while(!TAILQ_EMPTY(&conn->wreqs)) {
         struct ziti_write_req_s *next = TAILQ_FIRST(&conn->wreqs);
         if (next->message || next->close || next->eof)
             break;
 
-        if (chain_len + next->len + 2 > MAX_CHAIN_LEN)
+        if (chain_len + next->len + boundary_len > MAX_CHAIN_LEN)
             break;
 
         TAILQ_REMOVE(&conn->wreqs, next, _next);
         model_list_append(&req->chain, next);
-        chain_len += (next->len + 2);
+        chain_len += (next->len + boundary_len);
     }
 
     if (model_list_size(&req->chain) > 0) {
@@ -823,7 +839,8 @@ static bool flush_to_service(ziti_connection conn) {
         TAILQ_REMOVE(&conn->wreqs, req, _next);
 
         if (conn->state == Connected || req->close) {
-            if (conn->can_send_multipart && !req->close && !req->eof) {
+            if ((conn->flags & (EDGE_MULTIPART | EDGE_STREAM)) &&
+                !req->close && !req->eof) {
                 chain_data_requests(conn, req);
             }
 
@@ -922,7 +939,7 @@ void conn_inbound_data_msg(ziti_connection conn, message *msg) {
                 int crypto_rc = crypto_secretstream_xchacha20poly1305_pull(&conn->crypt_i,
                                                                            plain_text, &plain_len, &tag,
                                                                            msg->body, msg->header.body_len, NULL, 0);
-                if (crypto_rc != 0) {
+                if (crypto_rc != 0 && (conn->flags & EDGE_TRACE_UUID)) {
                     // try to figure out the cause of crypto error
                     struct msg_uuid *uuid;
                     size_t uuid_len;
@@ -938,9 +955,9 @@ void conn_inbound_data_msg(ziti_connection conn, message *msg) {
                         CONN_LOG(ERROR, "message/state corruption hash[" HASH_FMT "]",
                                  HASH_FMT_ARG(h));
                     }
-
-                    TRY(crypto, crypto_rc);
                 }
+
+                TRY(crypto, crypto_rc);
                 CONN_LOG(VERBOSE, "decrypted %lld bytes tag[%x]", plain_len, (int)tag);
             }
         }
@@ -958,7 +975,7 @@ void conn_inbound_data_msg(ziti_connection conn, message *msg) {
     }
 
     if (plain_text) {
-        if (flags & EDGE_MULTIPART) {
+        if (flags & EDGE_MULTIPART_MSG) {
             CONN_LOG(TRACE, "chunking multipart[%llu] message", plain_len);
             uint8_t *end = plain_text + plain_len;
             uint8_t *p = plain_text;
@@ -1366,21 +1383,25 @@ static void process_edge_message(struct ziti_conn *conn, message *msg) {
     assert(has_conn_id && conn_id == conn->conn_id);
 
     message_get_int32_header(msg, FlagsHeader, (int32_t*)&flags);
-    if (flags & EDGE_ACCEPT_MULTIPART) {
-        CONN_LOG(DEBUG, "peer can accept multipart payload");
-        conn->can_send_multipart = true;
+    uint32_t caps = flags & CONN_CAP_MASK;
+    if (caps != 0) {
+        CONN_LOG(DEBUG, "peer capability: stream[%s] multipart[%s] trace[%s]",
+                 BOOL_STR(caps & EDGE_STREAM), BOOL_STR(caps & EDGE_MULTIPART), BOOL_STR(caps & EDGE_TRACE_UUID)
+        );
+        conn->flags |= caps;
     }
 
-    if (message_get_bytes_header(msg, UUIDHeader, (const uint8_t **) &uuid, &uuid_len)) {
+    if ((conn->flags & EDGE_TRACE_UUID) &&
+        message_get_bytes_header(msg, UUIDHeader, (const uint8_t **) &uuid, &uuid_len)) {
         struct local_hash h;
         crypto_hash_sha256(h.hash, msg->body, msg->header.body_len);
         CONN_LOG(TRACE, "<= ct[%04X] uuid[" UUID_FMT "] edge_seq[%d] len[%d] ",
                  msg->header.content, UUID_FMT_ARG(uuid), seq, msg->header.body_len);
 
-        if (uuid->seq != conn->in_msg_seq + 1) {
+        if (uuid->seq != conn->in_msg_seq) {
             CONN_LOG(WARN, "unexpected msg_seq[%d] previous[%d]", uuid->seq, conn->in_msg_seq);
         }
-        conn->in_msg_seq = uuid->seq;
+        conn->in_msg_seq = uuid->seq + 1;
     } else {
         CONN_LOG(TRACE, "<= ct[%04X] edge_seq[%d] len[%d]", msg->header.content, seq, msg->header.body_len);
     }

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -282,7 +282,10 @@ static void on_client(uv_stream_t *server, int status) {
 
     PREPF(ziti, ziti_errorstr);
     TRY(ziti, ziti_conn_init(l->app_ctx->ziti, &clt->ziti_conn, c));
-    TRY(ziti, ziti_dial(clt->ziti_conn, l->service_name, on_ziti_connect, NULL));
+    ziti_dial_opts opts = {
+            .stream = true,
+    };
+    TRY(ziti, ziti_dial_with_options(clt->ziti_conn, l->service_name, &opts, on_ziti_connect, NULL));
     c->data = clt;
 
     CATCH(ziti) {


### PR DESCRIPTION
this change allows payload consolidations in order to reduce overlay overhead.
two consolidations modes are supported:
- stream: this mode can be set by application via `ziti_dial_option.stream` flag. This allows SDK to consolidate write request into one overlay message without preserving message boundaries.
- multipart: enabled if peer indicates that it can accept multipart messages. this allows SDK to consolidate write requests into one overlay message while preserving message boundaries.

[fixed #279]