### PR TITLE
Add ziti_set_hostname for caller-provided envInfo hostname

### DIFF
--- a/includes/ziti/ziti.h
+++ b/includes/ziti/ziti.h
@@ -427,6 +427,18 @@ ZITI_FUNC
 extern void ziti_set_device_id(const char *device_id);
 
 /**
+ * Override the hostname reported to the Ziti Controller in envInfo.
+ *
+ * On platforms where uv_os_gethostname() returns an unhelpful value (e.g. iOS
+ * apps that always see "localhost"), the application can supply a more
+ * meaningful name (such as UIDevice.current.name on iOS).
+ *
+ * Pass NULL or an empty string to revert to the value detected by the SDK.
+ */
+ZITI_FUNC
+extern void ziti_set_hostname(const char *hostname);
+
+/**
  * Load ziti identity config from memory or file.
  * First it tries to parse [conf_str] as identity Json.
  * if that fails it tries to load it from file using [conf_str] as the path.

--- a/library/sdk_info.c
+++ b/library/sdk_info.c
@@ -42,9 +42,10 @@ typedef uint32_t in_addr_t;
 
 static uv_once_t info_once;
 static ziti_env_info s_info;
+static char s_hostname[UV_MAXHOSTNAMESIZE];
+static char *s_hostname_override;
 static void ziti_info_init() {
     static uv_utsname_t os_info;
-    static char s_hostname[UV_MAXHOSTNAMESIZE];
     static char s_domain[UV_MAXHOSTNAMESIZE];
 
     uv_os_uname(&os_info);
@@ -114,5 +115,19 @@ void ziti_set_device_id(const char *device_id) {
 
     if (device_id) {
         s_info.device_id = strdup(device_id);
+    }
+}
+
+void ziti_set_hostname(const char *hostname) {
+    uv_once(&info_once, ziti_info_init);
+
+    free(s_hostname_override);
+    s_hostname_override = NULL;
+
+    if (hostname && *hostname) {
+        s_hostname_override = strdup(hostname);
+        s_info.hostname = s_hostname_override;
+    } else {
+        s_info.hostname = s_hostname;
     }
 }


### PR DESCRIPTION
Use a setter since I don't want to tangle up this SDK adding something like UIKit dependency for iOS (e.g., for UIDevice.current.name)