### PR TITLE
Improve parse message

### DIFF
--- a/inc_internal/message.h
+++ b/inc_internal/message.h
@@ -27,7 +27,10 @@
 
 #define MAGIC_INIT {0x3, 0x6, 0x9, 0xC}
 
-typedef char magic_t[4];
+typedef union {
+    char magic[4];
+    int32_t magint;
+} magic_t;
 
 #define HEADER_FIELDS(XX) \
 XX(content, uint32_t)\
@@ -52,7 +55,7 @@ static header_t EMPTY_HEADER = {
 typedef struct {
     uint32_t header_id;
     uint32_t length;
-    uint8_t *value;
+    const uint8_t *value;
 } hdr_t;
 
 #define var_header(id, var) header(id, sizeof(var), &(var))
@@ -97,9 +100,9 @@ bool message_get_bytes_header(message *m, int header_id, const uint8_t **ptr, si
 
 uint8_t *write_hdr(const hdr_t *h, uint8_t *buf);
 
-int parse_hdrs(uint8_t *buf, uint32_t len, hdr_t **hp);
+int parse_hdrs(const uint8_t *buf, uint32_t len, hdr_t **hp);
 
-message *message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE]);
+int message_new_from_header(pool_t *pool, uint8_t buf[HEADER_SIZE], message **msg_p);
 
 message *message_new(pool_t *pool, uint32_t content, const hdr_t *headers, int nheaders, size_t body_len);
 

--- a/includes/ziti/errors.h
+++ b/includes/ziti/errors.h
@@ -111,6 +111,8 @@ is offline or did not respond to the request*/
 #define ZITI_CERT_FAILED_VALIDATION                             (-36)
 /** returned when the certificate doesn't have an externalId") \*/
 #define ZITI_MISSING_CERT_CLAIM                                 (-37)
+/** ziti could not allocate memory */
+#define ZITI_ALLOC_FAILED                                       (-38)
 
 
 // Put new error codes here and add error string in error.c

--- a/library/errors.c
+++ b/library/errors.c
@@ -53,6 +53,7 @@
     XX(CERT_IN_USE,"the provided certificate already in use")       \
     XX(CERT_FAILED_VALIDATION, "the provided key/cert are invalid") \
     XX(MISSING_CERT_CLAIM, "the certificate is expected to contain an externalId but none was not found") \
+    XX(ALLOC_FAILED, "memory allocation failed") \
     XX(WTF, "WTF: programming error")
 
 

--- a/programs/ziti-prox-c/main.cpp
+++ b/programs/ziti-prox-c/main.cpp
@@ -32,7 +32,7 @@ public:
 
     Run(): App("run proxy", "run"),
            debug(2) {
-        add_option("--debug,-d", debug, "log level")->envname("ZITI_LOG");
+        add_option("--debug,-d", debug, "log level");
         add_option("--identity,-i", identity, "identity config")->required();
         add_option("listener", intercepts, "<name:port>");
         add_option("--bind,-b", bindings, "bind service <name:host:port>");

--- a/tests/message_tests.cpp
+++ b/tests/message_tests.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 #include "message.h"
 #include "edge_protocol.h"
+#include "ziti/errors.h"
 
 TEST_CASE("simple", "[model]") {
     auto p = pool_new(sizeof(message) + 200, 3, (void (*)(void *)) message_free);
@@ -39,7 +40,8 @@ TEST_CASE("simple", "[model]") {
     strncpy(reinterpret_cast<char *>(m1->body), content1, strlen(content1));
     message_set_seq(m1, &s1);
 
-    auto m2 = message_new_from_header(p, m1->msgbufp);
+    message *m2;
+    REQUIRE(message_new_from_header(p, m1->msgbufp, &m2) == ZITI_OK);
     CHECK(m2->header.seq == 3334);
     CHECK(m2->msgbuflen == m1->msgbuflen);
     memcpy(m2->msgbufp, m1->msgbufp, m1->msgbuflen);
@@ -83,7 +85,8 @@ TEST_CASE("large", "[model]") {
     message_set_seq(m1, &seq);
 
 
-    auto m2 = message_new_from_header(p, m1->msgbufp);
+    message *m2;
+    REQUIRE(message_new_from_header(p, m1->msgbufp, &m2) == ZITI_OK);
     CHECK(m2->header.seq == 3334);
     CHECK(seq == 3334);
     CHECK(m2->msgbuflen == m1->msgbuflen);
@@ -126,7 +129,8 @@ TEST_CASE("large unpooled", "[model]") {
     strncpy(reinterpret_cast<char *>(m1->body), content1, strlen(content1));
     message_set_seq(m1, &seq);
 
-    auto m2 = message_new_from_header(nullptr, m1->msgbufp);
+    message *m2;
+    REQUIRE(message_new_from_header(nullptr, m1->msgbufp, &m2) == ZITI_OK);
     CHECK(m2->header.seq == 3334);
     CHECK(seq == 3334);
     CHECK(m2->msgbuflen == m1->msgbuflen);


### PR DESCRIPTION
it appears that on some Android devices `realloc()` may fail

- avoid `realloc` altogether
- check for memory allocation and message alignment

[see openziti/ziti-tunnel-android#240]