### PR TITLE
finalize external OIDC flow with partial authentication

### DIFF
--- a/inc_internal/ext_oidc_pages.h
+++ b/inc_internal/ext_oidc_pages.h
@@ -94,6 +94,26 @@ static const char HTTP_SUCCESS_BODY[] =
         "</body>\n"
         "</html>\n";
 
+static const char HTTP_PARTIAL_SUCCESS_BODY[] =
+    "<!DOCTYPE html>\n"
+    "<html lang=\"en\">\n"
+    "<head><meta charset=\"utf-8\">\n"
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
+    "<title>OpenZiti Authentication</title>\n"
+    "<style>" CALLBACK_PAGE_STYLE "</style>\n"
+    "</head>\n"
+    "<body>\n"
+    "  <div class=\"card\">\n"
+    "    " ZITI_LOGO_SVG "\n"
+    "    <div class=\"attrib\">OpenZiti by NetFoundry</div>\n"
+    "    <h1>External token accepted, continue in the app to complete authentication</h1>\n"
+    "    <p>You may close this window.</p>\n"
+    "    <p>It will try to close itself in a few seconds.</p>\n"
+    "  </div>\n"
+    "  <script>setTimeout(function(){window.close();},3000);</script>\n"
+    "</body>\n"
+    "</html>\n";
+
 static const char HTTP_FAILURE_HEADER[] =
         "<!DOCTYPE html>\n"
         "<html lang=\"en\">\n"

--- a/library/ext_oidc.c
+++ b/library/ext_oidc.c
@@ -825,7 +825,11 @@ void ext_oidc_client_finalize(ext_oidc_client_t *clt, bool ok, const char *error
     stop_pending_watchdog(clt);
 
     if (ok) {
-        send_callback_response(clt->pending_sock, 200, "OK", HTTP_SUCCESS_BODY);
+        if (error_msg) {
+            send_callback_response(clt->pending_sock, 200, "OK", HTTP_PARTIAL_SUCCESS_BODY);
+        } else {
+            send_callback_response(clt->pending_sock, 200, "OK", HTTP_SUCCESS_BODY);
+        }
     } else {
         const char *token = NULL;
         if (clt->tokens) {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -2247,6 +2247,10 @@ void ztx_auth_state_cb(void *ctx, ziti_auth_state state, const void *data) {
             break;
         case ZitiAuthStatePartiallyAuthenticated: {
             ziti_set_partially_authenticated(ztx, data);
+            if (ztx->ext_auth) {
+                // external token accepted but needs user needs to finish via app (TOTP, etc)
+                ext_oidc_client_finalize(ztx->ext_auth, true, "partially authenticated");
+            }
             break;
         }
         case ZitiAuthStateFullyAuthenticated:


### PR DESCRIPTION
- partial auth indicates that external token is accepted
- indicate that user need to finish auth via the app(tunneler) in the callback page
[fixes #1083]