### PR TITLE
fix clang/macOS warnings

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -119,7 +119,7 @@ struct ziti_channel {
 struct ziti_write_req_s {
     struct ziti_conn *conn;
     struct ziti_channel *ch;
-    uint8_t *buf;
+    const uint8_t *buf;
     size_t len;
     bool eof;
     bool close;

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -819,7 +819,7 @@ extern int ziti_close_write(ziti_connection conn);
  * @return #ZITI_OK or corresponding #ZITI_ERRORS
  */
 ZITI_FUNC
-extern int ziti_write(ziti_connection conn, uint8_t *data, size_t length, ziti_write_cb write_cb, void *write_ctx);
+extern int ziti_write(ziti_connection conn, const uint8_t *data, size_t length, ziti_write_cb write_cb, void *write_ctx);
 
 /**
  * @brief Bridge [ziti_connection] to a given IO stream

--- a/library/bind.c
+++ b/library/bind.c
@@ -391,7 +391,7 @@ static void process_inspect(struct binding_s *b, message *msg) {
     char conn_info[256];
     char listener_id[sodium_base64_ENCODED_LEN(sizeof(conn->server.listener_id), sodium_base64_VARIANT_URLSAFE)];
     sodium_bin2base64(listener_id, sizeof(listener_id),
-                      conn->server.listener_id, sizeof(conn->server.listener_id), sodium_base64_VARIANT_URLSAFE);
+                      (uint8_t *) conn->server.listener_id, sizeof(conn->server.listener_id), sodium_base64_VARIANT_URLSAFE);
     size_t ci_len = snprintf(conn_info, sizeof(conn_info),
                              "id[%d] serviceName[%s] listenerId[%s] "
                              "closed[%s] encrypted[%s]",
@@ -577,7 +577,7 @@ int start_binding(struct binding_s *b, ziti_channel_t *ch) {
 
     b->waiter = ziti_channel_send_for_reply(b->ch, ContentTypeBind,
                                             headers, nheaders,
-                                            token, strlen(token), bind_reply_cb,
+                                            (uint8_t *) token, strlen(token), bind_reply_cb,
                                             b);
     return 1;
 }
@@ -628,7 +628,7 @@ static void stop_binding(struct binding_s *b) {
     };
     b->waiter = ziti_channel_send_for_reply(b->ch, ContentTypeUnbind,
                                             headers, 2,
-                                            token, strlen(token),
+                                            (uint8_t *) token, strlen(token),
                                             on_unbind, b);
 }
 

--- a/library/channel.c
+++ b/library/channel.c
@@ -763,7 +763,7 @@ static void send_hello(ziti_channel_t *ch, const char *token) {
             },
     };
     ch->latency = uv_now(ch->loop);
-    ziti_channel_send_for_reply(ch, ContentTypeHelloType, headers, 2, ch->token, strlen(ch->token), hello_reply_cb, ch);
+    ziti_channel_send_for_reply(ch, ContentTypeHelloType, headers, 2, (uint8_t *) ch->token, strlen(ch->token), hello_reply_cb, ch);
 }
 
 
@@ -936,7 +936,7 @@ static void on_channel_data(uv_stream_t *s, ssize_t len, const uv_buf_t *buf) {
 
     CH_LOG(TRACE, "on_data [len=%zd]", len);
     ch->last_read = uv_now(ch->loop);
-    buffer_append(ch->incoming, buf->base, (uint32_t) len);
+    buffer_append(ch->incoming, (uint8_t *) buf->base, (uint32_t) len);
     process_inbound(ch);
 }
 

--- a/library/conn_bridge.c
+++ b/library/conn_bridge.c
@@ -357,7 +357,7 @@ void on_udp_input(uv_udp_t *udp, ssize_t len, const uv_buf_t *b, const struct so
     br_set_idle_timeout(br);
 
     if (len > 0) {
-        int rc = ziti_write(br->conn, b->base, len, on_ziti_write, b->base);
+        int rc = ziti_write(br->conn, (uint8_t *) b->base, len, on_ziti_write, b->base);
         if (rc != ZITI_OK) {
             BR_LOG(WARN, "ziti_write failed: %d/%s", rc, ziti_errorstr(rc));
             close_bridge(br);
@@ -383,7 +383,7 @@ void on_input(uv_stream_t *s, ssize_t len, const uv_buf_t *b) {
     br_set_idle_timeout(br);
 
     if (len > 0) {
-        int rc = ziti_write(br->conn, b->base, len, on_ziti_write, b->base);
+        int rc = ziti_write(br->conn, (uint8_t *) b->base, len, on_ziti_write, b->base);
         if (rc != ZITI_OK) {
             BR_LOG(WARN, "ziti_write failed: %d/%s", rc, ziti_errorstr(rc));
             close_bridge(br);

--- a/library/connect.c
+++ b/library/connect.c
@@ -1280,7 +1280,7 @@ int ziti_accept(ziti_connection conn, ziti_conn_cb cb, ziti_data_cb data_cb) {
     return rc;
 }
 
-int ziti_write(ziti_connection conn, uint8_t *data, size_t length, ziti_write_cb write_cb, void *write_ctx) {
+int ziti_write(ziti_connection conn, const uint8_t *data, size_t length, ziti_write_cb write_cb, void *write_ctx) {
     if (conn->fin_sent) {
         CONN_LOG(ERROR, "attempted write after ziti_close_write()");
         return ZITI_INVALID_STATE;

--- a/programs/auth-samples/jwt_auth.cpp
+++ b/programs/auth-samples/jwt_auth.cpp
@@ -98,6 +98,9 @@ static void on_auth_event(ziti_context ztx, const ziti_auth_event &ev) {
             }, ztx);
             break;
         }
+        default:
+            std::cout << "unhandled auth action " << ev.action;
+            break;
     }
 }
 

--- a/programs/sample-host/sample-host.c
+++ b/programs/sample-host/sample-host.c
@@ -39,7 +39,7 @@ static ssize_t on_client_data(ziti_connection clt, const uint8_t *data, ssize_t 
         printf("client sent:%.*s\n", (int) len, data);
         char *reply = malloc(128);
         size_t l = sprintf(reply, "%zd", len);
-        ziti_write(clt, reply, l, on_client_write, reply);
+        ziti_write(clt, (uint8_t *) reply, l, on_client_write, reply);
     }
     else if (len == ZITI_EOF) {
         printf("client disconnected\n");
@@ -54,8 +54,8 @@ static ssize_t on_client_data(ziti_connection clt, const uint8_t *data, ssize_t 
 
 static void on_client_connect(ziti_connection clt, int status) {
     if (status == ZITI_OK) {
-        uint8_t *msg = "Hello from byte counter!";
-        ziti_write(clt, msg, strlen(msg), on_client_write, NULL);
+        const char *msg = "Hello from byte counter!";
+        ziti_write(clt, (uint8_t *) msg, strlen(msg), on_client_write, NULL);
     }
 }
 
@@ -111,7 +111,7 @@ static void input_read(uv_stream_t *s, ssize_t len, const uv_buf_t *b) {
     ziti_connection conn = s->data;
 
     if (len > 0) {
-        DIE(ziti_write(conn, b->base, len, on_write, b->base));
+        DIE(ziti_write(conn, (uint8_t *) b->base, len, on_write, b->base));
     }
     else {
         exit(0);

--- a/programs/sample_wttr/sample_wttr.c
+++ b/programs/sample_wttr/sample_wttr.c
@@ -63,14 +63,14 @@ void on_connect(ziti_connection conn, int status) {
 
     printf("sending HTTP request\n");
 
-    uint8_t *req = "GET /Rochester HTTP/1.0\r\n"
+    const char *req = "GET /Rochester HTTP/1.0\r\n"
                    "Accept: */*\r\n"
                    "Connection: close\r\n"
                    "Host: wttr.in\r\n"
                    "User-Agent: curl/7.59.0\r\n"
                    "\r\n";
 
-    DIE(ziti_write(conn, req, strlen(req), on_write, NULL));
+    DIE(ziti_write(conn, (uint8_t *) req, strlen(req), on_write, NULL));
 }
 
 void on_ziti_init(ziti_context ztx, const ziti_event_t *ev) {

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -693,7 +693,7 @@ static void stopper_recv(uv_udp_t *u, ssize_t len,
             ZITI_LOG(WARN, "unknown cmd: %.*s", (int)len, b->base);
             break;
         case ProxyCmd_dump:
-            u->data = addr;
+            u->data = (void *) addr;
             debug_dump(&app_ctx, dump, u);
             break;
         case ProxyCmd_stop:


### PR DESCRIPTION
mostly fixes these:
```
warning: passing 'char *' to parameter of type 'const uint8_t *' (aka 'const unsigned char *') converts between pointers to integer types where one is of the unique plain 'char' type and the other is not [-Wpointer-sign]
```