### PR TITLE
ziti config event: replaces ZitiAPIEvent

### DIFF
--- a/includes/ziti/ziti_events.h
+++ b/includes/ziti/ziti_events.h
@@ -34,7 +34,7 @@ typedef enum {
     ZitiRouterEvent = 1 << 1,
     ZitiServiceEvent = 1 << 2,
     ZitiAuthEvent = 1 << 3,
-    ZitiAPIEvent = 1 << 4,
+    ZitiConfigEvent = 1 << 4,
 } ziti_event_type;
 
 /**
@@ -69,9 +69,9 @@ struct ctrl_detail_s {
     bool active;
 };
 
-struct ziti_api_event {
-    const char *new_ctrl_address;
-    const char *new_ca_bundle;
+struct ziti_config_event {
+    const char *identity_name;
+    const ziti_config *config;
 };
 /**
  * \brief Edge Router Event.
@@ -147,7 +147,7 @@ typedef struct ziti_event_s {
         struct ziti_router_event router;
         struct ziti_service_event service;
         struct ziti_auth_event auth;
-        struct ziti_api_event api;
+        struct ziti_config_event cfg;
     };
 } ziti_event_t;
 

--- a/library/config.c
+++ b/library/config.c
@@ -77,5 +77,9 @@ int ziti_load_config(ziti_config *cfg, const char *cfgstr) {
         return rc;
     }
 
+    if (model_list_size(&cfg->controllers) == 0 && cfg->controller_url == NULL) {
+        return ZITI_INVALID_CONFIG;
+    }
+
     return ZITI_OK;
 }

--- a/library/config.c
+++ b/library/config.c
@@ -77,14 +77,5 @@ int ziti_load_config(ziti_config *cfg, const char *cfgstr) {
         return rc;
     }
 
-    if (model_list_size(&cfg->controllers) == 0 && cfg->controller_url == NULL) {
-        return ZITI_INVALID_CONFIG;
-    }
-
-    if (model_list_size(&cfg->controllers) == 0) {
-        model_list_append(&cfg->controllers, (void*)cfg->controller_url);
-        cfg->controller_url = NULL;
-    }
-
     return ZITI_OK;
 }

--- a/library/model_support.c
+++ b/library/model_support.c
@@ -341,12 +341,15 @@ int write_model_to_buf(const void *obj, const type_meta *meta, string_buf_t *buf
 
             int idx = 0;
             BUF_APPEND_B(buf, '[');
+            PRETTY_NL(buf);
             MODEL_LIST_FOREACH(f_ptr, *list) {
                 if (f_ptr == NULL) { break; }
                 if (idx++ > 0) {
                     BUF_APPEND_B(buf, ',');
+                    PRETTY_NL(buf);
                 }
 
+                PRETTY_INDENT(buf, indent + 1);
                 if (ftm->jsonifier) {
                     if (ftm == get_model_number_meta() || ftm == get_model_bool_meta()) {
                         CHECK_APPEND(ftm->jsonifier(&f_ptr, buf, indent + 1, flags));
@@ -357,18 +360,23 @@ int write_model_to_buf(const void *obj, const type_meta *meta, string_buf_t *buf
                     CHECK_APPEND(write_model_to_buf(f_ptr, ftm, buf, indent + 1, flags));
                 }
             }
+            PRETTY_NL(buf);
+            PRETTY_INDENT(buf, indent);
             BUF_APPEND_B(buf, ']');
         } else if (fm->mod == array_mod) {
             void **arr = (void **) (*f_addr);
 
             BUF_APPEND_B(buf, '[');
+            PRETTY_NL(buf);
             for (int idx = 0; true; idx++) {
                 f_ptr = arr[idx];
                 if (f_ptr == NULL) { break; }
                 if (idx > 0) {
                     BUF_APPEND_B(buf, ',');
+                    PRETTY_NL(buf);
                 }
 
+                PRETTY_INDENT(buf, indent + 1);
                 if (ftm->jsonifier) {
                     CHECK_APPEND(ftm->jsonifier(f_ptr, buf, indent + 1, flags));
                 }
@@ -376,16 +384,17 @@ int write_model_to_buf(const void *obj, const type_meta *meta, string_buf_t *buf
                     CHECK_APPEND(write_model_to_buf(f_ptr, ftm, buf, indent + 1, flags));
                 }
             }
+            PRETTY_NL(buf);
+            PRETTY_INDENT(buf, indent);
             BUF_APPEND_B(buf, ']');
-        }
-        else {
+        } else {
             ZITI_LOG(ERROR, "unsupported mod[%d] for field[%s]", fm->mod, fm->name);
             return -1;
         }
         comma = true;
     }
     PRETTY_NL(buf);
-    PRETTY_INDENT(buf, indent);
+    PRETTY_INDENT(buf, indent - 1);
     BUF_APPEND_B(buf, '}');
     return 0;
 }

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -12,42 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <ziti/ziti.h>
 #include <uv.h>
-#include <assert.h>
+
+#include <ziti/ziti.h>
 #include "utils.h"
 #include "zt_internal.h"
-
-
-typedef struct enroll_cfg_s {
-
-    ziti_enroll_cb external_enroll_cb;
-    void *external_enroll_ctx;
-
-    ziti_enrollment_jwt_header jwt_header;
-    ziti_enrollment_jwt zej;
-    char *raw_jwt;
-    unsigned char *jwt_signing_input;
-    char *jwt_sig;
-    size_t jwt_sig_len;
-
-    tls_context *tls;
-    ziti_controller *ctrl;
-
-    char *CA;
-
-    bool use_keychain;
-    const char *private_key;
-    tlsuv_private_key_t pk;
-    tlsuv_certificate_t cert;
-    const char *own_cert;
-    const char *name;
-
-    char *csr_pem;
-} enroll_cfg;
 
 
 struct ziti_enroll_req {

--- a/programs/auth-samples/jwt_auth.cpp
+++ b/programs/auth-samples/jwt_auth.cpp
@@ -113,7 +113,7 @@ static void event_handler(ziti_context ztx, const ziti_event_t *ev){
             break;
         case ZitiRouterEvent:
         case ZitiServiceEvent:
-        case ZitiAPIEvent:
+        case ZitiConfigEvent:
             break;
     }
 }

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -440,10 +440,12 @@ static void service_check_cb(ziti_context ztx, ziti_service *service, int status
 static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
     struct proxy_app_ctx *app_ctx = ziti_app_ctx(ztx);
     switch (event->type) {
-        case ZitiAPIEvent:
-            if (event->api.new_ctrl_address) ZITI_LOG(INFO, "update API URL to %s", event->api.new_ctrl_address);
-            if (event->api.new_ca_bundle) ZITI_LOG(INFO, "update CA bundle to %s", event->api.new_ca_bundle);
+        case ZitiConfigEvent: {
+            char *cfg = ziti_config_to_json(event->cfg.config, 0, NULL);
+            printf("new config:\n%s\n\n", cfg);
+            free(cfg);
             break;
+        }
 
         case ZitiContextEvent:
             if (event->ctx.ctrl_status == ZITI_OK) {

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -802,6 +802,7 @@ int run_proxy(struct run_opts *opts) {
 
     ziti_load_config(&cfg, opts->identity);
     ziti_context_init(&app_ctx.ziti, &cfg);
+    free_ziti_config(&cfg);
 
     ziti_options zopts = {
             .events = -1,

--- a/tests/enum_tests.cpp
+++ b/tests/enum_tests.cpp
@@ -139,7 +139,7 @@ TEST_CASE("parse enum array", "[model]") {
     CHECK(f1.states[2] == nullptr);
 
     size_t json_len;
-    auto js = FooWithEnumArray_to_json(&f1, 0, &json_len);
+    auto js = FooWithEnumArray_to_json(&f1, MODEL_JSON_COMPACT, &json_len);
 
     CHECK_THAT(js, Catch::Matchers::ContainsSubstring(R"("states":["Ugly","Bad"])"));
 
@@ -173,7 +173,7 @@ TEST_CASE("parse enum list", "[model]") {
 
 
     size_t json_len;
-    auto js = FooWithEnumList_to_json(&f1, 0, &json_len);
+    auto js = FooWithEnumList_to_json(&f1, MODEL_JSON_COMPACT, &json_len);
 
     CHECK_THAT(js, Catch::Matchers::ContainsSubstring(R"("states":["Ugly","Bad"])"));
 


### PR DESCRIPTION
ziti config event contains the most up-to-date configuration information: list of controllers, CA bundle

the app using the SDK is responsible for persisting (if desired) the new configuration for next start

[fixes #743]