### PR TITLE
fix backward compatibility: service bind

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -174,8 +174,10 @@ struct ziti_conn {
             ziti_listen_cb listen_cb;
             ziti_client_cb client_cb;
 
+            bool srv_routers_api_missing;
             ziti_edge_router_array routers;
             char *token;
+            ziti_session *session;
             model_map bindings;
             model_map children;
             uv_timer_t *timer;

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -90,7 +90,7 @@ typedef struct ziti_conn *ziti_connection;
  *
  * @see ziti_service_available(), ZITI_ERRORS
  */
-typedef void (*ziti_service_cb)(ziti_context ztx, ziti_service *, int status, void *data);
+typedef void (*ziti_service_cb)(ziti_context ztx, const ziti_service *, int status, void *data);
 
 /**
  * @brief Posture response MAC address callback

--- a/library/connect.c
+++ b/library/connect.c
@@ -420,7 +420,7 @@ static bool ziti_connect(struct ziti_ctx *ztx, ziti_session *session, struct zit
     return result;
 }
 
-static void connect_get_service_cb(ziti_context ztx, ziti_service *s, int status, void *ctx) {
+static void connect_get_service_cb(ziti_context ztx, const ziti_service *s, int status, void *ctx) {
     struct ziti_conn *conn = ctx;
     struct ziti_conn_req *req = conn->conn_req;
 


### PR DESCRIPTION
make sure we can bind to service on older networks -- prior to /service/(id)/edge-routers API availability

[fixes #757]