### PR TITLE
update vcpkg baseline to 2026.04.27

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -30,7 +30,7 @@ runs:
       run: |
         echo "now installing linux deps"
         apt update
-        apt install -y python3-venv
+        apt install -y python3-venv autoconf autoconf-archive automake libtool
 
     - name: macOS tools
       if: runner.os == 'macOS'

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,10 @@
   ],
   "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "overrides": [
+    "name": "libuv",
+    "version": "1.52.0",
+    "port-version": 0,
+    "$comment": "1.52.1 breaks on mingw so we're sticking with 1.52.0 until fix released and available in vcpkg"
   ],
   "dependencies": [
     "libuv",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,10 +6,12 @@
   ],
   "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "overrides": [
-    "name": "libuv",
-    "version": "1.52.0",
-    "port-version": 0,
-    "$comment": "1.52.1 breaks on mingw so we're sticking with 1.52.0 until fix released and available in vcpkg"
+    {
+      "name": "libuv",
+      "version": "1.52.0",
+      "port-version": 0,
+      "$comment": "1.52.1 breaks on mingw so we're sticking with 1.52.0 until fix released and available in vcpkg"
+    }
   ],
   "dependencies": [
     "libuv",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,16 +2,10 @@
   "name": "ziti",
   "version-semver": "1.0.0",
   "description": [
-    "using vcpkg baseline: 2026.02.27"
+    "using vcpkg baseline: 2026.04.27"
   ],
-  "builtin-baseline": "62159a45e18f3a9ac0548628dcaf74fcb60c6ff9",
+  "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713",
   "overrides": [
-    {
-      "name": "libsodium",
-      "version": "1.0.20",
-      "port-version": 3,
-      "$comment": "1.0.21 breaks on linux-arm64 so we're sticking with 1.0.20 until fix released and available in vcpkg"
-    }
   ],
   "dependencies": [
     "libuv",


### PR DESCRIPTION
dependency updates:
- libuv: 1.52.0 -> ~~1.52.1~~ no update because of mingw build issue
- zlib: 1.3.1 -> 1.3.2
- openssl: 3.6.1 -> 3.6.2
- libsodium: 1.0.20 -> 1.0.22