### PR TITLE
Extend identity cert

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -56,11 +56,12 @@ XX(expires, timestamp, none, expiresAt, __VA_ARGS__) \
 XX(expireSeconds, model_number, none, expirationSeconds, __VA_ARGS__) \
 XX(updated, timestamp, none, updatedAt, __VA_ARGS__) \
 XX(cached_last_activity_at, timestamp, none, cachedLastActivityAt, __VA_ARGS__) \
+XX(identity_id, model_string, none, identityId, __VA_ARGS__) \
 XX(identity, ziti_identity, none, identity, __VA_ARGS__) \
 XX(posture_query_set, ziti_posture_query_set, array, postureQueries, __VA_ARGS__) \
-XX(is_mfa_required, model_bool, none, IsMfaRequired, __VA_ARGS__) \
-XX(is_mfa_complete, model_bool, none, IsMfaComplete, __VA_ARGS__) \
-XX(is_cert_extendable, model_bool, none, IsCertExtendable, __VA_ARGS__) \
+XX(is_mfa_required, model_bool, none, isMfaRequired, __VA_ARGS__) \
+XX(is_mfa_complete, model_bool, none, isMfaComplete, __VA_ARGS__) \
+XX(is_cert_extendable, model_bool, none, isCertExtendable, __VA_ARGS__) \
 XX(auth_queries, ziti_auth_query_mfa, list, authQueries, __VA_ARGS__) \
 XX(authenticator_id, model_string, none, authenticatorId, __VA_ARGS__)
 

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -249,6 +249,15 @@ typedef struct ziti_options_s {
      * \brief callback invoked is response to subscribed events.
      */
     ziti_event_cb event_cb;
+
+    /**
+     * \brief this setting allows SDK to auto-extend identity certificate.
+     *
+     * This only applies if certificate was issued by the OpenZiti network.
+     * The application must handle [ZitiConfigEvent] to capture and save
+     * the newly issued certificate.
+     */
+    bool enable_cert_extension;
 } ziti_options;
 
 typedef struct ziti_dial_opts_s {

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -256,8 +256,11 @@ typedef struct ziti_options_s {
      * This only applies if certificate was issued by the OpenZiti network.
      * The application must handle [ZitiConfigEvent] to capture and save
      * the newly issued certificate.
+     * SDK will extend certificate when expiration date falls
+     * in the next [cert_extension_window] days.
+     * To enable certificate extension the value must be greater than 0
      */
-    bool enable_cert_extension;
+    unsigned int cert_extension_window;
 } ziti_options;
 
 typedef struct ziti_dial_opts_s {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -22,6 +22,7 @@
 #include <auth_queries.h>
 #include <uv.h>
 #include <assert.h>
+#include <time.h>
 
 #if _WIN32
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -421,7 +421,7 @@ void ziti_set_fully_authenticated(ziti_context ztx, const char *session_token) {
         ziti_ctrl_create_api_certificate(ztx_get_controller(ztx), ztx->sessionCsr, on_create_cert, ztx);
     }
 
-    if (ztx->id_creds.cert && ztx->id_creds.cert->get_expiration) {
+    if (ztx->opts.enable_cert_extension && ztx->id_creds.cert) {
         struct tm exp;
 
         ztx->id_creds.cert->get_expiration(ztx->id_creds.cert, &exp);
@@ -1891,6 +1891,7 @@ int ziti_context_set_options(ziti_context ztx, const ziti_options *options) {
         copy_opt(pq_mac_cb);
         copy_opt(pq_os_cb);
         copy_opt(pq_process_cb);
+        copy_opt(enable_cert_extension);
 
 #undef copy_opt
     }

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -40,7 +40,7 @@
 #endif
 #endif
 
-#define TEN_DAYS (60 * 60 * 24 * 10)
+#define ONE_DAY (60 * 60 * 24)
 
 #define ztx_controller(ztx) \
 ((ztx)->ctrl.url ? (ztx)->ctrl.url : (ztx)->config.controller_url)
@@ -421,14 +421,14 @@ void ziti_set_fully_authenticated(ziti_context ztx, const char *session_token) {
         ziti_ctrl_create_api_certificate(ztx_get_controller(ztx), ztx->sessionCsr, on_create_cert, ztx);
     }
 
-    if (ztx->opts.enable_cert_extension && ztx->id_creds.cert) {
+    if (ztx->opts.cert_extension_window && ztx->id_creds.cert) {
         struct tm exp;
 
         ztx->id_creds.cert->get_expiration(ztx->id_creds.cert, &exp);
         time_t now = time(0);
         time_t exptime = mktime(&exp);
 
-        bool renew = exptime - now < TEN_DAYS;
+        bool renew = exptime - now < ztx->opts.cert_extension_window * ONE_DAY;
         if (renew) {
             if (ztx->opts.events & ZitiConfigEvent) {
                 ZTX_LOG(INFO, "renewing identity certificate exp[%04d-%02d-%02d %02d:%02d]",
@@ -1891,7 +1891,7 @@ int ziti_context_set_options(ziti_context ztx, const ziti_options *options) {
         copy_opt(pq_mac_cb);
         copy_opt(pq_os_cb);
         copy_opt(pq_process_cb);
-        copy_opt(enable_cert_extension);
+        copy_opt(cert_extension_window);
 
 #undef copy_opt
     }


### PR DESCRIPTION
in order to enable identity certificate auto-extension, an application must do the following:
- set `ziti_option.enable_cert_extension` and handle `ZitiConfigEvent`
- applicaiton must save the new certificate chain delivered as part of ZitiConfigEvent

[fixes #700]