### PR TITLE
refactor connection flushing

### DIFF
--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -210,9 +210,9 @@ struct ziti_conn {
             int fin_recv; // 0 - not received, 1 - received, 2 - called app data cb
             bool disconnecting;
 
+            deadline_t flusher;
             TAILQ_HEAD(, message_s) in_q;
             buffer *inbound;
-            uv_idle_t *flusher;
             TAILQ_HEAD(, ziti_write_req_s) wreqs;
             TAILQ_HEAD(, ziti_write_req_s) pending_wreqs;
 

--- a/library/channel.c
+++ b/library/channel.c
@@ -135,7 +135,7 @@ int ziti_channel_prepare(ziti_channel_t *ch) {
 
     // process_inbound() may consume all message buffers from the pool,
     // but it will put ziti connection(s) into `flush` state
-    // activating uv_idle_t handle, causing zero-timeout IO
+    // causing zero-timeout IO
     // and a flush attempt on the next loop iteration
     if (ch->state == Connected) {
         if (pool_has_available(ch->in_msg_pool) || ch->in_next != NULL) {


### PR DESCRIPTION
use deadline instead of uv_idle_t
uv_idle_t handle behaves just like a deadline_t with timeout==0