### PR TITLE
don't list routers until session is available

### DIFF
--- a/library/bind.c
+++ b/library/bind.c
@@ -489,6 +489,10 @@ void start_binding(struct binding_s *b, ziti_channel_t *ch) {
     struct ziti_conn *conn = b->conn;
     char *token = conn->server.token;
     CONN_LOG(TRACE, "ch[%d] => Edge Bind request token[%s]", ch->id, token);
+    if (!token) {
+        schedule_rebind(b->conn, true);
+        return;
+    }
 
     b->ch = ch;
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -252,7 +252,6 @@ static void list_routers_cb(ziti_service_routers *srv_routers, const ziti_error 
         }
     }
     free(srv_routers);
-ZITI_LOG(DEBUG, "calling process_bindings");
     process_bindings(conn);
 }
 
@@ -283,15 +282,15 @@ static void get_service_cb(ziti_context ztx, const ziti_service *service, int st
         conn->server.srv_routers_api_missing = false;
     }
 
-    if (!conn->server.srv_routers_api_missing) {
-        ziti_ctrl_list_service_routers(ztx_get_controller(ztx), service, list_routers_cb, conn);
-    }
-
     conn->encrypted = service->encryption;
     if (conn->server.token == NULL) {
         ziti_ctrl_create_session(ztx_get_controller(ztx), service->id, ziti_session_types.Bind, session_cb, conn);
     } else if (conn->server.srv_routers_api_missing) {
         ziti_ctrl_get_session(ztx_get_controller(ztx), conn->server.session->id, session_cb, conn);
+    }
+
+    if (!conn->server.srv_routers_api_missing) {
+        ziti_ctrl_list_service_routers(ztx_get_controller(ztx), service, list_routers_cb, conn);
     }
 }
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -146,10 +146,12 @@ static void process_bindings(struct ziti_conn *conn) {
 }
 
 static void schedule_rebind(struct ziti_conn *conn, bool now) {
+    if (now) ZITI_LOG(DEBUG, "it is now");
     if (!ziti_is_enabled(conn->ziti_ctx)) {
         uv_timer_stop(conn->server.timer);
         return;
     }
+    if (now) ZITI_LOG(DEBUG, "it is still now");
 
     uint64_t delay = REFRESH_DELAY;
 
@@ -490,6 +492,7 @@ void start_binding(struct binding_s *b, ziti_channel_t *ch) {
     char *token = conn->server.token;
     CONN_LOG(TRACE, "ch[%d] => Edge Bind request token[%s]", ch->id, token);
     if (!token) {
+        ZITI_LOG(DEBUG, "scheduling rebind now");
         schedule_rebind(b->conn, true);
         return;
     }

--- a/library/bind.c
+++ b/library/bind.c
@@ -142,16 +142,15 @@ static void process_bindings(struct ziti_conn *conn) {
         if (target <= 0) break;
     }
 
-    schedule_rebind(conn, true);
+    schedule_rebind(conn, target > 0);
 }
 
 static void schedule_rebind(struct ziti_conn *conn, bool now) {
-    if (now) ZITI_LOG(DEBUG, "it is now");
+    ZITI_LOG(DEBUG, "it is %snow", now ? "" : "not ");
     if (!ziti_is_enabled(conn->ziti_ctx)) {
         uv_timer_stop(conn->server.timer);
         return;
     }
-    if (now) ZITI_LOG(DEBUG, "it is still now");
 
     uint64_t delay = REFRESH_DELAY;
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -110,7 +110,6 @@ static void process_bindings(struct ziti_conn *conn) {
     struct ziti_ctx *ztx = conn->ziti_ctx;
 
     size_t target = MIN(conn->server.max_bindings, model_map_size(&ztx->channels));
-    ZITI_LOG(DEBUG, "target is %ld", target);
     const char *url;
     for(int idx = 0; conn->server.routers && conn->server.routers[idx]; idx++) {
         ziti_edge_router *er = conn->server.routers[idx];
@@ -141,7 +140,7 @@ static void process_bindings(struct ziti_conn *conn) {
         }
         if (target <= 0) break;
     }
-
+    ZITI_LOG(DEBUG, "target is %ld", target);
     schedule_rebind(conn, target > 0);
 }
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -110,6 +110,7 @@ static void process_bindings(struct ziti_conn *conn) {
     struct ziti_ctx *ztx = conn->ziti_ctx;
 
     size_t target = MIN(conn->server.max_bindings, model_map_size(&ztx->channels));
+    ZITI_LOG(DEBUG, "target is %ld", target);
     const char *url;
     for(int idx = 0; conn->server.routers && conn->server.routers[idx]; idx++) {
         ziti_edge_router *er = conn->server.routers[idx];
@@ -177,6 +178,7 @@ static void session_cb(ziti_session *session, const ziti_error *err, void *ctx) 
     switch (e) {
         case ZITI_OK: {
             FREE(conn->server.token);
+            ZITI_LOG(DEBUG, "session token: %s", session->token);
             conn->server.token = (char*)session->token;
             session->token = NULL;
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -142,7 +142,7 @@ static void process_bindings(struct ziti_conn *conn) {
         if (target <= 0) break;
     }
 
-    schedule_rebind(conn, target > 0);
+    schedule_rebind(conn, true);
 }
 
 static void schedule_rebind(struct ziti_conn *conn, bool now) {

--- a/library/bind.c
+++ b/library/bind.c
@@ -195,6 +195,7 @@ static void session_cb(ziti_session *session, const ziti_error *err, void *ctx) 
                     conn->server.routers[idx++] = er;
                 }
                 model_list_clear(&session->edge_routers, NULL);
+                ZITI_LOG(DEBUG, "calling process_bindings");
                 process_bindings(conn);
             }
 
@@ -251,7 +252,7 @@ static void list_routers_cb(ziti_service_routers *srv_routers, const ziti_error 
         }
     }
     free(srv_routers);
-
+ZITI_LOG(DEBUG, "calling process_bindings");
     process_bindings(conn);
 }
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -110,6 +110,7 @@ static void process_bindings(struct ziti_conn *conn) {
     struct ziti_ctx *ztx = conn->ziti_ctx;
 
     size_t target = MIN(conn->server.max_bindings, model_map_size(&ztx->channels));
+
     const char *url;
     for(int idx = 0; conn->server.routers && conn->server.routers[idx]; idx++) {
         ziti_edge_router *er = conn->server.routers[idx];
@@ -140,7 +141,7 @@ static void process_bindings(struct ziti_conn *conn) {
         }
         if (target <= 0) break;
     }
-    ZITI_LOG(DEBUG, "target is %ld", target);
+
     schedule_rebind(conn, target > 0);
 }
 
@@ -248,6 +249,7 @@ static void list_routers_cb(ziti_service_routers *srv_routers, const ziti_error 
         }
     }
     free(srv_routers);
+
     process_bindings(conn);
 }
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -110,7 +110,6 @@ static void process_bindings(struct ziti_conn *conn) {
     struct ziti_ctx *ztx = conn->ziti_ctx;
 
     size_t target = MIN(conn->server.max_bindings, model_map_size(&ztx->channels));
-    ZITI_LOG(DEBUG, "target is %ld", target);
     const char *url;
     for(int idx = 0; conn->server.routers && conn->server.routers[idx]; idx++) {
         ziti_edge_router *er = conn->server.routers[idx];
@@ -146,7 +145,6 @@ static void process_bindings(struct ziti_conn *conn) {
 }
 
 static void schedule_rebind(struct ziti_conn *conn, bool now) {
-    ZITI_LOG(DEBUG, "it is %snow", now ? "" : "not ");
     if (!ziti_is_enabled(conn->ziti_ctx)) {
         uv_timer_stop(conn->server.timer);
         return;
@@ -178,7 +176,6 @@ static void session_cb(ziti_session *session, const ziti_error *err, void *ctx) 
     switch (e) {
         case ZITI_OK: {
             FREE(conn->server.token);
-            ZITI_LOG(DEBUG, "session token: %s", session->token);
             conn->server.token = (char*)session->token;
             session->token = NULL;
 
@@ -195,7 +192,6 @@ static void session_cb(ziti_session *session, const ziti_error *err, void *ctx) 
                     conn->server.routers[idx++] = er;
                 }
                 model_list_clear(&session->edge_routers, NULL);
-                ZITI_LOG(DEBUG, "calling process_bindings");
                 process_bindings(conn);
             }
 
@@ -491,11 +487,6 @@ void start_binding(struct binding_s *b, ziti_channel_t *ch) {
     struct ziti_conn *conn = b->conn;
     char *token = conn->server.token;
     CONN_LOG(TRACE, "ch[%d] => Edge Bind request token[%s]", ch->id, token);
-    if (!token) {
-        ZITI_LOG(DEBUG, "scheduling rebind now");
-        schedule_rebind(b->conn, true);
-        return;
-    }
 
     b->ch = ch;
 

--- a/library/bind.c
+++ b/library/bind.c
@@ -110,7 +110,7 @@ static void process_bindings(struct ziti_conn *conn) {
     struct ziti_ctx *ztx = conn->ziti_ctx;
 
     size_t target = MIN(conn->server.max_bindings, model_map_size(&ztx->channels));
-
+    ZITI_LOG(DEBUG, "target is %ld", target);
     const char *url;
     for(int idx = 0; conn->server.routers && conn->server.routers[idx]; idx++) {
         ziti_edge_router *er = conn->server.routers[idx];


### PR DESCRIPTION
list_routers_cb calls process_bindings, which needs the session