### PR TITLE
avoid unnecessarily disconnecting ERs

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -33,7 +33,6 @@ XX(tls, model_string, none, tls, __VA_ARGS__)
 
 #define ZITI_EDGE_ROUTER_MODEL(XX, ...)\
 XX(name, model_string, none, name, __VA_ARGS__)\
-XX(hostname, model_string, none, hostname, __VA_ARGS__) \
 XX(protocols, ziti_er_protocols, none, supportedProtocols, __VA_ARGS__)
 
 #define ZITI_SERVICE_EDGE_ROUTERS_MODEL(XX, ...) \

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -357,13 +357,15 @@ bool ziti_channel_is_connected(ziti_channel_t *ch);
 
 uint64_t ziti_channel_latency(ziti_channel_t *ch);
 
+void ziti_channel_set_url(ziti_channel_t *ch, const char *url);
+
 int ziti_channel_force_connect(ziti_channel_t *ch);
 
 int ziti_channel_update_token(ziti_channel_t *ch, const char *token);
 
 int ziti_channel_update_posture(ziti_channel_t *ch, const uint8_t *data, size_t len);
 
-int ziti_channel_connect(ziti_context ztx, const char *name, const char *url);
+int ziti_channel_connect(ziti_context ztx, const ziti_edge_router *er);
 
 int ziti_channel_prepare(ziti_channel_t *ch);
 

--- a/library/connect.c
+++ b/library/connect.c
@@ -388,23 +388,19 @@ static bool ziti_connect(struct ziti_ctx *ztx, ziti_session *session, struct zit
 
 
     MODEL_LIST_FOREACH(er, session->edge_routers) {
-        const char *tls = er->protocols.tls;
+        ch = model_map_get(&ztx->channels, er->name);
+        if (ch == NULL) continue;
 
-        if (tls) {
-            ch = model_map_get(&ztx->channels, tls);
-            if (ch == NULL) continue;
-
-            if (ch->state == Connected) {
-                uint64_t latency = ziti_channel_latency(ch);
-                if (latency < best_latency) {
-                    best_ch = ch;
-                    best_latency = latency;
-                }
+        if (ch->state == Connected) {
+            uint64_t latency = ziti_channel_latency(ch);
+            if (latency < best_latency) {
+                best_ch = ch;
+                best_latency = latency;
             }
+        }
 
-            if (ch->state == Disconnected) {
+        if (ch->state == Disconnected) {
                 model_list_append(&disconnected, ch);
-            }
         }
     }
 


### PR DESCRIPTION
avoid disconnecting edge router if controller has not refreshed ER model yet (usually after restart) -- TLS address may be missing

also, process possible ER advertised address changes

[fixes #861]