### PR TITLE
fix HA enrollment: alternate controllers cannot be used for enrollment

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT TARGET tlsuv)
     else ()
         FetchContent_Declare(tlsuv
                 GIT_REPOSITORY https://github.com/openziti/tlsuv.git
-                GIT_TAG v0.33.1
+                GIT_TAG v0.33.2
         )
         FetchContent_MakeAvailable(tlsuv)
     endif (tlsuv_DIR)

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -240,10 +240,6 @@ static int start_enrollment(struct ziti_enroll_req *er) {
 
     er->cfg.controller_url = strdup(er->enrollment.controller);
     model_list_append(&er->cfg.controllers, strdup(er->enrollment.controller));
-    const char* ctrl;
-    MODEL_LIST_FOREACH(ctrl, er->enrollment.controllers) {
-        model_list_append(&er->cfg.controllers, strdup(ctrl));
-    }
     ziti_ctrl_init(er->loop, &er->controller, &er->cfg.controllers, er->tls);
 
     ziti_ctrl_get_well_known_certs(&er->controller, well_known_certs_cb, er);


### PR DESCRIPTION
JWT won't validate

using alternate controllers will be implemented once controllers support it