### PR TITLE
fix: resolve SIGBUS on ARMv7 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,11 @@ if (ziti_ASAN)
     elseif (MINGW)
         message(WARNING "ASAN is not supported on MinGW builds")
     else ()
-        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-        add_link_options(-fsanitize=address)
+        add_compile_options(
+                -fsanitize=address,alignment,undefined
+                -fno-sanitize-recover=alignment
+                -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=address,alignment,undefined)
     endif ()
 endif (ziti_ASAN)
 

--- a/library/connect.c
+++ b/library/connect.c
@@ -308,21 +308,24 @@ message *create_message(struct ziti_conn *conn, uint32_t content, uint32_t flags
 static int send_message(struct ziti_conn *conn, message *m, struct ziti_write_req_s *wr) {
     ziti_channel_t *ch = conn->channel;
     if (m->header.content == ContentTypeData) {
-        struct msg_uuid *uuid = NULL;
+        uint8_t *uuid_buf = NULL;
         size_t len;
-        message_get_bytes_header(m, UUIDHeader, (const uint8_t **) &uuid, &len);
+        message_get_bytes_header(m, UUIDHeader, (const uint8_t **)&uuid_buf, &len);
 
-        if (uuid) {
-            assert(len == sizeof(*uuid));
+        if (uuid_buf) {
+            struct msg_uuid uuid;
+            assert(len == sizeof(uuid.raw));
+            memcpy(uuid.raw, uuid_buf, sizeof(uuid.raw));
             struct local_hash h = {0};
             crypto_hash_sha256(h.hash, m->body, m->header.body_len);
             int32_t seq;
             message_get_int32_header(m, SeqHeader, &seq);
 
-            uuid->slug = htole32(h.i32[0]);
+            uuid.slug = htole32(h.i32[0]);
             CONN_LOG(TRACE, "=> ct[%s] uuid[" UUID_FMT "] edge_seq[%d] len[%d] hash[" HASH_FMT "]",
-                     content_type_id(m->header.content), UUID_FMT_ARG(uuid), seq,
+                     content_type_id(m->header.content), UUID_FMT_ARG(&uuid), seq,
                      m->header.body_len, HASH_FMT_ARG(h));
+            memcpy(uuid_buf, uuid.raw, sizeof(uuid.raw));
         }
     }
     return ziti_channel_send_message(ch, m, wr);
@@ -996,15 +999,18 @@ void conn_inbound_data_msg(ziti_connection conn, message *msg) {
                                             plain_text, msg->header.body_len);
     if (plain_len < 0 && (conn->flags & EDGE_TRACE_UUID)) {
         // try to figure out the cause of crypto error
-        struct msg_uuid *uuid;
+        const uint8_t *uuid_buf;
+        struct msg_uuid uuid;
         size_t uuid_len;
         struct local_hash h;
         crypto_hash_sha256(h.hash, msg->body, msg->header.body_len);
 
-        if (message_get_bytes_header(msg, UUIDHeader, (const uint8_t **) &uuid, &uuid_len)) {
+        if (message_get_bytes_header(msg, UUIDHeader, (const uint8_t **) &uuid_buf, &uuid_len)) {
+            assert(uuid_len == sizeof(uuid.raw));
+            memcpy(uuid.raw, uuid_buf, sizeof(uuid.raw));
             CONN_LOG(ERROR, "uuid[" UUID_FMT "] %s corruption hash[" HASH_FMT "]",
-                     UUID_FMT_ARG(uuid),
-                     uuid->slug != htole32(h.i32[0]) ? "payload" : "crypto state",
+                     UUID_FMT_ARG(&uuid),
+                     uuid.slug != htole32(h.i32[0]) ? "payload" : "crypto state",
                      HASH_FMT_ARG(h));
         } else {
             CONN_LOG(ERROR, "message/state corruption hash[" HASH_FMT "]",
@@ -1465,7 +1471,8 @@ static void process_edge_message(struct ziti_conn *conn, message *msg) {
     int32_t seq = -1;
     int32_t conn_id = -1;
     uint32_t flags = 0;
-    struct msg_uuid *uuid;
+    const uint8_t *uuid_buf;
+    struct msg_uuid uuid;
     size_t uuid_len;
     bool has_seq = message_get_int32_header(msg, SeqHeader, &seq);
     bool has_conn_id = message_get_int32_header(msg, ConnIdHeader, &conn_id);
@@ -1481,16 +1488,18 @@ static void process_edge_message(struct ziti_conn *conn, message *msg) {
     }
 
     if ((conn->flags & EDGE_TRACE_UUID) &&
-        message_get_bytes_header(msg, UUIDHeader, (const uint8_t **) &uuid, &uuid_len)) {
+        message_get_bytes_header(msg, UUIDHeader, (const uint8_t **) &uuid_buf, &uuid_len)) {
+        assert(uuid_len == sizeof(uuid.raw));
+        memcpy(uuid.raw, uuid_buf, sizeof(uuid.raw));
         struct local_hash h;
         crypto_hash_sha256(h.hash, msg->body, msg->header.body_len);
         CONN_LOG(TRACE, "<= ct[%s] uuid[" UUID_FMT "] edge_seq[%d] len[%d] ",
-                 content_type_id(msg->header.content), UUID_FMT_ARG(uuid), seq, msg->header.body_len);
+                 content_type_id(msg->header.content), UUID_FMT_ARG(&uuid), seq, msg->header.body_len);
 
-        if (uuid->seq != conn->in_msg_seq) {
-            CONN_LOG(WARN, "unexpected msg_seq[%d] previous[%d]", uuid->seq, conn->in_msg_seq);
+        if (uuid.seq != conn->in_msg_seq) {
+            CONN_LOG(WARN, "unexpected msg_seq[%d] previous[%d]", uuid.seq, conn->in_msg_seq);
         }
-        conn->in_msg_seq = uuid->seq + 1;
+        conn->in_msg_seq = uuid.seq + 1;
     } else {
         CONN_LOG(TRACE, "<= ct[%s] edge_seq[%d] len[%d]", content_type_id(msg->header.content), seq, msg->header.body_len);
     }

--- a/library/message.c
+++ b/library/message.c
@@ -22,7 +22,9 @@
 #include "endian_internal.h"
 
 static const uint8_t *read_int32(const uint8_t *p, uint32_t *val) {
-    *val = le32toh(*(uint32_t *) p);
+    uint32_t v;
+    memcpy(&v, p, sizeof(v));
+    *val = le32toh(v);
     return p + sizeof(uint32_t);
 }
 

--- a/tests/message_tests.cpp
+++ b/tests/message_tests.cpp
@@ -14,10 +14,51 @@
 
 #include "catch2_includes.hpp"
 
+#include <cstdlib>
 #include <cstring>
 #include "message.h"
 #include "edge_protocol.h"
 #include "ziti/errors.h"
+
+// Regression for SIGBUS on armeabi-v7a inside parse_hdrs (library/message.c).
+// Wire format per header: id(4 LE) || length(4 LE) || value(length bytes).
+// A header with length=1 advances the cursor by 9, leaving the next header's
+// id at a 4-byte-misaligned address. read_int32 used to do `*(uint32_t*)p`
+// from a uint8_t*, which is UB and faults on ARMv7 strict-alignment cores.
+// With -fsanitize=alignment this trips even on x86_64 / arm64-macOS.
+TEST_CASE("parse_hdrs handles misaligned subsequent headers", "[model][alignment]") {
+    alignas(uint32_t) uint8_t buf[] = {
+        // header[0]: id=1, length=1, value=[0x42]  -> consumes 9 bytes
+        0x01, 0x00, 0x00, 0x00,
+        0x01, 0x00, 0x00, 0x00,
+        0x42,
+        // header[1]: id=2, length=4, value=[0xDE,0xAD,0xBE,0xEF]
+        // starts at offset 9 - deliberately not 4-byte aligned.
+        0x02, 0x00, 0x00, 0x00,
+        0x04, 0x00, 0x00, 0x00,
+        0xDE, 0xAD, 0xBE, 0xEF,
+    };
+    constexpr uint32_t buf_len = sizeof(buf);
+
+    hdr_t *hdrs = nullptr;
+    int n = parse_hdrs(buf, buf_len, &hdrs);
+
+    REQUIRE(n == 2);
+    REQUIRE(hdrs != nullptr);
+
+    CHECK(hdrs[0].header_id == 1);
+    CHECK(hdrs[0].length == 1);
+    CHECK(hdrs[0].value[0] == 0x42);
+
+    CHECK(hdrs[1].header_id == 2);
+    CHECK(hdrs[1].length == 4);
+    CHECK(hdrs[1].value[0] == 0xDE);
+    CHECK(hdrs[1].value[1] == 0xAD);
+    CHECK(hdrs[1].value[2] == 0xBE);
+    CHECK(hdrs[1].value[3] == 0xEF);
+
+    free(hdrs);
+}
 
 TEST_CASE("simple", "[model]") {
     auto p = pool_new(sizeof(message) + 200, 3, (void (*)(void *)) message_free);


### PR DESCRIPTION
fix `read_int32` to handle unaligned buffer read

add alignment sanitizer options to ziti_ASAN

[fixes #1063]