### PR TITLE
make sure ziti_ctrl uses correct auth header

### DIFF
--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -44,6 +44,7 @@ typedef struct ziti_controller_s {
     // tuning options
     unsigned int page_size;
 
+    bool legacy;
     bool is_ha;
     ziti_version version;
     ctrl_version_cb version_cb;
@@ -61,6 +62,8 @@ typedef struct ziti_controller_s {
 int ziti_ctrl_init(uv_loop_t *loop, ziti_controller *ctrl, model_list *urls, tls_context *tls);
 
 int ziti_ctrl_set_token(ziti_controller *ctrl, const char *access_token);
+
+void ziti_ctrl_set_legacy(ziti_controller *ctrl, bool legacy);
 
 int ziti_ctrl_cancel(ziti_controller *ctrl);
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -2097,6 +2097,9 @@ static void version_pre_auth_cb(const ziti_version *version, const ziti_error *e
             ZTX_LOG(ERROR, "controller reported OIDC_AUTH capability without OIDC API version");
             use_oidc = false;
         }
+        // make sure ziti_ctrl client is configured for correct auth
+        ziti_ctrl_set_legacy(ztx_get_controller(ztx), !use_oidc);
+
         if (!ztx->auth_method) {
             if (use_oidc) {
                 ztx->auth_method = new_oidc_auth(ztx->loop, oidc_path, ztx->tlsCtx);

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -376,6 +376,10 @@ static void internal_version_cb(ziti_version *v, ziti_error *e, struct ctrl_resp
     ctrl_default_cb(NULL, e, resp);
 }
 
+void ziti_ctrl_set_legacy(ziti_controller *ctrl, bool legacy) {
+    ctrl->legacy = legacy;
+}
+
 void ziti_ctrl_clear_auth(ziti_controller *ctrl) {
     ctrl->has_token = false;
     if (ctrl->client) {
@@ -395,8 +399,7 @@ static void ctrl_login_cb(ziti_api_session *s, ziti_error *e, struct ctrl_resp *
     if (s) {
         CTRL_LOG(DEBUG, "authenticated successfully session[%s]", s->id);
         ctrl->has_token = true;
-        bool use_oidc = ziti_has_capability(&ctrl->version, ziti_ctrl_caps.OIDC_AUTH);
-        if (!use_oidc) {
+        if (ctrl->legacy) {
             tlsuv_http_header(ctrl->client, "zt-session", NULL);
             tlsuv_http_header(ctrl->client, "zt-session", s->token);
         }


### PR DESCRIPTION
controller capabilities can be misleading

continuation of the fix in #961