### PR TITLE
fix ziti_shutdown(): trying to logout sometimes lead to crashes

### DIFF
--- a/library/ziti.c
+++ b/library/ziti.c
@@ -529,7 +529,7 @@ static void ziti_stop_internal(ziti_context ztx, void *data) {
 
         ziti_ctrl_cancel(ztx_get_controller(ztx));
         // logout
-        ziti_ctrl_logout(ztx_get_controller(ztx), logout_cb, ztx);
+        ziti_ctrl_clear_api_session(ztx_get_controller(ztx));
         update_ctrl_status(ztx, ZITI_DISABLED, ziti_errorstr(ZITI_DISABLED));
         ztx->enabled = false;
     }

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -689,6 +689,9 @@ static void on_http_close(tlsuv_http_t *clt) {
 }
 
 int ziti_ctrl_cancel(ziti_controller *ctrl) {
+    if (ctrl->client == NULL) {
+        return ZITI_OK;
+    }
     return tlsuv_http_cancel_all(ctrl->client);
 }
 


### PR DESCRIPTION
- in HA logout is superfluous