### PR TITLE
fix: recover from a stuck legacy (cert-based) auth/refresh request

### DIFF
--- a/library/legacy_auth.c
+++ b/library/legacy_auth.c
@@ -23,6 +23,15 @@
 #define API_SESSION_DELAY_WINDOW_SECONDS 60
 #define API_SESSION_EXPIRATION_TOO_SMALL_SECONDS 120
 
+// tlsuv_http only exposes a connect timeout -- once a request is past connect
+// it can be left dangling indefinitely (e.g. a peer that accepts the TCP
+// handshake and then never responds, as seen when a controller instance
+// disappears mid-request during a rolling restart). Without a bound here,
+// a single stuck refresh/auth request latches `refreshing` permanently and
+// the auth state machine never retries again. See fix for permanent
+// UNAUTHORIZED after API session expiry, cert-based auth path.
+#define AUTH_REQUEST_TIMEOUT_SECONDS 30
+
 #define AUTH_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "legacy_auth[%s]: " fmt, auth->http.host, ##__VA_ARGS__)
 
 struct legacy_auth_s {
@@ -33,6 +42,7 @@ struct legacy_auth_s {
 
     tlsuv_http_t http;
     uv_timer_t timer;
+    uv_timer_t req_timer; // watchdog: bounds how long an in-flight refresh/auth request can go unanswered
     ziti_api_session *session;
     
     bool has_x509;
@@ -63,6 +73,7 @@ static void free_body_cb(tlsuv_http_req_t *req, char *body, ssize_t len) {
 }
 
 static void legacy_timer_cb(uv_timer_t *t);
+static void legacy_req_timeout_cb(uv_timer_t *t);
 
 #define LEGACY_AUTH_INIT()          \
     (ziti_auth_method_t) {          \
@@ -85,6 +96,7 @@ ziti_auth_method_t *new_legacy_auth(uv_loop_t *loop, const char *url, tls_contex
     tlsuv_http_connect_timeout(&auth->http, 10 * 1000);
     tlsuv_http_set_ssl(&auth->http, tls);
     uv_timer_init(loop, &auth->timer);
+    uv_timer_init(loop, &auth->req_timer);
     AUTH_LOG(DEBUG, "method initialized");
     return &auth->api;
 }
@@ -142,12 +154,18 @@ int legacy_auth_refresh(ziti_auth_method_t *self) {
 int legacy_auth_stop(ziti_auth_method_t *self) {
     struct legacy_auth_s *auth = container_of(self, struct legacy_auth_s, api);
     uv_timer_stop(&auth->timer);
+    uv_timer_stop(&auth->req_timer);
     return ZITI_OK;
 }
 
 static void close_cb(uv_timer_t *t) {
     struct legacy_auth_s *auth = container_of(t, struct legacy_auth_s, timer);
     free(auth);
+}
+
+static void req_timer_close_cb(uv_timer_t *t) {
+    struct legacy_auth_s *auth = container_of(t, struct legacy_auth_s, req_timer);
+    uv_close((uv_handle_t *)&auth->timer, (uv_close_cb)close_cb);
 }
 
 void legacy_auth_free(ziti_auth_method_t *self) {
@@ -157,7 +175,8 @@ void legacy_auth_free(ziti_auth_method_t *self) {
     cstr_drop(&auth->primary_jwt);
     cstr_drop(&auth->secondary_jwt);
 
-    uv_close((uv_handle_t *)&auth->timer, (uv_close_cb)close_cb);
+    // chain the closes: `auth` is freed once the last handle embedded in it closes
+    uv_close((uv_handle_t *)&auth->req_timer, (uv_close_cb)req_timer_close_cb);
     tlsuv_http_close(&auth->http, NULL);
 }
 
@@ -215,6 +234,7 @@ static int legacy_auth_totp(ziti_auth_method_t *self, const char *code, auth_mfa
 
 static void legacy_session_cb(tlsuv_http_resp_t *resp, const char *err, json_object *json, void *ctx) {
     struct legacy_auth_s *auth = ctx;
+    uv_timer_stop(&auth->req_timer);
     auth->refreshing = false;
     const char *delay_type = "refresh";
     uint64_t delay = 0;
@@ -306,6 +326,7 @@ void legacy_timer_cb(uv_timer_t *t) {
             AUTH_LOG(DEBUG, "refreshing session[%p]", auth->session->id);
             tlsuv_http_req_t *req = ziti_json_request(&auth->http, "GET", "/current-api-session", legacy_session_cb, auth);
             tlsuv_http_req_header(req, HTTP_ZT_SESSION, auth->session->token);
+            uv_timer_start(&auth->req_timer, legacy_req_timeout_cb, AUTH_REQUEST_TIMEOUT_SECONDS * 1000, 0);
             return;
         }
     }
@@ -349,6 +370,19 @@ void legacy_timer_cb(uv_timer_t *t) {
 
     tlsuv_http_req_header(req, HTTP_CONTENT_TYPE, APPLICATION_JSON);
     tlsuv_http_req_data(req, body, body_len, free_body_cb);
+    uv_timer_start(&auth->req_timer, legacy_req_timeout_cb, AUTH_REQUEST_TIMEOUT_SECONDS * 1000, 0);
+}
+
+// Watchdog for a refresh/auth request that connected but never got a response
+// (tlsuv_http has no idle/response timeout of its own -- only connect_timeout).
+// Canceling routes the outstanding request back through legacy_session_cb with
+// UV_ECANCELED, which clears `refreshing` and re-arms the normal retry/backoff
+// path below -- the same recovery legacy_session_cb already performs for any
+// other transport failure.
+static void legacy_req_timeout_cb(uv_timer_t *t) {
+    struct legacy_auth_s *auth = container_of(t, struct legacy_auth_s, req_timer);
+    AUTH_LOG(WARN, "no response after %ds, canceling and retrying", AUTH_REQUEST_TIMEOUT_SECONDS);
+    tlsuv_http_cancel_all(&auth->http);
 }
 
 static const ziti_auth_query_mfa* get_mfa(ziti_api_session *session) {


### PR DESCRIPTION
## Symptom

A cert-based (non-OIDC) identity lost its API session and never recovered on
its own -- it looped on `UNAUTHORIZED/no api session token set for
ziti_controller` continuously for hours, well past the point the underlying
disruption had cleared, until the process was manually restarted. This is the
same defect class as #990 ("OIDC token refresh never recovers from network
disruption, permanent UNAUTHORIZED state requires restart"), but #990's fix
(#1025) is scoped entirely to `oidc.c`/`oidc.h`/`credentials.c` -- the OIDC
token-refresh path. The identity in this report uses cert-based auth
(`--identity <file>.json`, not OIDC enrollment), so #1025's fix does not
cover this code path. #572 (2023, general controller-API "stuck, never
reconnects" pattern, not OIDC-specific, closed without an evident code fix)
looks like the same still-open gap in the non-OIDC path.

Environment: `ziti-edge-tunnel`/`ziti-sdk-c` 1.18.1, `tlsuv` v0.41.4, 3-node
Raft HA controller cluster, 30-minute API session timeout. Client process
never crashed or exited (`systemctl` showed `active (running)` throughout),
so nothing triggered `Restart=always`; only an explicit process restart
recovered it, and the fresh process authenticated immediately.

```
# Steady-state failure loop, repeating every ~10s for hours:
ERROR ziti-sdk:ziti.c:1728 update_identity_data() ztx[1] failed to get identity_data: no api session token set for ziti_controller[UNAUTHORIZED]
ERROR ziti-sdk:ziti.c:1647 edge_routers_cb() ztx[1] failed to get current edge routers: code[0] UNAUTHORIZED/no api session token set for ziti_controller
ERROR ziti-sdk:connect.c:524 process_connect() conn[...] ziti context is not authenticated, cannot connect to service[...]
ERROR tunnel-cbs:ziti_tunnel_cbs.c:128 on_ziti_connect() ziti dial failed: invalid state
```

## Root cause

`tlsuv_http` exposes a connect timeout (`tlsuv_http_connect_timeout()`) but
no idle/response timeout. In `legacy_auth.c`, once a refresh/auth request
completes its TCP handshake, there is no bound on how long it can wait for a
response. If the peer accepts the connection and then never responds (e.g. a
controller instance that disappears mid-request during a rolling restart,
which is what coincided with the session invalidation in this report),
`legacy_session_cb()` is simply never invoked. `auth->refreshing` stays
latched `true` forever, and the existing retry/backoff logic in
`legacy_session_cb()` -- which does work correctly for every other failure
mode -- never gets a chance to run, because it's never reached.

## Fix

Add a bounded watchdog timer (`AUTH_REQUEST_TIMEOUT_SECONDS`, 30s) around
each outstanding legacy refresh/auth request (`library/legacy_auth.c`). On
expiry it calls `tlsuv_http_cancel_all()` on the auth context's HTTP client,
which routes the stuck request back through `legacy_session_cb()` with
`UV_ECANCELED` -- the same transport-failure path already exercised for
other network errors, and it re-arms the existing retry/backoff calculation
unchanged. The watchdog timer is started alongside every outstanding
request and stopped as soon as a response (successful or not) arrives, so it
never fires for healthy sessions.

This mirrors the recovery semantics #1025 added for the OIDC auth path,
applied to the legacy/cert-based path that #1025 did not cover.

Handle lifecycle: `req_timer` is closed and its close callback chains into
closing the existing `timer` handle (whose close callback frees `auth`), so
`auth` is only freed after both embedded `uv_timer_t` handles have finished
closing.

No behavior change for healthy sessions: the watchdog only fires when a
request has gone unanswered past `AUTH_REQUEST_TIMEOUT_SECONDS`; the
existing delay/backoff calculations (`refresh_delay()`, `next_backoff()`)
are untouched.

## Test evidence

- Full existing unit test suite (`ctest`, Catch2, 83 tests / ~100k
  assertions) passes unchanged against the patched build -- no regressions.
- Added a standalone regression harness (not part of this PR, used for local
  verification) that opens a mock controller which accepts a connection and
  then goes silent, confirming: the watchdog fires at ~30s, cancels the
  stuck request, the existing backoff path schedules a retry, the retry
  opens a fresh connection, and a subsequent valid response drives the auth
  state machine to `ZitiAuthStateFullyAuthenticated`.
- Not verified: end-to-end recovery against a live controller cluster
  reproducing the exact rolling-restart timing from the original incident
  (`tests/integ` requires a live quickstart Ziti network and was out of
  scope for this change's local verification).

## Related

- #990 -- same "permanent UNAUTHORIZED, restart required" symptom, fixed by
  #1025, but scoped to OIDC auth only.
- #1025 -- the OIDC-path fix this PR mirrors for the legacy/cert-based path.
- #572 -- closed 2023, no evident code fix; same "stuck, controller API
  handle never reconnects" pattern via the general controller-API path,
  likely the same defect class as #990 in the non-OIDC path.
