### PR TITLE
win32 build: Visual studio 2026

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - uses: openziti/ziti/setup-cli@main
 
-    - uses: lukka/get-cmake@v3.30.1
+    - uses: lukka/get-cmake@latest
 
     - uses: lukka/run-vcpkg@v11
       with:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,7 +59,7 @@
     {
       "name": "vs-2022",
       "hidden": true,
-      "generator": "Visual Studio 17 2022"
+      "generator": "Visual Studio 18 2026"
     },
     {
       "name": "ci-std",


### PR DESCRIPTION
it appears that VS2022 is no longer available on github images
