### PR TITLE
Auth method transition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(cmake/variables.cmake)
 set(tlsuv_DIR "" CACHE FILEPATH "developer option: use local tlsuv checkout")
 # developer setting: tlsuv branch or tag to use (if tlsuv_DIR is unset)
 if (NOT tlsuv_VERSION)
-    set(tlsuv_VERSION "v0.41.4")
+    set(tlsuv_VERSION "v0.42.2")
 endif (NOT tlsuv_VERSION)
 
 message("project version: ${PROJECT_VERSION}")

--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -253,6 +253,11 @@ XX(code, model_number, none, code, __VA_ARGS__) \
 XX(cause, model_string, none, cause, __VA_ARGS__)     \
 XX(retry, model_number, none, retryHint, __VA_ARGS__)
 
+#define ZITI_CTRL_VERSION_MODEL(XX, ...) \
+ZITI_VERSION_MODEL(XX, __VA_ARGS__) \
+XX(capabilities, model_string, array, capabilities, __VA_ARGS__) \
+XX(api_versions, ziti_api_versions, ptr, apiVersions, __VA_ARGS__)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -334,6 +339,8 @@ DECLARE_MODEL(ziti_controller_detail, ZITI_CONTROLLER_DETAIL)
 DECLARE_MODEL(ziti_pr_base, ZITI_PR_BASE)
 
 DECLARE_MODEL(edge_error, EDGE_ERROR_MODEL)
+
+DECLARE_MODEL(ziti_ctrl_version, ZITI_CTRL_VERSION_MODEL)
 
 bool ziti_has_capability(const ziti_version *v, ziti_ctrl_cap c);
 int parse_enrollment_jwt(const char *token, ziti_enrollment_jwt_header *zejh, ziti_enrollment_jwt *zej, char **sig, size_t *sig_len);

--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -33,8 +33,8 @@ struct posture_checks {
     // map<type/process_path, is errored
     model_map error_states;
 
-    char *previous_api_session_id;
-    char *controller_instance_id;
+    cstr previous_api_session_id;
+    cstr controller_instance_id;
     bool must_send;
     bool must_send_every_time;
 

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -16,6 +16,7 @@
 #ifndef ZITI_SDK_CONTROLLER_H
 #define ZITI_SDK_CONTROLLER_H
 
+#include <stc/cstr.h>
 #include <tlsuv/http.h>
 #include "internal_model.h"
 #include "ziti/ziti_model.h"
@@ -28,7 +29,7 @@ typedef void (*ziti_ctrl_redirect_cb)(const char *new_address, void *ctx);
 
 typedef void (*ziti_ctrl_change_cb)(void *ctx, const model_map *endpoints);
 
-typedef void (*ctrl_version_cb)(const ziti_version *, const ziti_error *, void *);
+typedef void (*ctrl_version_cb)(const ziti_ctrl_version *, const ziti_error *, void *);
 
 typedef void(*routers_cb)(ziti_service_routers *srv_routers, const ziti_error *, void *);
 
@@ -36,7 +37,7 @@ typedef struct ziti_controller_s {
     uv_loop_t *loop;
     tlsuv_http_t *client;
 
-    char *url;
+    cstr url;
     model_map endpoints;
 
     unsigned int active_reqs;
@@ -45,14 +46,18 @@ typedef struct ziti_controller_s {
     unsigned int page_size;
 
     bool legacy;
-    bool is_ha;
-    ziti_version version;
+    struct {
+        bool ha:1;
+        bool oidc_auth:1;
+        bool oidc_auth_csr:1;
+    } capabilities;
+    ziti_ctrl_version version;
     ctrl_version_cb version_cb;
     void *version_cb_ctx;
     void *version_req;
 
     bool has_token;
-    char *instance_id;
+    cstr instance_id;
 
     ziti_ctrl_change_cb change_cb;
     ziti_ctrl_redirect_cb redirect_cb;
@@ -79,6 +84,7 @@ int ziti_ctrl_close(ziti_controller *ctrl);
 void ziti_ctrl_clear_auth(ziti_controller *ctrl);
 
 void ziti_ctrl_get_version(ziti_controller *ctrl, ctrl_version_cb cb, void *ctx);
+bool ziti_ctrl_has_capability(ziti_controller *ctrl, ziti_ctrl_cap cap);
 
 void ziti_ctrl_list_ext_jwt_signers(ziti_controller *ctrl,
                                     void (*cb)(ziti_jwt_signer_array, const ziti_error*, void*),
@@ -155,6 +161,10 @@ void ziti_ctrl_post_mfa_recovery_codes(ziti_controller *ctrl, char *body, size_t
 void ziti_ctrl_extend_cert_authenticator(ziti_controller *ctrl, const char *authenticatorId, const char *csr, void(*cb)(ziti_extend_cert_authenticator_resp*, const ziti_error *, void *), void *ctx);
 
 void ziti_ctrl_verify_extend_cert_authenticator(ziti_controller *ctrl, const char *authenticatorId, const char *client_cert, void(*cb)(void *, const ziti_error *, void *), void *ctx);
+
+static inline const char *ziti_ctrl_get_url(ziti_controller *ctrl) {
+    return cstr_str(&ctrl->url);
+}
 
 #ifdef __cplusplus
 }

--- a/includes/ziti/ziti_model.h
+++ b/includes/ziti/ziti_model.h
@@ -97,9 +97,7 @@ XX(OIDC_AUTH_WITH_CSR, __VA_ARGS__)
 #define ZITI_VERSION_MODEL(XX, ...) \
 XX(version, model_string, none, version, __VA_ARGS__) \
 XX(revision, model_string, none, revision, __VA_ARGS__) \
-XX(build_date, model_string, none, buildDate, __VA_ARGS__) \
-XX(capabilities, ziti_ctrl_cap, array, capabilities, __VA_ARGS__) \
-XX(api_versions, ziti_api_versions, ptr, apiVersions, __VA_ARGS__)
+XX(build_date, model_string, none, buildDate, __VA_ARGS__)
 
 #define ZITI_IDENTITY_MODEL(XX, ...) \
 XX(id, model_string, none, id, __VA_ARGS__) \

--- a/library/internal_model.c
+++ b/library/internal_model.c
@@ -178,6 +178,8 @@ IMPL_MODEL(ziti_pr_base, ZITI_PR_BASE)
 
 IMPL_MODEL(edge_error, EDGE_ERROR_MODEL)
 
+IMPL_MODEL(ziti_ctrl_version, ZITI_CTRL_VERSION_MODEL)
+
 bool ziti_service_has_permission(const ziti_service *service, ziti_session_type sessionType) {
     if (sessionType == ziti_session_types.Dial) {
         return (service->perm_flags & ZITI_CAN_DIAL) != 0;
@@ -518,17 +520,6 @@ int ziti_intercept_from_client_cfg(ziti_intercept_cfg_v1 *intercept, const ziti_
     return 0;
 }
 
-bool ziti_has_capability(const ziti_version *v, ziti_ctrl_cap c) {
-    if (v != NULL && v->capabilities != NULL) {
-        ziti_ctrl_cap **cap;
-        for (int idx = 0; v->capabilities[idx] != NULL; idx++) {
-            if (*v->capabilities[idx] == c) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
 
 
 IMPL_MODEL_FUNCS(ziti_address)

--- a/library/legacy_auth.c
+++ b/library/legacy_auth.c
@@ -248,6 +248,9 @@ static void legacy_session_cb(tlsuv_http_resp_t *resp, const char *err, json_obj
     ziti_api_session *session = NULL;
 
     switch(resp->code) {
+    case UV_ECANCELED:
+        // shutting down
+        return;
     case HTTP_STATUS_UNAUTHORIZED:
         if (auth->session) {
             AUTH_LOG(DEBUG, "session is no longer valid: %s", resp->status);

--- a/library/message.c
+++ b/library/message.c
@@ -154,12 +154,12 @@ bool message_get_bool_header(message *m, int header_id, bool *v) {
 
 bool message_get_int32_header(message *m, int header_id, int32_t *v) {
     hdr_t *h = find_header(m, header_id);
-    uint32_t val = 0;
     if (h != NULL) {
+        uint32_t val = 0;
         for (unsigned int i = 0; i < h->length && i < 4; i++) {
-            val += (h->value[i] << (i * 8));
+            val += (uint32_t)h->value[i] << (i * 8);
         }
-        *v = val;
+        *v = (int32_t)val;
         return true;
     }
     return false;
@@ -167,11 +167,11 @@ bool message_get_int32_header(message *m, int header_id, int32_t *v) {
 
 bool message_get_uint64_header(message *m, int header_id, uint64_t *v) {
     hdr_t *h = find_header(m, header_id);
-    uint64_t val = 0;
     if (h != NULL) {
+        uint64_t val = 0;
         for (unsigned int i = 0; i < h->length && i < 8; i++) {
             uint64_t b = h->value[i];
-            val += (b << (i * 8));
+            val += b << (i * 8);
         }
         *v = val;
         return true;

--- a/library/posture.c
+++ b/library/posture.c
@@ -137,8 +137,8 @@ void ziti_posture_init(ziti_context ztx, long interval_secs) {
     if (ztx->posture_checks == NULL) {
         NEWP(pc, struct posture_checks);
 
-        pc->previous_api_session_id = NULL;
-        pc->controller_instance_id = NULL;
+        pc->previous_api_session_id = cstr_init();
+        pc->controller_instance_id = cstr_init();
         pc->must_send_every_time = true;
         pc->must_send = false;
         pc->send_period = interval_secs * 1000;
@@ -160,8 +160,8 @@ void ziti_posture_checks_free(struct posture_checks *pcs) {
             pwk->canceled = true;
             it = model_map_it_remove(it);
         }
-        FREE(pcs->previous_api_session_id);
-        FREE(pcs->controller_instance_id);
+        cstr_drop(&pcs->previous_api_session_id);
+        cstr_drop(&pcs->controller_instance_id);
         FREE(pcs);
     }
 }
@@ -195,10 +195,10 @@ void ziti_send_posture_data(ziti_context ztx) {
     }
 
     ZTX_LOG(VERBOSE, "starting to send posture data");
-    bool new_session_id = checks->previous_api_session_id == NULL || strcmp(checks->previous_api_session_id, ztx->session->id) != 0;
+    bool new_session_id = !cstr_equals(&checks->previous_api_session_id, ztx->session->id);
 
     ziti_controller *ctrl = ztx_get_controller(ztx);
-    bool new_controller_instance = (checks->controller_instance_id == NULL && ctrl->instance_id != NULL) || strcmp(checks->controller_instance_id, ctrl->instance_id) != 0;
+    bool new_controller_instance = !cstr_eq(&checks->controller_instance_id, &ctrl->instance_id);
 
     if (new_controller_instance) {
         ZTX_LOG(INFO, "first run or potential controller restart detected");
@@ -211,10 +211,8 @@ void ziti_send_posture_data(ziti_context ztx) {
                 new_controller_instance ? "TRUE" : "FALSE");
 
         checks->must_send = true;
-        FREE(checks->previous_api_session_id);
-        FREE(checks->controller_instance_id);
-        checks->previous_api_session_id = strdup(ztx->session->id);
-        checks->controller_instance_id = strdup(ctrl->instance_id);
+        cstr_assign(&checks->previous_api_session_id, ztx->session->id);
+        cstr_copy(&checks->controller_instance_id, ctrl->instance_id);
     } else {
         ZTX_LOG(DEBUG, "posture checks must_send set to FALSE, new_session_id[%s], must_send_every_time[%s], new_controller_instance[%s]",
                 new_session_id ? "TRUE" : "FALSE",

--- a/library/utils.c
+++ b/library/utils.c
@@ -697,11 +697,12 @@ uint64_t next_backoff(int *count, int max, uint64_t base) {
     return random % ((1U << backoff) * base);
 }
 
-
+typedef void (*json_req_cb_t)(struct tlsuv_http_resp_s *, const char *, struct json_object *, void *);
 struct json_req_ctx {
-    void (*cb)(tlsuv_http_resp_t *resp, const char *err, json_object *content, void *ctx);
+    json_req_cb_t cb;
     void *ctx;
     json_tokener *json_parser;
+    json_object *resp;
     cstr error;
 };
 
@@ -720,42 +721,53 @@ static void json_body_cb(tlsuv_http_req_t *r, char *body, ssize_t len) {
     struct json_req_ctx *jctx = r->data;
     if (jctx == NULL) return;
 
-    if (len > 0) {
-        json_object *j = json_tokener_parse_ex(jctx->json_parser, body, (int) len);
-        if (j != NULL) {
-            const char *err = cstr_is_empty(&jctx->error) ? NULL : cstr_str(&jctx->error);
-            jctx->cb(&r->resp, err,  j, jctx->ctx);
-            r->data = NULL;
-            r->resp.body_cb = NULL;
-            json_object_put(j);
-            json_req_free(jctx);
-            return;
-        }
+    json_req_cb_t cb = jctx->cb;
+    void *cb_ctx = jctx->ctx;
 
-        int err = json_tokener_get_error(jctx->json_parser);
-        if (err != json_tokener_continue) {
-            r->data = NULL;
-            r->resp.body_cb = NULL;
-            jctx->cb(&r->resp, json_tokener_error_desc(err), NULL, jctx->ctx);
-            json_req_free(jctx);
+    if (len == UV_EOF) {
+        r->data = NULL;
+        r->resp.body_cb = NULL;
+        if (jctx->resp != NULL) {
+            json_object *j = jctx->resp;
+            if (cb) cb(&r->resp, NULL,  jctx->resp, cb_ctx);
+            json_object_put(j);
+        } else {
+            if (cb) cb(&r->resp, json_tokener_error_desc(json_tokener_get_error(jctx->json_parser)), NULL, cb_ctx);
         }
+        json_req_free(jctx);
         return;
     }
 
-    // error before req is complete
-    r->data = NULL;
-    r->resp.body_cb = NULL;
-    const char *err = (len == 0) ? NULL : uv_strerror((int)len);
-    jctx->cb(&r->resp, err, NULL, jctx->ctx);
-    json_req_free(jctx);
+    if (len > 0) {
+        jctx->resp = json_tokener_parse_ex(jctx->json_parser, body, (int) len);
+        int err = json_tokener_get_error(jctx->json_parser);
+        if (jctx->resp != NULL || err == json_tokener_continue) return;
+
+        r->data = NULL;
+        r->resp.body_cb = NULL;
+        if (cb) cb(&r->resp, json_tokener_error_desc(err), NULL, cb_ctx);
+        json_req_free(jctx);
+    } else {
+        // error before req is complete
+        r->data = NULL;
+        r->resp.body_cb = NULL;
+        const char *err = (len == 0) ? NULL : uv_strerror((int)len);
+        jctx->cb(&r->resp, err, NULL, jctx->ctx);
+        json_req_free(jctx);
+    }
 }
 
 static void json_req_cb(tlsuv_http_resp_t *resp, void *ctx) {
     struct json_req_ctx *jctx = ctx;
+    if (jctx == NULL) return;
 
     if (resp->code < 0) {
-        jctx->cb(resp, resp->status, NULL, jctx->ctx);
+        json_req_cb_t cb = jctx->cb;
+        void *cb_ctx = jctx->ctx;
         json_req_free(jctx);
+        resp->req->data = NULL;
+
+        if (cb) cb(resp, resp->status, NULL, cb_ctx);
         return;
     }
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -51,11 +51,11 @@
 #define ONE_DAY (60 * 60 * 24)
 
 #define ztx_controller(ztx) \
-((ztx)->ctrl.url ? (ztx)->ctrl.url : (ztx)->config.controller_url)
+(cstr_is_empty(&(ztx)->ctrl.url) ? cstr_str(&(ztx)->ctrl.url) : (ztx)->config.controller_url)
 
 int code_to_error(const char *code);
 
-static void version_pre_auth_cb(const ziti_version *version, const ziti_error *err, void *ctx);
+static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_error *err, void *ctx);
 static void update_ctrl_status(ziti_context ztx, int code, const char *msg);
 
 static void edge_routers_cb(ziti_edge_router_array ers, const ziti_error *err, void *ctx);
@@ -80,8 +80,6 @@ static void shutdown_and_free(ziti_context ztx);
 static void ca_bundle_cb(char *pkcs7, const ziti_error *err, void *ctx);
 
 static void update_identity_data(ziti_identity_data *data, const ziti_error *err, void *ctx);
-
-static void on_create_cert(ziti_create_api_cert_resp *resp, const ziti_error *e, void *ctx);
 
 static int ztx_init_controller(ziti_context ztx);
 
@@ -259,6 +257,7 @@ void ziti_set_unauthenticated(ziti_context ztx, const ziti_error *err) {
 
 void ziti_set_impossible_to_authenticate(ziti_context ztx, const ziti_error *err) {
     ziti_controller *ctrl = ztx_get_controller(ztx);
+    ztx->auth_state = ZitiAuthImpossibleToAuthenticate;
     if (err->err == UV_ECONNREFUSED || err->err == UV_EAI_NONAME) {
         ZTX_LOG(ERROR, "auth provider is not available: %s", uv_strerror(err->err));
         // current controller became unavailable
@@ -284,6 +283,7 @@ void ziti_set_impossible_to_authenticate(ziti_context ztx, const ziti_error *err
 
 void ziti_set_partially_authenticated(ziti_context ztx, const ziti_auth_query_mfa *mfa_q) {
     ZTX_LOG(DEBUG, "setting api_session_state[%d] to %d", ztx->auth_state, ZitiAuthStatePartiallyAuthenticated);
+    ztx->auth_state = ZitiAuthStatePartiallyAuthenticated;
     update_ctrl_status(ztx, ZITI_PARTIALLY_AUTHENTICATED, NULL);
 
     ziti_event_t ev = {
@@ -412,7 +412,7 @@ void ziti_set_fully_authenticated(ziti_context ztx, const char *session_token) {
         ziti_ctrl_set_ext_token(ctrl, cstr_str(&jwt->encoded));
     }
     if (ztx->auth_method->kind == OIDC) {
-        if (ctrl->is_ha) {
+        if (ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_cap_HA_CONTROLLER)) {
             ziti_ctrl_list_controllers(ctrl, ctrl_list_cb, ztx);
         }
 
@@ -733,11 +733,11 @@ void ziti_set_app_ctx(ziti_context ztx, void *app_ctx) {
 }
 
 const char *ziti_get_controller(ziti_context ztx) {
-    return ztx_get_controller(ztx)->url;
+    return cstr_str(&ztx_get_controller(ztx)->url);
 }
 
 const ziti_version *ziti_get_controller_version(ziti_context ztx) {
-    return &ztx_get_controller(ztx)->version;
+    return (ziti_version*)&ztx_get_controller(ztx)->version;
 }
 
 const ziti_identity *ziti_get_identity(ziti_context ztx) {
@@ -772,7 +772,6 @@ static void free_ztx(uv_handle_t *h) {
     free_ziti_api_session_ptr(ztx->session);
     ztx->session = NULL;
 
-    ziti_ctrl_close(ztx_get_controller(ztx));
     if (ztx->tlsCtx) ztx->tlsCtx->free_ctx(ztx->tlsCtx);
     if (ztx->id_creds.cert) {
         ztx->id_creds.cert->free(ztx->id_creds.cert);
@@ -884,8 +883,9 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
         printer(ctx, "====\n");
     }
 
-    printer(ctx, "Controller%s:\t[%s] %s\n", ztx->ctrl.is_ha ? "[HA]" : "", ztx->ctrl.version.version, ztx_controller(ztx));
-    if (ztx->ctrl.is_ha) {
+    bool is_ha = ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_cap_HA_CONTROLLER);
+    printer(ctx, "Controller%s:\t[%s] %s\n", is_ha ? "[HA]" : "", ztx->ctrl.version.version, ztx_controller(ztx));
+    if (is_ha) {
         const char *url;
         ziti_controller_detail *detail;
         MODEL_MAP_FOREACH(url, detail, &ztx->ctrl.endpoints) {
@@ -1920,6 +1920,11 @@ void ztx_prepare(uv_prepare_t *prep) {
     ziti_context ztx = prep->data;
     ZTX_LOG(TRACE, "preparing ztx for IO");
 
+    if (ztx->auth_method && ztx->auth_method->kind == LEGACY) {
+        if (ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_caps.OIDC_AUTH)) {
+            version_pre_auth_cb(&ztx->ctrl.version, NULL, ztx);
+        }
+    }
     if (!cstr_is_empty(&ztx->session_token)) {
         const struct timeval *exp = ztx->auth_method ? ztx->auth_method->expiration(ztx->auth_method) : NULL;
         // session token should be kept upto date by the auth_method,
@@ -2173,7 +2178,7 @@ static void pre_auth_retry(void *data) {
     }
 }
 
-static void version_pre_auth_cb(const ziti_version *version, const ziti_error *err, void *ctx) {
+static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_error *err, void *ctx) {
     ziti_context ztx = ctx;
     if (err) {
         ZTX_LOG(WARN, "failed to get controller version: %s/%s", err->code, err->message);
@@ -2181,12 +2186,7 @@ static void version_pre_auth_cb(const ziti_version *version, const ziti_error *e
         return;
     }
 
-    bool use_oidc = ziti_has_capability(version, ziti_ctrl_caps.OIDC_AUTH);
-    const char *force_legacy = getenv("ZITI_FORCE_LEGACY_AUTH");
-    if (force_legacy) {
-        ZTX_LOG(WARN, "ZITI_FORCE_LEGACY_AUTH is set, forcing legacy authentication method");
-        use_oidc = false;
-    }
+    bool use_oidc = ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_caps.OIDC_AUTH);
 
     ZTX_LOG(INFO, "connected to controller %s version %s(%s %s)",
             ztx_controller(ztx), version->version, version->revision, version->build_date);
@@ -2281,7 +2281,8 @@ void ztx_auth_state_cb(void *ctx, ziti_auth_state state, const void *data) {
             break;
         }
     }
-    ztx->auth_state = state;
+
+    assert(ztx->auth_state == state);
 }
 
 ziti_channel_t * ztx_get_channel(ziti_context ztx, const ziti_edge_router *er) {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -51,7 +51,7 @@
 #define ONE_DAY (60 * 60 * 24)
 
 #define ztx_controller(ztx) \
-(cstr_is_empty(&(ztx)->ctrl.url) ? cstr_str(&(ztx)->ctrl.url) : (ztx)->config.controller_url)
+(!cstr_is_empty(&(ztx)->ctrl.url) ? cstr_str(&(ztx)->ctrl.url) : (ztx)->config.controller_url)
 
 int code_to_error(const char *code);
 
@@ -223,6 +223,7 @@ extern void ziti_set_enabled(ziti_context ztx, bool enabled) {
 
 void ziti_set_auth_started(ziti_context ztx) {
     ZTX_LOG(DEBUG, "setting api_session_state[%d] to %d", ztx->auth_state, ZitiAuthStateAuthStarted);
+    ztx->auth_state = ZitiAuthStateAuthStarted;
     cstr_clear(&ztx->session_token);
 }
 

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -86,7 +86,7 @@ XX(INVALID_ENROLLMENT_NOT_ALLOWED, ZITI_ENROLLMENT_NOT_ALLOWED)
 }
 
 #define CTRL_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "ctrl[%s] " fmt, \
-ctrl->url ? ctrl->url : "<unset>", ##__VA_ARGS__)
+cstr_str(&ctrl->url), ##__VA_ARGS__)
 
 #define MAKE_RESP(ctrl, cb, parser, ctx) prepare_resp(ctrl, (ctrl_resp_cb_t)(cb), (body_parse_fn)(parser), ctx)
 
@@ -180,11 +180,10 @@ static void ctrl_resp_cb(tlsuv_http_resp_t *r, void *data) {
 
             if (ctrl->active_reqs == 0) {
                 CTRL_LOG(INFO, "attempting to switch endpoint");
-                const char *next_ep = ctrl_next_ep(ctrl, ctrl->url);
+                const char *next_ep = ctrl_next_ep(ctrl, cstr_str(&ctrl->url));
                 if (next_ep != NULL) {
-                    FREE(ctrl->url);
                     CTRL_LOG(INFO, "switching to endpoint[%s]", next_ep);
-                    ctrl->url = strdup(next_ep);
+                    cstr_assign(&ctrl->url, next_ep);
                     tlsuv_http_set_url(ctrl->client, next_ep);
                     internal_get_version(ctrl);
                 }
@@ -222,42 +221,42 @@ static void ctrl_resp_cb(tlsuv_http_resp_t *r, void *data) {
         }
 
         const char *instance_id = find_header(r, "ziti-instance-id");
-
-        if (instance_id &&
-            (resp->ctrl->instance_id == NULL || strcmp(instance_id, resp->ctrl->instance_id) != 0)) {
-            FREE(resp->ctrl->instance_id);
-            resp->ctrl->instance_id = strdup(instance_id);
+        if (instance_id) {
+            if (!cstr_equals(&ctrl->instance_id, instance_id) && strcmp(r->req->path, "/version") != 0) {
+                CTRL_LOG(DEBUG, "controller restart detected. requesting version information");
+                internal_get_version(ctrl);
+            }
+            cstr_assign(&ctrl->instance_id, instance_id);
         }
     }
 }
 
 static void ctrl_default_cb(void *s, const ziti_error *e, struct ctrl_resp *resp) {
     ziti_controller *ctrl = resp->ctrl;
-    if (resp->new_address && strcmp(resp->new_address, ctrl->url) != 0) {
+    if (resp->new_address && !cstr_equals(&ctrl->url, resp->new_address)) {
         CTRL_LOG(INFO, "controller supplied new address[%s]", resp->new_address);
 
         const char *k;
         ziti_controller_detail *detail;
         MODEL_MAP_FOREACH(k, detail, &ctrl->endpoints) {
-            if (strcasecmp(k, ctrl->url) == 0) {
+            if (cstr_iequals(&ctrl->url, k) == 0) {
                 model_map_remove(&ctrl->endpoints, k);
                 break;
             }
         }
-        FREE(ctrl->url);
-        ctrl->url = resp->new_address;
+        cstr_assign(&ctrl->url, resp->new_address);
         resp->new_address = NULL;
         if(detail == NULL) {
             detail = alloc_ziti_controller_detail();
         }
         FREE(detail->name);
-        detail->name = strdup(ctrl->url);
+        detail->name = strdup(resp->new_address);
         model_map_set(&ctrl->endpoints, detail->name, detail);
 
-        tlsuv_http_set_url(ctrl->client, ctrl->url);
+        tlsuv_http_set_url(ctrl->client, cstr_str(&ctrl->url));
 
         if (resp->ctrl->redirect_cb) {
-            ctrl->redirect_cb(ctrl->url, ctrl->cb_ctx);
+            ctrl->redirect_cb(cstr_str(&ctrl->url), ctrl->cb_ctx);
         }
     }
 
@@ -322,7 +321,7 @@ static void internal_ctrl_list_cb(ziti_controller_detail_array arr, const ziti_e
         model_map old = ctrl->endpoints;
         ctrl->endpoints = new_eps;
         model_map_clear(&old, (void (*)(void *)) free_ziti_controller_detail_ptr);
-        if (ctrl->is_ha) {
+        if (ctrl->capabilities.ha) {
             ctrl->change_cb(ctrl->cb_ctx, &ctrl->endpoints);
         }
     } else {
@@ -332,7 +331,7 @@ static void internal_ctrl_list_cb(ziti_controller_detail_array arr, const ziti_e
     free(arr);
 }
 
-static void internal_version_cb(ziti_version *v, ziti_error *e, struct ctrl_resp *resp) {
+static void internal_version_cb(ziti_ctrl_version *v, ziti_error *e, struct ctrl_resp *resp) {
     ziti_controller *ctrl = resp->ctrl;
     if (e) {
         CTRL_LOG(WARN, "%s(%s)", e->code, e->message);
@@ -344,7 +343,7 @@ static void internal_version_cb(ziti_version *v, ziti_error *e, struct ctrl_resp
             CTRL_LOG(INFO, "controller updated to %s(%s)[%s]",
                      v->version, v->revision, v->build_date);
         }
-        free_ziti_version(&ctrl->version);
+        free_ziti_ctrl_version(&ctrl->version);
         ctrl->version = *v;
 
         api_path *path = NULL;
@@ -357,8 +356,26 @@ static void internal_version_cb(ziti_version *v, ziti_error *e, struct ctrl_resp
         } else {
             CTRL_LOG(WARN, "controller did not provide expected(v1) API version path");
         }
-
-        ctrl->is_ha = ziti_has_capability(&ctrl->version, ziti_ctrl_caps.HA_CONTROLLER);
+        memset(&ctrl->capabilities, 0, sizeof(ctrl->capabilities));
+        for (int idx = 0; ctrl->version.capabilities[idx] != NULL; idx++) {
+            model_string name = ctrl->version.capabilities[idx];
+            ziti_ctrl_cap cap = ziti_ctrl_caps.value_of(name);
+            switch (cap) {
+            case ziti_ctrl_cap_OIDC_AUTH:
+                ctrl->capabilities.oidc_auth = true;
+                break;
+            case ziti_ctrl_cap_OIDC_AUTH_WITH_CSR:
+                ctrl->capabilities.oidc_auth_csr = true;
+                break;
+            case ziti_ctrl_cap_HA_CONTROLLER:
+                ctrl->capabilities.ha = true;
+                break;
+            case ziti_ctrl_cap_Unknown: 
+            default:
+                CTRL_LOG(WARN, "controller provided unknown capability: %s", name);
+                break;
+            }
+        }
 
         // data was moved to ctrl.version
         free(v);
@@ -604,10 +621,10 @@ int ziti_ctrl_init(uv_loop_t *loop, ziti_controller *ctrl, model_list *urls, tls
     }
 
     const char *initial_ep = ctrl_next_ep(ctrl, NULL);
-    ctrl->url = strdup(initial_ep);
+    cstr_assign(&ctrl->url, initial_ep);
 
     ctrl->client = calloc(1, sizeof(tlsuv_http_t));
-    if (tlsuv_http_init(loop, ctrl->client, ctrl->url) != 0) {
+    if (tlsuv_http_init(loop, ctrl->client, cstr_str(&ctrl->url)) != 0) {
         if (tlsuv_http_close(ctrl->client, (tlsuv_http_close_cb) free) != 0) {
             free(ctrl->client);
         }
@@ -623,7 +640,7 @@ int ziti_ctrl_init(uv_loop_t *loop, ziti_controller *ctrl, model_list *urls, tls
     tlsuv_http_connect_timeout(ctrl->client, ZITI_CTRL_TIMEOUT);
     tlsuv_http_header(ctrl->client, HTTP_ACCEPT, APPLICATION_JSON);
     ctrl->has_token = false;
-    ctrl->instance_id = NULL;
+    ctrl->instance_id = cstr_init();
 
     CTRL_LOG(DEBUG, "ziti controller client initialized");
     internal_get_version(ctrl);
@@ -655,7 +672,7 @@ int ziti_ctrl_set_token(ziti_controller *ctrl, const char *token) {
             tlsuv_http_header(ctrl->client, HTTP_AUTHORIZATION, cstr_str(&bearer));
         }
 
-        if (ctrl->is_ha) {
+        if (ctrl->capabilities.ha) {
             ziti_ctrl_list_controllers(ctrl, internal_ctrl_list_cb, ctrl);
         }
     }
@@ -686,10 +703,10 @@ int ziti_ctrl_cancel(ziti_controller *ctrl) {
 }
 
 int ziti_ctrl_close(ziti_controller *ctrl) {
-    free_ziti_version(&ctrl->version);
+    free_ziti_ctrl_version(&ctrl->version);
     model_map_clear(&ctrl->endpoints, (void (*)(void *)) free_ziti_controller_detail_ptr);
-    FREE(ctrl->url);
-    FREE(ctrl->instance_id);
+    cstr_drop(&ctrl->url);
+    cstr_drop(&ctrl->instance_id);
     if (ctrl->client) {
         tlsuv_http_close(ctrl->client, on_http_close);
     }
@@ -698,7 +715,7 @@ int ziti_ctrl_close(ziti_controller *ctrl) {
 }
 
 static void internal_get_version(ziti_controller *ctrl) {
-    struct ctrl_resp *resp = MAKE_RESP(ctrl, NULL, ziti_version_ptr_from_json, NULL);
+    struct ctrl_resp *resp = MAKE_RESP(ctrl, NULL, ziti_ctrl_version_ptr_from_json, NULL);
     resp->ctrl_cb = (ctrl_cb_t) internal_version_cb;
 
     ctrl->version_req = start_request(ctrl->client, "GET", "/version", ctrl_resp_cb, resp);
@@ -713,8 +730,8 @@ void ziti_ctrl_get_version(ziti_controller *ctrl, ctrl_version_cb cb, void *ctx)
     ctrl->version_cb = cb;
     ctrl->version_cb_ctx = ctx;
 
-    // if no version present and no active request
-    // /version might have failed previously so try requesting it again
+    // if no version present and no active request,
+    // /version might have failed previously, so try requesting it again
     if (ctrl->version_req == NULL) {
         internal_get_version(ctrl);
     }
@@ -816,8 +833,8 @@ void ziti_ctrl_current_edge_routers(ziti_controller *ctrl, void (*cb)(ziti_edge_
     resp->base_path = "/current-identity/edge-routers";
     ctrl_paging_req(resp);
 
-    // piggy back controller list request
-    if (ctrl->is_ha) {
+    // piggyback controller list request
+    if (ctrl->capabilities.ha) {
         ziti_ctrl_list_controllers(ctrl, internal_ctrl_list_cb, ctrl);
     }
 }
@@ -1136,4 +1153,16 @@ void ziti_ctrl_enroll_token(ziti_controller *ctrl, const char *token, const char
 
     json_object_put(body);
     cstr_drop(&auth_header);
+}
+
+bool ziti_ctrl_has_capability(ziti_controller *ctrl, ziti_ctrl_cap cap) {
+    switch (cap) {
+    case ziti_ctrl_cap_HA_CONTROLLER: return ctrl->capabilities.ha;
+    case ziti_ctrl_cap_OIDC_AUTH: return ctrl->capabilities.oidc_auth;
+    case ziti_ctrl_cap_OIDC_AUTH_WITH_CSR: return ctrl->capabilities.oidc_auth_csr;
+    default:
+        CTRL_LOG(ERROR, "TODO: add capability %d", cap);
+        assert(false);
+    }
+    return false;
 }

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -239,18 +239,18 @@ static void ctrl_default_cb(void *s, const ziti_error *e, struct ctrl_resp *resp
         const char *k;
         ziti_controller_detail *detail;
         MODEL_MAP_FOREACH(k, detail, &ctrl->endpoints) {
-            if (cstr_iequals(&ctrl->url, k) == 0) {
+            if (cstr_iequals(&ctrl->url, k)) {
                 model_map_remove(&ctrl->endpoints, k);
                 break;
             }
         }
         cstr_assign(&ctrl->url, resp->new_address);
-        resp->new_address = NULL;
         if(detail == NULL) {
             detail = alloc_ziti_controller_detail();
         }
         FREE(detail->name);
-        detail->name = strdup(resp->new_address);
+        detail->name = resp->new_address;
+        resp->new_address = NULL;
         model_map_set(&ctrl->endpoints, detail->name, detail);
 
         tlsuv_http_set_url(ctrl->client, cstr_str(&ctrl->url));

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -443,12 +443,12 @@ static void enroll_cb(ziti_enrollment_resp *resp, const ziti_error *err, void *e
     struct ziti_enroll_req *er = enroll_ctx;
 
     if (err != NULL) {
-        ZITI_LOG_ERROR(ERROR, err, "failed to enroll with controller: %s", er->controller.url);
+        ZITI_LOG_ERROR(ERROR, err, "failed to enroll with controller: %s", ziti_ctrl_get_url(&er->controller));
         complete_request(er, (int)err->err);
         return;
     }
 
-    ZITI_LOG(DEBUG, "successfully enrolled with controller %s", er->controller.url);
+    ZITI_LOG(DEBUG, "successfully enrolled with controller %s", ziti_ctrl_get_url(&er->controller));
     er->cfg.id.cert = resp->cert ? strdup(resp->cert) : strdup(er->opts.cert);
 
     complete_request(er, ZITI_OK);

--- a/programs/ziti-prox-c/main.cpp
+++ b/programs/ziti-prox-c/main.cpp
@@ -31,13 +31,14 @@
 class Run: public CLI::App {
 public:
 
-    Run(): App("run proxy", "run"),
-           debug(2) {
+    Run(): App("run proxy", "run") {
         add_option("--debug,-d", debug, "log level");
         add_option("--identity,-i", identity, "identity config")->required();
         add_option("listener", intercepts, "<name:port>");
-        add_option("--bind,-b", bindings, "bind service <name:host:port>");
-        add_option("--bind-udp,-B", udp_bindings, "bind udp service <name:host:port>");
+        add_option("--bind,-b", bindings, "bind service <name:host:port>")
+            ->allow_extra_args(false);
+        add_option("--bind-udp,-B", udp_bindings, "bind udp service <name:host:port>")
+            ->allow_extra_args(false);
         add_option("--proxy,-p", proxy, "upstream proxy url -- will be used to connect to ziti network");
         add_option("--http-proxy,-P", http_proxy_port, "enables http proxy behavior")
             ->expected(0,1)
@@ -51,8 +52,8 @@ public:
 
 
 private:
-    bool aes_crypto;
-    int debug;
+    bool aes_crypto{false};
+    int debug{3};
     std::string identity;
     std::vector<std::string> intercepts;
     std::vector<std::string> bindings;

--- a/programs/ziti-prox-c/proxy.c
+++ b/programs/ziti-prox-c/proxy.c
@@ -605,19 +605,26 @@ static void on_ziti_event(ziti_context ztx, const ziti_event_t *event) {
                     break;
             }
             break;
-        case ZitiAuthEvent:
-            if (event->auth.action == ziti_auth_prompt_totp) {
+        case ZitiAuthEvent: {
+            switch (event->auth.action) {
+            case ziti_auth_prompt_totp:
                 ZITI_LOG(INFO, "ziti requires MFA %s/%s", event->auth.type, event->auth.detail);
                 mfa_auth_event_handler(ztx);
-            } else if (event->auth.action == ziti_auth_login_external) {
+                break;
+            case ziti_auth_login_external:
                 ext_auth_event_handler(ztx, NULL);
-            } else if (event->auth.action == ziti_auth_select_external) {
+                break;
+            case ziti_auth_select_external:
                 ext_auth_select(ztx, (const ziti_jwt_signer **)event->auth.providers);
-            } else {
+                break;
+            case ziti_auth_success:
+                ZITI_LOG(INFO, "ziti auth completed");
+                break;
+            default:
                 ZITI_LOG(ERROR, "unhandled auth event %d/%s", event->auth.action, event->auth.type);
             }
             break;
-
+        }
         default:
             break;
     }

--- a/tests/integ/oidc-tests.cpp
+++ b/tests/integ/oidc-tests.cpp
@@ -136,25 +136,29 @@ TEST_CASE_METHOD(ZitiTestCase, "oidc-totp", "[totp]") {
     REQUIRE(run(UNTIL(mfa.cb_called)));
     CHECK(mfa.status == ZITI_MFA_INVALID_TOKEN);
 
-    auto ts = std::chrono::system_clock::now();
-    auto code = totp.generate_totp(ts);
-    auto code_str = std::to_string(code);
+    for (int i = 0; i < 3; i++) {
+        mfa.cb_called = false;
+        mfa.status = ZITI_OK;
 
-    mfa.cb_called = false;
-    mfa.status = ZITI_OK;
+        auto ts = std::chrono::system_clock::now();
+        auto code = totp.generate_totp(ts);
+        auto code_str = std::to_string(code);
 
-    ziti_mfa_verify(ztx, code_str.c_str(), [](ziti_context ztx, int status, void *ctx){
-        auto m = (struct mfa *)ctx;
-        m->cb_called = true;
-        m->status = status;
-        m->verified = (status == ZITI_OK);
-    }, &mfa);
+        INFO("totp attempt: " << (i + 1));
+        ziti_mfa_verify(ztx, code_str.c_str(), [](ziti_context ztx, int status, void *ctx){
+            auto m = (struct mfa *)ctx;
+            m->cb_called = true;
+            m->status = status;
+            m->verified = (status == ZITI_OK);
+        }, &mfa);
 
-    CHECK(run(UNTIL(mfa.cb_called)));
-    CHECK(mfa.verified);
-    CHECK(mfa.status == ZITI_OK);
-
-    CHECK(run(UNTIL(this->loaded && this->load_error == ZITI_OK)));
+        REQUIRE(run(UNTIL(mfa.cb_called)));
+        if (mfa.verified) {
+            break;
+        }
+    }
+    REQUIRE(mfa.verified);
 
     INFO("TOTP enrollment and verification successful");
+    REQUIRE(run(UNTIL(this->loaded && this->load_error == ZITI_OK)));
 }

--- a/tests/integ/oidc-tests.cpp
+++ b/tests/integ/oidc-tests.cpp
@@ -144,7 +144,7 @@ TEST_CASE_METHOD(ZitiTestCase, "oidc-totp", "[totp]") {
         auto code = totp.generate_totp(ts);
         auto code_str = std::to_string(code);
 
-        INFO("totp attempt: " << (i + 1));
+        UNSCOPED_INFO("totp attempt: " << (i + 1));
         ziti_mfa_verify(ztx, code_str.c_str(), [](ziti_context ztx, int status, void *ctx){
             auto m = (struct mfa *)ctx;
             m->cb_called = true;
@@ -156,6 +156,7 @@ TEST_CASE_METHOD(ZitiTestCase, "oidc-totp", "[totp]") {
         if (mfa.verified) {
             break;
         }
+        uv_sleep(1000);
     }
     REQUIRE(mfa.verified);
 

--- a/tests/test_ziti_model.cpp
+++ b/tests/test_ziti_model.cpp
@@ -701,8 +701,8 @@ TEST_CASE("parse-ctrl-version", "[model]") {
     REQUIRE(v1Path);
     REQUIRE_THAT(v1Path->path, Catch::Matchers::Equals("/edge/v1"));
 
-    CHECK(*ver.capabilities[0] == ziti_ctrl_cap_HA_CONTROLLER);
-    CHECK(*ver.capabilities[1] == ziti_ctrl_cap_OIDC_AUTH);
+    CHECK_THAT(ver.capabilities[0], Equals("HA_CONTROLLER"));
+    CHECK_THAT(ver.capabilities[1], Equals("OIDC_AUTH"));
     CHECK(ver.capabilities[2] == nullptr);
 
     free_ziti_ctrl_version(&ver);

--- a/tests/test_ziti_model.cpp
+++ b/tests/test_ziti_model.cpp
@@ -694,8 +694,8 @@ TEST_CASE("parse-ctrl-version", "[model]") {
         "version": "v0.19.12"
     })";
 
-    ziti_version ver;
-    REQUIRE(parse_ziti_version(&ver, json, strlen(json)) > 0);
+    ziti_ctrl_version ver;
+    REQUIRE(parse_ziti_ctrl_version(&ver, json, strlen(json)) > 0);
     REQUIRE(ver.api_versions != nullptr);
     auto v1Path = (api_path *) model_map_get(&ver.api_versions->edge, "v1");
     REQUIRE(v1Path);
@@ -705,11 +705,11 @@ TEST_CASE("parse-ctrl-version", "[model]") {
     CHECK(*ver.capabilities[1] == ziti_ctrl_cap_OIDC_AUTH);
     CHECK(ver.capabilities[2] == nullptr);
 
-    free_ziti_version(&ver);
+    free_ziti_ctrl_version(&ver);
     CHECK(ver.capabilities == nullptr);
     CHECK(ver.api_versions == nullptr);
     INFO("should be safe to free object again");
-    free_ziti_version(&ver);
+    free_ziti_ctrl_version(&ver);
 }
 
 TEST_CASE("parse-ziti-address", "[model]") {


### PR DESCRIPTION
Goal: 
when network is updated and gains internal OIDC authentication (automatic when updating to ziti 2.0+), ziti context should switch to it without requiring restart

Implementation:
`ziti_ctrl` automatically updates controller version whenever `ziti-instance-id` changes. controller capabilities are cached
ziti_context detects when OIDC auth method becomes available and replaces auth_method

Caveats:
User may need to complete secondary authentication steps (external auth, or TOTP) to gain full functionality

[fixes #1089]