### PR TITLE
Allow better dev debugging

### DIFF
--- a/library/utils.c
+++ b/library/utils.c
@@ -321,7 +321,11 @@ static const char *basename(const char *path) {
 }
 
 void ziti_logger(int level, const char *module, const char *file, unsigned int line, const char *func, FORMAT_STRING(const char *fmt), ...) {
+#ifdef ZITI_DEBUG
+    static size_t loglinelen = 32768;
+#else
     static size_t loglinelen = 1024;
+#endif
 
     log_writer logfunc = logger;
     if (logfunc == NULL) { return; }

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -430,6 +430,9 @@ static void ctrl_body_cb(tlsuv_http_req_t *req, char *b, ssize_t len) {
     if (len > 0) {
         if (resp->resp_content == ctrl_content_json) {
             if (resp->content == NULL) {
+#ifdef ZITI_DEBUG
+                CTRL_LOG(DEBUG, "HTTP RESPONSE: %s", b);
+#endif
                 resp->content = json_tokener_parse_ex(resp->content_proc, b, (int) len);
                 if (resp->content == NULL && json_tokener_get_error(resp->content_proc) != json_tokener_continue) {
                     CTRL_LOG(WARN, "parsing error: %s",


### PR DESCRIPTION
if ZITI_DEBUG is defined, change the log len to much longer and allow debugging the http responses from the controller