### PR TITLE
Avoid bind crypto errors

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -179,7 +179,7 @@ struct ziti_conn {
             ziti_client_cb client_cb;
 
             bool srv_routers_api_missing;
-            ziti_edge_router_array routers;
+            model_list routers;
             char *token;
             ziti_session *session;
             model_map bindings;

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -827,6 +827,12 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
     printer(ctx, "tlsuv:    %s (%s)\n", tlsuv_version(), ztx->tlsCtx->version());
     printer(ctx, "sodium:   %s\n", sodium_version_string());
     printer(ctx, "libuv:    %s\n", uv_version_string());
+
+    printer(ctx, "\n======= Env Info ==========\n");
+    const ziti_env_info *info = get_env_info();
+    printer(ctx, "OS/arch:  %s %s (%s/%s)\n", info->os, info->arch, info->os_release, info->os_version);
+    printer(ctx, "Hostname: %s/%s\n", info->hostname, info->domain);
+
     printer(ctx, "\n=================\nZiti Context:\n");
     printer(ctx, "ID:\t%d\n", ztx->id);
     if (ziti_is_enabled(ztx)) {


### PR DESCRIPTION
Need to preserve e2ee keys between bind since network may reuse existing terminator without updating key data