### PR TITLE
Refactor zitilib daemon

### DIFF
--- a/library/ziti.c
+++ b/library/ziti.c
@@ -1715,6 +1715,10 @@ static void edge_routers_cb(ziti_edge_router_array ers, const ziti_error *err, v
 static void update_identity_data(ziti_identity_data *data, const ziti_error *err, void *ctx) {
     ziti_context ztx = ctx;
 
+    if (err && err->err == ZITI_DISABLED) {
+        return;
+    }
+
     if (err) {
         ZTX_LOG(ERROR, "failed to get identity_data: %s[%s]", err->message, err->code);
         if (err->err == ZITI_AUTHENTICATION_FAILED) {
@@ -1759,7 +1763,7 @@ static void ca_bundle_cb(char *pkcs7, const ziti_error *err, void *ctx) {
 
             ztx_config_update(ztx);
         }
-    } else {
+    } else if (err->err != ZITI_DISABLED) {
         ZTX_LOG(ERROR, "failed to get CA bundle from controller: %s", err->message);
     }
 
@@ -2404,7 +2408,9 @@ done:
 static void api_session_cb(ziti_api_session *api_sess, const ziti_error *err, void *ctx) {
     ziti_context ztx = ctx;
     if (err) {
-        ZTX_LOG(ERROR, "failed to get api session: %s/%s", err->code, err->message);
+        if (err->err != ZITI_DISABLED) {
+            ZTX_LOG(ERROR, "failed to get api session: %s/%s", err->code, err->message);
+        }
         return;
     }
 

--- a/library/zitilib/daemon.c
+++ b/library/zitilib/daemon.c
@@ -1,0 +1,190 @@
+// Copyright (c) 2026.  NetFoundry Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+//
+#include <ziti/zitilib.h>
+#include <ziti/ziti_log.h>
+
+#include "zl.h"
+
+#include <tlsuv/queue.h>
+#include <uv.h>
+
+#define INVALID_THREAD ((uv_thread_t) -1)
+
+uv_key_t err_key;
+
+static uv_once_t init;
+static uv_mutex_t q_mut;
+static uv_async_t q_async;
+static LIST_HEAD(loop_queue, queue_elem_s) loop_q;
+
+
+// invocation state
+static uv_mutex_t loop_lock;
+static uv_cond_t loop_cond;
+static uv_thread_t daemon_thread = INVALID_THREAD;
+
+typedef struct queue_elem_s {
+    loop_work_cb cb;
+    void *arg;
+    future_t *f;
+    LIST_ENTRY(queue_elem_s) _next;
+} queue_elem_t;
+
+static void process_on_loop(uv_async_t *async);
+static void looper(void *arg);
+
+
+static void internal_init() {
+#if defined(PTHREAD_ONCE_INIT)
+//    pthread_atfork(NULL, NULL, child_init);
+#endif
+    uv_key_create(&err_key);
+    uv_mutex_init(&q_mut);
+    uv_mutex_init(&loop_lock);
+    uv_cond_init(&loop_cond);
+}
+
+void Ziti_lib_init(void) {
+    uv_once(&init, internal_init);
+
+    c_with(uv_mutex_lock(&loop_lock), uv_mutex_unlock(&loop_lock)) {
+        if (daemon_thread == INVALID_THREAD) {
+            uv_thread_create(&daemon_thread, looper, NULL);
+            uv_cond_wait(&loop_cond, &loop_lock);
+        }
+    }
+}
+
+future_t *schedule_on_loop(loop_work_cb cb, void *arg, bool wait) {
+    future_t *f = NULL;
+    if (wait) {
+        f = new_future();
+    }
+
+    queue_elem_t *el = calloc(1, sizeof(queue_elem_t));
+    el->cb = cb;
+    el->arg = arg;
+    el->f = f;
+
+    uv_mutex_lock(&q_mut);
+    LIST_INSERT_HEAD(&loop_q, el, _next);
+    uv_mutex_unlock(&q_mut);
+    uv_async_send(&q_async);
+
+    return f;
+}
+
+void process_on_loop(uv_async_t *async) {
+    LIST_HEAD(loop_queue, queue_elem_s) q = {0};
+
+    // drain q
+    uv_mutex_lock(&q_mut);
+    while (!LIST_EMPTY(&loop_q)) {
+        queue_elem_t *el = LIST_FIRST(&loop_q);
+        LIST_REMOVE(el, _next);
+        LIST_INSERT_HEAD(&q, el, _next);
+    }
+    uv_mutex_unlock(&q_mut);
+
+    while (!LIST_EMPTY(&q)) {
+        queue_elem_t *el = LIST_FIRST(&q);
+        LIST_REMOVE(el, _next);
+        el->cb(el->arg, el->f, async->loop);
+        free(el);
+    }
+}
+
+static void looper(void *arg) {
+    (void)arg;
+    uv_loop_t *loop = uv_loop_new();
+    c_with(uv_mutex_lock(&loop_lock), uv_mutex_unlock(&loop_lock)) {
+        ziti_log_init(loop, -1, NULL);
+        uv_async_init(loop, &q_async, process_on_loop);
+        uv_cond_broadcast(&loop_cond);
+    }
+
+    ZITI_LOG(DEBUG, "loop is starting");
+    uv_run(loop, UV_RUN_DEFAULT);
+    if (!LIST_EMPTY(&loop_q)) {
+        ZITI_LOG(WARN, "queue is not empty at shutdown");
+    }
+    ZITI_LOG(DEBUG, "loop is done");
+
+    if (uv_loop_close(loop) == UV_EBUSY) {
+        ZITI_LOG(WARN, "some handles still active at shutdown");
+        uv_print_all_handles(loop, stderr);
+    }
+    free(loop);
+
+    c_with(uv_mutex_lock(&loop_lock), uv_mutex_unlock(&loop_lock)) {
+        daemon_thread = INVALID_THREAD;
+        memset(&q_async, 0, sizeof(q_async));
+        uv_cond_broadcast(&loop_cond);
+    }
+}
+
+void do_shutdown(void *args, future_t *f, uv_loop_t *l) {
+    (void)args;
+    model_map_iter *it = model_map_iterator(&ziti_contexts);
+    while (it) {
+        ztx_wrap_t *w = model_map_it_value(it);
+        it = model_map_it_remove(it);
+        if (w->ztx) {
+            ziti_shutdown(w->ztx);
+        }
+        model_map_clear(&w->intercepts, (void (*)(void *)) free_ziti_intercept_cfg_v1_ptr);
+    }
+    complete_future(f, NULL, 0);
+    uv_close((uv_handle_t *) &q_async, NULL);
+
+    uv_stop(l);
+}
+
+void Ziti_lib_shutdown(void) {
+    uv_thread_t t;
+    c_with(uv_mutex_lock(&loop_lock), uv_mutex_unlock(&loop_lock)) {
+        t = daemon_thread;
+        if (t != INVALID_THREAD) {
+            schedule_on_loop(do_shutdown, NULL, false);
+            uv_cond_wait(&loop_cond, &loop_lock);
+        }
+    }
+
+    if (t != INVALID_THREAD) {
+        uv_thread_join(&t);
+    }
+}
+
+int Ziti_last_error() {
+    intptr_t p = (intptr_t) uv_key_get(&err_key);
+    return (int)p;
+}
+
+void zl_set_error(int err) {
+    uv_key_set(&err_key, (void *) (intptr_t) err);
+}
+
+bool zl_check_daemon() {
+    uv_thread_t t;
+    c_with(uv_mutex_lock(&loop_lock), uv_mutex_unlock(&loop_lock)) {
+            t = daemon_thread;
+    }
+    return t != INVALID_THREAD;
+}
+

--- a/library/zitilib/daemon.c
+++ b/library/zitilib/daemon.c
@@ -112,6 +112,7 @@ void process_on_loop(uv_async_t *async) {
 
 static void looper(void *arg) {
     (void)arg;
+    uv_thread_setname("zitilib-daemon");
     uv_loop_t *loop = uv_loop_new();
     c_with(uv_mutex_lock(&loop_lock), uv_mutex_unlock(&loop_lock)) {
         ziti_log_init(loop, -1, NULL);
@@ -125,6 +126,15 @@ static void looper(void *arg) {
         ZITI_LOG(WARN, "queue is not empty at shutdown");
     }
     ZITI_LOG(DEBUG, "loop is done");
+
+    // there should not be any active loop handles at this point,
+    // but run the loop a few times to allow any pending close callbacks to run and free their handles
+    for (int i = 0; i < 10; i++) {
+        int n = uv_run(loop, UV_RUN_ONCE);
+        if (n == 0) {
+            break;
+        }
+    }
 
     if (uv_loop_close(loop) == UV_EBUSY) {
         ZITI_LOG(WARN, "some handles still active at shutdown");

--- a/library/zitilib/zitilib.c
+++ b/library/zitilib/zitilib.c
@@ -1,16 +1,18 @@
 // Copyright (c) 2022-2026.  NetFoundry Inc
 //
-// 	Licensed under the Apache License, Version 2.0 (the "License");
-// 	you may not use this file except in compliance with the License.
-// 	You may obtain a copy of the License at
+// SPDX-License-Identifier: Apache-2.0
 //
-// 	https://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// 	Unless required by applicable law or agreed to in writing, software
-// 	distributed under the License is distributed on an "AS IS" BASIS,
-// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 	See the License for the specific language governing permissions and
-// 	limitations under the License.
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 
 #include <tlsuv/queue.h>
@@ -36,27 +38,7 @@ static const char *configs[] = {
         NULL,
 };
 
-typedef struct queue_elem_s {
-    loop_work_cb cb;
-    void *arg;
-    future_t *f;
-    LIST_ENTRY(queue_elem_s) _next;
-} queue_elem_t;
-
-static void internal_init();
-
-static void do_shutdown(void *args, future_t *f, uv_loop_t *l);
 static void do_timeout_cleanup(void *args, future_t *f, uv_loop_t *l);
-
-static uv_once_t init;
-static uv_loop_t *lib_loop;
-static uv_thread_t lib_thread;
-static uv_key_t err_key;
-static uv_mutex_t q_mut;
-static uv_async_t q_async;
-static LIST_HEAD(loop_queue, queue_elem_s) loop_q;
-
-static future_t *child_init_future;
 
 #if _WIN32
 
@@ -70,7 +52,6 @@ struct sockaddr_un {
 #endif
 #endif
 
-
 struct backlog_entry_s {
     struct ziti_sock_s *parent;
     ziti_connection conn;
@@ -79,29 +60,9 @@ struct backlog_entry_s {
     TAILQ_ENTRY(backlog_entry_s) _next;
 };
 
-
-
 model_map ziti_contexts;
 
 model_map ziti_sockets;
-
-void Ziti_lib_init(void) {
-    uv_once(&init, internal_init);
-}
-
-ZITI_FUNC
-uv_thread_t Ziti_lib_thread() {
-    return lib_thread;
-}
-
-int Ziti_last_error() {
-    intptr_t p = (intptr_t) uv_key_get(&err_key);
-    return (int)p;
-}
-
-void zl_set_error(int err) {
-    uv_key_set(&err_key, (void *) (intptr_t) err);
-}
 
 static void free_wrap(ztx_wrap_t *w) {
     if (w == NULL) return;
@@ -335,7 +296,7 @@ error:
 }
 
 int Ziti_load_context(ziti_handle_t *h, const char *identity) {
-    if (h == NULL || identity == NULL) {
+    if (h == NULL || identity == NULL || !zl_check_daemon()) {
         return ZITI_INVALID_STATE;
     }
     future_t *f = schedule_on_loop(load_ziti_ctx, (void *) identity, true);
@@ -359,7 +320,7 @@ int Ziti_load_context(ziti_handle_t *h, const char *identity) {
 }
 
 int Ziti_load_context_with_timeout(ziti_handle_t *h, const char *identity, int timeout_ms) {
-    if (h == NULL || identity == NULL) {
+    if (h == NULL || identity == NULL || !zl_check_daemon()) {
         return ZITI_INVALID_STATE;
     }
 
@@ -678,7 +639,7 @@ static void do_ziti_bind(struct conn_req_s *req, future_t *f, uv_loop_t *l) {
 }
 
 int Ziti_bind(ziti_socket_t socket, ziti_handle_t zh, const char *service, const char *terminator) {
-
+    if (!zl_check_daemon()) { return EINVAL; }
     if (zh == ZITI_INVALID_HANDLE) { return EINVAL; }
     if (service == NULL) { return EINVAL; }
 
@@ -717,6 +678,10 @@ static void do_ziti_listen(void *arg, future_t *f, uv_loop_t *l) {
 }
 
 int Ziti_listen(ziti_socket_t socket, int backlog) {
+    if (!zl_check_daemon()) {
+        return ZITI_INVALID_STATE;
+    }
+
     if (backlog <= 0) {
         return EINVAL;
     }
@@ -809,92 +774,6 @@ ziti_socket_t Ziti_accept(ziti_socket_t server, char *caller, int caller_len) {
     return clt;
 }
 
-
-void Ziti_lib_shutdown(void) {
-    future_t *f = schedule_on_loop(do_shutdown, NULL, true);
-    await_future(f, NULL);
-    uv_thread_join(&lib_thread);
-    uv_once_t child_once = UV_ONCE_INIT;
-    memcpy(&init, &child_once, sizeof(child_once));
-    uv_key_delete(&err_key);
-    destroy_future(f);
-}
-
-static void looper(void *arg) {
-    uv_loop_t *l = arg;
-    ZITI_LOG(DEBUG, "loop is starting");
-    uv_run(l, UV_RUN_DEFAULT);
-    ZITI_LOG(DEBUG, "loop is done");
-}
-
-future_t *schedule_on_loop(loop_work_cb cb, void *arg, bool wait) {
-    future_t *f = NULL;
-    if (wait) {
-        f = new_future();
-    }
-
-    queue_elem_t *el = calloc(1, sizeof(queue_elem_t));
-    el->cb = cb;
-    el->arg = arg;
-    el->f = f;
-
-    uv_mutex_lock(&q_mut);
-    LIST_INSERT_HEAD(&loop_q, el, _next);
-    uv_mutex_unlock(&q_mut);
-    uv_async_send(&q_async);
-
-    return f;
-}
-
-void process_on_loop(uv_async_t *async) {
-    LIST_HEAD(loop_queue, queue_elem_s) q = {0};
-
-    // drain q
-    uv_mutex_lock(&q_mut);
-    while (!LIST_EMPTY(&loop_q)) {
-        queue_elem_t *el = LIST_FIRST(&loop_q);
-        LIST_REMOVE(el, _next);
-        LIST_INSERT_HEAD(&q, el, _next);
-    }
-    uv_mutex_unlock(&q_mut);
-
-    while (!LIST_EMPTY(&q)) {
-        queue_elem_t *el = LIST_FIRST(&q);
-        LIST_REMOVE(el, _next);
-        el->cb(el->arg, el->f, async->loop);
-        free(el);
-    }
-}
-
-
-static void internal_init() {
-#if defined(PTHREAD_ONCE_INIT)
-//    pthread_atfork(NULL, NULL, child_init);
-#endif
-    uv_key_create(&err_key);
-    uv_mutex_init(&q_mut);
-    lib_loop = uv_loop_new();
-    ziti_log_init(lib_loop, -1, NULL);
-    uv_async_init(lib_loop, &q_async, process_on_loop);
-    uv_thread_create(&lib_thread, looper, lib_loop);
-}
-
-void do_shutdown(void *args, future_t *f, uv_loop_t *l) {
-    model_map_iter *it = model_map_iterator(&ziti_contexts);
-    while (it) {
-        ztx_wrap_t *w = model_map_it_value(it);
-        it = model_map_it_remove(it);
-        if (w->ztx) {
-            ziti_shutdown(w->ztx);
-        }
-        model_map_clear(&w->intercepts, (void (*)(void *)) free_ziti_intercept_cfg_v1_ptr);
-    }
-    complete_future(f, NULL, 0);
-    uv_close((uv_handle_t *) &q_async, NULL);
-
-    uv_stop(q_async.loop);
-}
-
 void do_timeout_cleanup(void *args, future_t *f, uv_loop_t *l) {
     char *identity = (char *)args;
     if (identity == NULL) {
@@ -935,6 +814,10 @@ static void do_enroll(ziti_enroll_opts *opts, future_t *f, uv_loop_t *loop) {
 }
 
 int Ziti_enroll_identity(const char *jwt, const char *key, const char *cert, char **id_json, unsigned long *id_json_len) {
+    if (!zl_check_daemon()) {
+        return ZITI_INVALID_STATE;
+    }
+
     ziti_enroll_opts opts = {
             .token = jwt,
             .key = key,
@@ -1026,6 +909,10 @@ int Ziti_enroll_controller(const char *url, const char *jwt, ziti_enroll_mode mo
                            const char *signer_name,
                            char **id_json, unsigned long *id_json_len) {
     if ((url == NULL && jwt == NULL) || id_json == NULL || id_json_len == NULL) {
+        return ZITI_INVALID_STATE;
+    }
+
+    if (!zl_check_daemon()) {
         return ZITI_INVALID_STATE;
     }
 
@@ -1270,9 +1157,14 @@ static void get_signers(void *arg, future_t *f, uv_loop_t *loop) {
     ziti_get_ext_jwt_signers(wrap->ztx, signers_cb, req);
 }
 
-const char * const *  Ziti_get_ext_signers(ziti_handle_t handle) {
+const char * const *  Ziti_get_ext_signers(ziti_handle_t ztx) {
+    if (ztx == ZITI_INVALID_HANDLE || !zl_check_daemon()) {
+        zl_set_error(EINVAL);
+        return NULL;
+    }
+
     struct signers_req_s req = {
-            .ziti_handle = handle,
+            .ziti_handle = ztx,
     };
 
     future_t *f = schedule_on_loop(get_signers, &req, true);
@@ -1333,7 +1225,7 @@ static void set_ext_signer(void *arg, future_t *f, uv_loop_t *loop) {
 
 char* Ziti_login_external(ziti_handle_t ztx, const char *signer_name) {
 
-    if (ztx == ZITI_INVALID_HANDLE) {
+    if (ztx == ZITI_INVALID_HANDLE || !zl_check_daemon()) {
         zl_set_error(EINVAL);
         return NULL;
     }
@@ -1400,6 +1292,10 @@ static void do_totp_login(void *arg, future_t *f, uv_loop_t *l) {
 }
 
 int Ziti_login_totp(ziti_handle_t ztx, const char *code) {
+    if (ztx == ZITI_INVALID_HANDLE || !zl_check_daemon()) {
+        return ZITI_INVALID_STATE;
+    }
+
     struct login_req_s req = {
             .ziti_handle = ztx,
             .code = code,
@@ -1433,6 +1329,9 @@ static void wait_for_auth_cb(void *arg, future_t *f, uv_loop_t *l) {
 }
 
 int Ziti_wait_for_auth(ziti_handle_t ztx, int timeout_ms) {
+    if (ztx == ZITI_INVALID_HANDLE || !zl_check_daemon()) {
+        return ZITI_INVALID_STATE;
+    }
     future_t *f = schedule_on_loop(wait_for_auth_cb, (void *)(uintptr_t)ztx, true);
     int err = await_future_timed(f, NULL, timeout_ms);
     destroy_future(f);

--- a/library/zitilib/zl.h
+++ b/library/zitilib/zl.h
@@ -1,16 +1,18 @@
 // Copyright (c) 2026.  NetFoundry Inc
 //
-// 	Licensed under the Apache License, Version 2.0 (the "License");
-// 	you may not use this file except in compliance with the License.
-// 	You may obtain a copy of the License at
+// SPDX-License-Identifier: Apache-2.0
 //
-// 	https://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// 	Unless required by applicable law or agreed to in writing, software
-// 	distributed under the License is distributed on an "AS IS" BASIS,
-// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 	See the License for the specific language governing permissions and
-// 	limitations under the License.
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //
 //
@@ -89,6 +91,7 @@ int connect_socket(int af, ziti_socket_t clt_sock, ziti_socket_t *ziti_sock);
 bool zl_is_blocking(ziti_socket_t s);
 int zl_socket_af(ziti_socket_t s);
 void zl_set_error(int err);
+bool zl_check_daemon();
 
 ZITI_FUNC
 const char *Ziti_lookup(in_addr_t addr);

--- a/tests/integ/ctrl_tests.cpp
+++ b/tests/integ/ctrl_tests.cpp
@@ -2,20 +2,24 @@
 
 // Copyright (c) 2026.  NetFoundry Inc
 //
-// 	Licensed under the Apache License, Version 2.0 (the "License");
-// 	you may not use this file except in compliance with the License.
-// 	You may obtain a copy of the License at
+// SPDX-License-Identifier: Apache-2.0
 //
-// 	https://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// 	Unless required by applicable law or agreed to in writing, software
-// 	distributed under the License is distributed on an "AS IS" BASIS,
-// 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// 	See the License for the specific language governing permissions and
-// 	limitations under the License.
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <catch2/catch_all.hpp>
 #include <ziti/ziti.h>
+#include <ziti/zitilib.h>
+
 #include "oidc.h"
 #include "ziti/ziti_log.h"
 #include "ziti_ctrl.h"
@@ -158,4 +162,21 @@ TEST_CASE("ctrl-token-auth", "[integ]") {
     // free_ziti_version(&v);
     // free_ziti_service(&service);
     // free_ziti_config(&cfg);
+}
+
+TEST_CASE("zitilib startup/shutdown", "[zitilib]") {
+    Ziti_lib_init();
+    Ziti_lib_init();
+
+    ziti_handle_t mm;
+    CHECK(ZITI_OK == Ziti_load_context(&mm, TEST_CLIENT));
+
+    Ziti_lib_shutdown();
+    Ziti_lib_shutdown();
+
+    CHECK(ZITI_INVALID_STATE == Ziti_load_context(&mm, TEST_CLIENT));
+
+    Ziti_lib_init();
+    CHECK(ZITI_OK == Ziti_load_context(&mm, TEST_CLIENT));
+    Ziti_lib_shutdown();
 }


### PR DESCRIPTION
- break out background thread/loop management into a separate file
- allow for multiple `Ziti_lib_init()/Ziti_lib_shutdown()` cycles
- add checks to prevent hangups when API is called without `Ziti_lib_init()` called first