### PR TITLE
simplify external OIDC token refresh

### DIFF
--- a/library/ext_oidc.c
+++ b/library/ext_oidc.c
@@ -782,18 +782,9 @@ static void ext_refresh_time_cb(uv_timer_t *t) {
     tlsuv_http_req_header(req, "Authorization",
                           get_basic_auth_header(clt->signer_cfg.client_id));
     const char *refresher = json_object_get_string(tok);
-    if (clt->refresh_grant && strcmp(clt->refresh_grant, TOKEN_EXCHANGE_GRANT) == 0) {
-        tlsuv_http_req_form(req, 4, (tlsuv_http_pair[]) {
-                {"grant_type", TOKEN_EXCHANGE_GRANT},
-                {"requested_token_type", "urn:ietf:params:oauth:token-type:refresh_token"},
-                {"subject_token_type",   "urn:ietf:params:oauth:token-type:refresh_token"},
-                {"subject_token",        refresher},
-        });
-    } else {
-        tlsuv_http_req_form(req, 3, (tlsuv_http_pair[]) {
-                {"client_id",     clt->signer_cfg.client_id},
-                {"grant_type",    "refresh_token"},
-                {"refresh_token", refresher},
-        });
-    }
+    tlsuv_http_req_form(req, 3, (tlsuv_http_pair[]) {
+        {"client_id",     clt->signer_cfg.client_id},
+        {"grant_type",    "refresh_token"},
+        {"refresh_token", refresher},
+    });
 }

--- a/library/external_auth.c
+++ b/library/external_auth.c
@@ -186,6 +186,8 @@ extern int ziti_ext_auth_token(ziti_context ztx, const char *token) {
         return ZITI_OK;
     }
 
-    ztx->auth_method->start(ztx->auth_method, ztx_auth_state_cb, ztx);
+    if (ztx->auth_state == ZitiAuthStateUnauthenticated) {
+        ztx->auth_method->start(ztx->auth_method, ztx_auth_state_cb, ztx);
+    }
     return ZITI_OK;
 }


### PR DESCRIPTION
do not restart auth_method unnecessarily