### PR TITLE
Support additional query parameters on ext-jwt-signer authorize URL

### DIFF
--- a/inc_internal/ext_oidc.h
+++ b/inc_internal/ext_oidc.h
@@ -57,6 +57,9 @@ struct ext_oidc_client_s {
     uv_timer_t *timer;
     char *jwt_token_auth;
 
+    tlsuv_http_pair *auth_params;
+    int auth_params_count;
+
     struct auth_req *request;
 };
 

--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -953,6 +953,14 @@ typedef void (*ziti_mfa_cb)(ziti_context ztx, int status, void *ctx);
 typedef void (*ziti_ext_auth_launch_cb)(ziti_context ztx, const char *url, void *ctx);
 
 /**
+ * @brief Name/value pair for additional ext-auth query parameters.
+ */
+typedef struct ziti_auth_query_param_s {
+    const char *name;
+    const char *value;
+} ziti_auth_query_param;
+
+/**
  * @brief Callback called after ziti_mfa_get_recovery_codes() and ziti_mfa_new_recovery_codes()
  *
  * This function is invoked after a call to get or regenerate mfa recovery codes.
@@ -1085,6 +1093,20 @@ extern void ziti_mfa_auth(ziti_context ztx, const char *code, ziti_mfa_cb auth_c
  */
 ZITI_FUNC
 extern int ziti_ext_auth(ziti_context ztx, ziti_ext_auth_launch_cb launch_cb, void *ctx);
+
+/**
+ * @brief Set additional query parameters for external authentication.
+ *
+ * Parameters are appended to the authorize URL when the SDK starts the
+ * OIDC flow with an external JWT signer. Call before ziti_ext_auth().
+ *
+ * @param ztx the handle to the Ziti Edge identity context
+ * @param params array of name/value pairs (copied by the SDK)
+ * @param count number of pairs in the array
+ * @return #ZITI_OK or corresponding error
+ */
+ZITI_FUNC
+extern int ziti_ext_auth_set_params(ziti_context ztx, const ziti_auth_query_param *params, int count);
 
 /**
  * @brief Submit external authentication token

--- a/library/buffer.c
+++ b/library/buffer.c
@@ -189,7 +189,7 @@ int string_buf_appendn(string_buf_t *wb, const char *str, size_t len) {
 }
 
 int string_buf_append_urlsafe(string_buf_t *wb, const char *str) {
-    static const char unsafe[] = " /:\"<>%{}|\\^`";
+    static const char unsafe[] = " /:\"<>%{}|\\^`&=+#?";
 
     if (str == NULL) {
         return 0;

--- a/library/ext_oidc.c
+++ b/library/ext_oidc.c
@@ -141,6 +141,18 @@ int ext_oidc_client_init(uv_loop_t *loop, ext_oidc_client_t *clt,
 
     snprintf(clt->name, sizeof(clt->name), "%s", cfg->name ? cfg->name : cfg->provider_url);
     OIDC_LOG(INFO, "initializing with provider[%s]", cfg->provider_url);
+
+    // free previous auth params if re-initializing
+    if (clt->auth_params) {
+        for (int i = 0; i < clt->auth_params_count; i++) {
+            free((void *)clt->auth_params[i].name);
+            free((void *)clt->auth_params[i].value);
+        }
+        free(clt->auth_params);
+        clt->auth_params = NULL;
+        clt->auth_params_count = 0;
+    }
+
     clt->config = NULL;
     clt->tokens = NULL;
     clt->token_cb = NULL;
@@ -639,7 +651,7 @@ int ext_oidc_client_start(ext_oidc_client_t *clt, ext_oidc_token_cb cb) {
     }
 
     char *scope = string_buf_to_string(scopes_buf, NULL);
-    tlsuv_http_pair query[] = {
+    tlsuv_http_pair base_query[] = {
             {"client_id",             clt->signer_cfg.client_id},
             {"scope",                 scope},
             {"response_type",         "code"},
@@ -650,8 +662,21 @@ int ext_oidc_client_start(ext_oidc_client_t *clt, ext_oidc_token_cb cb) {
             {"audience",              clt->signer_cfg.audience ?
                                       clt->signer_cfg.audience : "openziti"},
     };
+    int base_count = sizeof(base_query) / sizeof(base_query[0]);
+    int extra_count = clt->auth_params_count;
+    int total = base_count + extra_count;
 
-    ext_start_auth(req, auth_url, sizeof(query)/sizeof(query[0]), query);
+    tlsuv_http_pair *query = calloc(total, sizeof(tlsuv_http_pair));
+    memcpy(query, base_query, base_count * sizeof(tlsuv_http_pair));
+    int qi = base_count;
+    for (int i = 0; i < extra_count; i++) {
+        if (clt->auth_params[i].name && clt->auth_params[i].value) {
+            query[qi++] = clt->auth_params[i];
+        }
+    }
+
+    ext_start_auth(req, auth_url, qi, query);
+    free(query);
     free(scope);
     delete_string_buf(scopes_buf);
     return 0;
@@ -689,6 +714,16 @@ int ext_oidc_client_close(ext_oidc_client_t *clt, ext_oidc_close_cb cb) {
     uv_close((uv_handle_t *) clt->timer, (uv_close_cb) free);
     clt->timer = NULL;
     free_ziti_jwt_signer(&clt->signer_cfg);
+
+    if (clt->auth_params) {
+        for (int i = 0; i < clt->auth_params_count; i++) {
+            free((void *)clt->auth_params[i].name);
+            free((void *)clt->auth_params[i].value);
+        }
+        free(clt->auth_params);
+        clt->auth_params = NULL;
+        clt->auth_params_count = 0;
+    }
 
     if (clt->request) {
         failed_auth_req(clt->request, strerror(ECANCELED));

--- a/library/external_auth.c
+++ b/library/external_auth.c
@@ -147,13 +147,17 @@ extern int ziti_ext_auth_set_params(ziti_context ztx, const ziti_auth_query_para
         return ZITI_OK;
     }
 
-    // copy params
+    // copy params, skip entries with NULL name or value
     ztx->ext_auth->auth_params = calloc(count, sizeof(tlsuv_http_pair));
-    ztx->ext_auth->auth_params_count = count;
+    int ci = 0;
     for (int i = 0; i < count; i++) {
-        ztx->ext_auth->auth_params[i].name = strdup(params[i].name);
-        ztx->ext_auth->auth_params[i].value = params[i].value ? strdup(params[i].value) : NULL;
+        if (params[i].name && params[i].value) {
+            ztx->ext_auth->auth_params[ci].name = strdup(params[i].name);
+            ztx->ext_auth->auth_params[ci].value = strdup(params[i].value);
+            ci++;
+        }
     }
+    ztx->ext_auth->auth_params_count = ci;
     return ZITI_OK;
 }
 

--- a/library/external_auth.c
+++ b/library/external_auth.c
@@ -127,6 +127,36 @@ static void ext_token_cb(ext_oidc_client_t *oidc, enum ext_oidc_status status, c
     }
 }
 
+extern int ziti_ext_auth_set_params(ziti_context ztx, const ziti_auth_query_param *params, int count) {
+    if (ztx->ext_auth == NULL) {
+        return ZITI_INVALID_STATE;
+    }
+
+    // free previous params
+    if (ztx->ext_auth->auth_params) {
+        for (int i = 0; i < ztx->ext_auth->auth_params_count; i++) {
+            free((void *)ztx->ext_auth->auth_params[i].name);
+            free((void *)ztx->ext_auth->auth_params[i].value);
+        }
+        free(ztx->ext_auth->auth_params);
+        ztx->ext_auth->auth_params = NULL;
+        ztx->ext_auth->auth_params_count = 0;
+    }
+
+    if (params == NULL || count <= 0) {
+        return ZITI_OK;
+    }
+
+    // copy params
+    ztx->ext_auth->auth_params = calloc(count, sizeof(tlsuv_http_pair));
+    ztx->ext_auth->auth_params_count = count;
+    for (int i = 0; i < count; i++) {
+        ztx->ext_auth->auth_params[i].name = strdup(params[i].name);
+        ztx->ext_auth->auth_params[i].value = params[i].value ? strdup(params[i].value) : NULL;
+    }
+    return ZITI_OK;
+}
+
 extern int ziti_ext_auth(ziti_context ztx,
                          void (*ziti_ext_launch)(ziti_context, const char*, void *), void *ctx) {
     if (ztx->ext_auth == NULL) {


### PR DESCRIPTION
This is to enable auth/enrollment (e.g., enrollToCert) flows to take device info into account along with user info and make available as claims for use in identity name and external id creation.

Notes:
RFC 6749 §3.1 (OAuth 2.0 authorization endpoint): "The authorization server MUST ignore unrecognized request parameters."

OpenID Connect Core §3.1.2.1: "The Authorization Server MUST ignore unrecognized request parameters."