### PR TITLE
fix: update dependabot configuration to target all actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directories:
       - '.github/workflows'
-      - '.github/actions'
+      - '.github/actions/*'
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION


[skip ci]