### PR TITLE
Windows/x86 build: fix artifacts names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,16 @@ if (ziti_DEVELOPER_MODE)
 endif ()
 
 if (ziti_ASAN)
-    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-    add_link_options(-fsanitize=address)
+    if (MSVC)
+        add_compile_options(/fsanitize=address)
+        add_compile_definitions(
+                _DISABLE_VECTOR_ANNOTATION
+                _DISABLE_STRING_ANNOTATION
+        )
+    else ()
+        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=address)
+    endif ()
 endif (ziti_ASAN)
 
 if (ziti_TEST_COVERAGE)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -101,6 +101,9 @@
         "vs-2022"
       ],
       "architecture": "Win32",
+      "cacheVariables": {
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/toolchains/Windows-x86-msvc.cmake"
+      },
       "hidden": true
     },
     {

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -187,7 +187,7 @@ function(config_ziti_library target)
     if (MSVC)
         target_compile_options(${target}
                 PUBLIC /experimental:c11atomics
-                PRIVATE /w4100
+                PRIVATE /wd4100 /wd4101 /wd4018
         )
     endif (MSVC)
 

--- a/toolchains/Windows-x86-msvc.cmake
+++ b/toolchains/Windows-x86-msvc.cmake
@@ -1,0 +1,8 @@
+# cross-compile for windows/x86 on windows/x64 host with visual studio
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86)
+# setting CMAKE_GENERATOR_PLATFORM should be sufficient if you believe the doc, it results in build files
+# that cause msbuild to that the ZERO_CHECK project doesn't contain the "Debug|x64" platform/config
+# combination. running cmake with '-A x86' avoids the msbuild failure.
+set(CMAKE_GENERATOR_PLATFORM Win32)
+set(CMAKE_C_COMPILER cl.exe)


### PR DESCRIPTION
enable address sanitizer on Windows/MSVC