### PR TITLE
Update success page

### DIFF
--- a/library/oidc.c
+++ b/library/oidc.c
@@ -479,7 +479,7 @@ static void ext_accept(uv_work_t *wr) {
             "<!DOCTYPE html>\n"
             "<html lang=\"en\">\n"
             "<head>\n"
-            "    <title>Successful Authentication to External Provider</title>\n"
+            "    <title>OpenZiti: Successful Authentication to External Provider.</title>\n"
             "    <script>\n"
             "        function closeWindow() {\n"
             "            setTimeout(function() {\n"
@@ -489,6 +489,7 @@ static void ext_accept(uv_work_t *wr) {
             "    </script>\n"
             "</head>\n"
             "<body onload=\"closeWindow()\">\n"
+            "    <img height=\"40px\" src=\"https://openziti.io/img/ziti-logo-dark.svg\"/>"
             "    <h2>Successfully authenticated to external provider.</h2><p>You may close this page. It will attempt to close itself in 3 seconds.</p>\n"
             "</body>\n"
             "</html>\n";

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -479,7 +479,7 @@ static void ext_accept(uv_work_t *wr) {
             "<!DOCTYPE html>\n"
             "<html lang=\"en\">\n"
             "<head>\n"
-            "    <title>OpenZiti: Successful Authentication to External Provider.</title>\n"
+            "    <title>OpenZiti: Successful Authentication with External Provider.</title>\n"
             "    <script>\n"
             "        function closeWindow() {\n"
             "            setTimeout(function() {\n"
@@ -490,7 +490,7 @@ static void ext_accept(uv_work_t *wr) {
             "</head>\n"
             "<body onload=\"closeWindow()\">\n"
             "    <img height=\"40px\" src=\"https://openziti.io/img/ziti-logo-dark.svg\"/>"
-            "    <h2>Successfully authenticated to external provider.</h2><p>You may close this page. It will attempt to close itself in 3 seconds.</p>\n"
+            "    <h2>Successfully authenticated with external provider.</h2><p>You may close this page. It will attempt to close itself in 3 seconds.</p>\n"
             "</body>\n"
             "</html>\n";
 #define RESP_FMT "HTTP/1.0 200 OK\r\n"\

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -475,8 +475,23 @@ static void ext_accept(uv_work_t *wr) {
     string_buf_t resp_buf;
     string_buf_init(&resp_buf);
 
-    char resp_body[] = "<script type=\"text/javascript\">window.close()</script>"
-                       "<body onload=\"window.close()\">You may close this window</body>";
+    const char resp_body[] =
+            "<!DOCTYPE html>\n"
+            "<html lang=\"en\">\n"
+            "<head>\n"
+            "    <title>Successful Authentication to External Provider</title>\n"
+            "    <script>\n"
+            "        function closeWindow() {\n"
+            "            setTimeout(function() {\n"
+            "                window.close(); // Close the current window\n"
+            "            }, 3000);\n"
+            "        }\n"
+            "    </script>\n"
+            "</head>\n"
+            "<body onload=\"closeWindow()\">\n"
+            "    <h2>Successfully authenticated to external provider.</h2><p>You may close this page. It will attempt to close itself in 3 seconds.</p>\n"
+            "</body>\n"
+            "</html>\n";
 #define RESP_FMT "HTTP/1.0 200 OK\r\n"\
 "Connection: close\r\n"\
 "Content-Type: text/html\r\n"\


### PR DESCRIPTION
small tweak to the external provider successful login page to remain open for a few seconds and then try to auto close