### PR TITLE
better auth diagnostics in ziti_dump

### DIFF
--- a/inc_internal/auth_method.h
+++ b/inc_internal/auth_method.h
@@ -58,6 +58,7 @@ struct ziti_auth_method_s {
     int (*submit_mfa)(ziti_auth_method_t *self, const char *code, auth_mfa_cb);
     int (*stop)(ziti_auth_method_t *self);
     void (*free)(ziti_auth_method_t *self);
+    void (*dump)(struct ziti_auth_method_s *self, int (*printer)(void *arg, const char *fmt, ...), void *ctx);
 };
 
 ziti_auth_method_t *new_legacy_auth(uv_loop_t *l, const char *url, tls_context *tls, bool x509);

--- a/inc_internal/zt_internal.h
+++ b/inc_internal/zt_internal.h
@@ -270,6 +270,7 @@ static inline bool ctrl_version_supports_enroll_to(const char *ctrl_ver) {
 const ziti_env_info* get_env_info();
 
 int ztx_init_external_auth(ziti_context ztx, const ziti_jwt_signer *signer);
+void ztx_dump_external_auth(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...), void *ctx);
 extern void ztx_request_session_cert(ziti_context ztx);
 extern void ztx_clear_session_creds(ziti_context ztx);
 

--- a/library/external_auth.c
+++ b/library/external_auth.c
@@ -15,6 +15,7 @@
 #include "ext_oidc.h"
 #include "zt_internal.h"
 #include <assert.h>
+#include <inttypes.h>
 #include <ziti/ziti_events.h>
 
 static void ext_token_cb(ext_oidc_client_t *oidc, enum ext_oidc_status status, const void *data);
@@ -76,6 +77,32 @@ int ztx_init_external_auth(ziti_context ztx, const ziti_jwt_signer *oidc_cfg) {
     }
 
     return ziti_get_ext_jwt_signers(ztx, ext_signers_cb, ztx);
+}
+
+void ztx_dump_external_auth(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...), void *ctx) {
+    ext_oidc_client_t *ea = ztx->ext_auth;
+    if (ea == NULL) {
+        return;
+    }
+
+    printer(ctx, "ext auth client: name[%s]\n", ea->name);
+    printer(ctx, "\tclient_id[%s]\n", ea->signer_cfg.client_id ? ea->signer_cfg.client_id : "");
+    printer(ctx, "\tprovider[%s]\n", ea->signer_cfg.provider_url ? ea->signer_cfg.provider_url : "");
+    if (ea->signer_cfg.audience) {
+        printer(ctx, "\taudience[%s]\n", ea->signer_cfg.audience);
+    }
+    if (!cstr_is_empty(&ea->current.issuer)) {
+        printer(ctx, "\taccess_token: issuer[%s] expiration[%" PRId64 "]\n",
+                cstr_str(&ea->current.issuer), ea->current.expiration);
+    }
+    if (!cstr_is_empty(&ea->refresh_token.issuer)) {
+        printer(ctx, "\trefresh_token_issuer[%s] expiration[%" PRId64 "]\n",
+                cstr_str(&ea->refresh_token.issuer), ea->refresh_token.expiration);
+    }
+    printer(ctx, "\trefresh_failures[%d]\n", ea->refresh_failures);
+    if (ea->timer && uv_is_active((uv_handle_t*)ea->timer)) {
+        printer(ctx, "\trefresh in %" PRIi64 "s\n", uv_timer_get_due_in(ea->timer) / 1000);
+    }
 }
 
 static void internal_link_cb(ext_oidc_client_t *oidc, const char *url, void *ctx) {

--- a/library/legacy_auth.c
+++ b/library/legacy_auth.c
@@ -55,6 +55,7 @@ static int legacy_auth_totp(ziti_auth_method_t *self, const char *code, auth_mfa
 static const ziti_auth_query_mfa* get_mfa(ziti_api_session *session);
 static uint64_t refresh_delay(struct legacy_auth_s *auth, ziti_api_session *);
 static const struct timeval* legacy_auth_expiration(ziti_auth_method_t *self);
+static void legacy_auth_dump(ziti_auth_method_t *self, int (*printer)(void *arg, const char *fmt, ...), void *ctx);
 
 char *ziti_mfa_code_body(const char *code);
 
@@ -74,6 +75,7 @@ static void legacy_timer_cb(uv_timer_t *t);
         .stop = legacy_auth_stop,   \
         .free = legacy_auth_free,   \
         .submit_mfa = legacy_auth_totp, \
+        .dump = legacy_auth_dump,   \
     }
 
 ziti_auth_method_t *new_legacy_auth(uv_loop_t *loop, const char *url, tls_context *tls, bool x509) {
@@ -123,6 +125,30 @@ int legacy_auth_start(ziti_auth_method_t *self, auth_state_cb cb, void *ctx) {
 const struct timeval* legacy_auth_expiration(ziti_auth_method_t *self) {
     struct legacy_auth_s *auth = container_of(self, struct legacy_auth_s, api);
     return auth->session ? &auth->session->expires : NULL;
+}
+
+static void legacy_auth_dump(ziti_auth_method_t *self, int (*printer)(void *arg, const char *fmt, ...), void *ctx) {
+    struct legacy_auth_s *auth = container_of(self, struct legacy_auth_s, api);
+
+    printer(ctx, "\tauth_method[Legacy]\n");
+    printer(ctx, "\ttype[%s]\n", auth->has_x509 ? "x509" : "ext-jwt");
+
+    if (auth->session) {
+        printer(ctx, "\tsession_id[%s]\n", auth->session->id ? auth->session->id : "");
+        printer(ctx, "\tauthenticator_id[%s]\n", auth->session->authenticator_id ? auth->session->authenticator_id : "");
+        printer(ctx, "\texpires[%ld.%06ld]\n",
+                (long)auth->session->expires.tv_sec,
+                (long)auth->session->expires.tv_usec);
+        printer(ctx, "\tmfa_required[%s] mfa_complete[%s]\n",
+                auth->session->is_mfa_required ? "true" : "false",
+                auth->session->is_mfa_complete ? "true" : "false");
+    }
+
+    printer(ctx, "\trefreshing[%s] fail_count[%d]\n",
+            auth->refreshing ? "true" : "false", auth->fail_count);
+    if (uv_is_active((uv_handle_t*)&auth->timer)) {
+        printer(ctx, "\trefresh in %" PRIi64 "s\n", uv_timer_get_due_in(&auth->timer) / 1000);
+    }
 }
 
 int legacy_auth_refresh(ziti_auth_method_t *self) {

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -87,6 +87,7 @@ static const struct timeval *oidc_auth_expiration(ziti_auth_method_t *self);
 static int oidc_auth_ext_jwt(ziti_auth_method_t *self, const char *token);
 static int oidc_auth_set_endpoint(ziti_auth_method_t *self, const api_path *api);
 static void oidc_auth_free(ziti_auth_method_t *self);
+static void oidc_auth_dump(ziti_auth_method_t *self, int (*printer)(void *arg, const char *fmt, ...), void *ctx);
 static void oidc_auth_close_cb(oidc_client_t *clt);
 static int oidc_totp_enroll(
     ziti_auth_method_t *self,
@@ -799,6 +800,7 @@ ziti_auth_method_t *new_oidc_auth(uv_loop_t *l, const api_path *api, tls_context
         .set_ext_jwt = oidc_auth_ext_jwt,
         .enroll_mfa = oidc_totp_enroll,
         .verify_mfa = oidc_totp_verify,
+        .dump = oidc_auth_dump,
     };
 
     const char *u;
@@ -862,6 +864,30 @@ static void oidc_auth_close_cb(oidc_client_t *clt) {
 static void oidc_auth_free(ziti_auth_method_t *self) {
     oidc_client_t *clt = OIDC_AUTH_FROM_API(self);
     oidc_client_close(clt, oidc_auth_close_cb);
+}
+
+static void oidc_auth_dump(ziti_auth_method_t *self, int (*printer)(void *arg, const char *fmt, ...), void *ctx) {
+    oidc_client_t *clt = OIDC_AUTH_FROM_API(self);
+
+    printer(ctx, "\tOIDC provider[%s]\n", cstr_str(&clt->provider_url));
+    if (!cstr_is_empty(&clt->current.issuer)) {
+        printer(ctx, "\taccess_token: issuer[%s] expiration[%" PRId64 "]\n",
+                cstr_str(&clt->current.issuer), clt->current.expiration);
+    }
+    if (!cstr_is_empty(&clt->refresh_token.issuer)) {
+        printer(ctx, "\trefresh_token: issuer[%s] expiration[%" PRId64 "]\n",
+                cstr_str(&clt->refresh_token.issuer), clt->refresh_token.expiration);
+    }
+
+    printer(ctx, "\tstarted[%s] configuring[%s] need_refresh[%s] refresh_failures[%d]\n",
+            clt->started ? "true" : "false",
+            clt->configuring ? "true" : "false",
+            clt->need_refresh ? "true" : "false",
+            clt->refresh_failures);
+
+    if (clt->timer && uv_is_active((uv_handle_t*)clt->timer)) {
+        printer(ctx, "\trefresh in %" PRIi64 "s\n", uv_timer_get_due_in(clt->timer) / 1000);
+    }
 }
 
 static void set_expiration(oidc_client_t *clt, const char *token) {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -932,7 +932,7 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
         printer(ctx, "====\n");
     }
 
-    printer(ctx, "\n=================\nExternal Credentials:\n");
+    printer(ctx, "\n=================\nExternal Signers:\n");
     const char *signer_name;
     ziti_jwt_signer *signer;
     printer(ctx, "ext signers[%zd]:\n", model_map_size(&ztx->ext_signers));
@@ -942,8 +942,12 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
                 signer->provider_url ? signer->provider_url : "(none)");
     }
 
+    printer(ctx, "\n=================\nExternal Auth:\n");
+    ztx_dump_external_auth(ztx, printer, ctx);
+
     const char *iss;
     zt_jwt *jwt;
+    printer(ctx, "\n=================\nExternal Tokens:\n");
     printer(ctx, "ext jwt tokens[%zd]:\n", model_map_size(&ztx->ext_jwt_tokens));
     MODEL_MAP_FOREACH(iss, jwt, &ztx->ext_jwt_tokens) {
         printer(ctx,

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -906,12 +906,20 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
     printer(ctx, "\n=================\nAPI Session:\n");
 
     if (ztx->auth_method) {
-        printer(ctx, "Session Info: \nauth_method[%s]\napi_session_state[%d]\n",
-                ztx->auth_method->kind == OIDC ? "OIDC" : "Legacy",
-                ztx->auth_state);
+        static const char *auth_state_str[] = {
+                "Unauthenticated",
+                "AuthStarted",
+                "PartiallyAuthenticated",
+                "FullyAuthenticated",
+                "ImpossibleToAuthenticate",
+        };
+
+        printer(ctx, "Session Info:\n");
+        printer(ctx, "\tauth_state[%s]\n", auth_state_str[ztx->auth_state]);
+        ztx->auth_method->dump(ztx->auth_method, printer, ctx);
 
         if (ztx->auth_method->kind == OIDC) {
-            printer(ctx, "Session Token: %s\n", jwt_payload(cstr_str(&ztx->session_token)));
+            printer(ctx, "\tSessionToken: %s\n", jwt_payload(cstr_str(&ztx->session_token)));
         }
     } else {
         printer(ctx, "No Session found\n");


### PR DESCRIPTION
internal auth sample output:
```
Session Info:
        auth_state[FullyAuthenticated]
        OIDC provider[https://1edf08b9-c9c9-4e20-9a7f-fd8b0e2482de.production.netfoundry.io:443/oidc]
        access_token: issuer[https://1edf08b9-c9c9-4e20-9a7f-fd8b0e2482de.production.netfoundry.io:443/oidc] expiration[1784129612]
        refresh_token: issuer[https://1edf08b9-c9c9-4e20-9a7f-fd8b0e2482de.production.netfoundry.io:443/oidc] expiration[1784214212]
        started[true] configuring[false] need_refresh[false] refresh_failures[0]
        refresh in 1097s
```

External auth:
```
External Auth:
ext auth client: name[MMAuth0]
        client_id[xxXXXXXX]
        provider[https://dev-b2q0t23rxctngxka.us.auth0.com/]
        audience[nfmattermost]
        access_token: issuer[https://dev-b2q0t23rxctngxka.us.auth0.com/] expiration[1784214212]
        refresh_failures[0]
```