### PR TITLE
fix busy legacy_auth churn with certain old controller configurations

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -256,7 +256,7 @@ XX(retry, model_number, none, retryHint, __VA_ARGS__)
 #define ZITI_CTRL_VERSION_MODEL(XX, ...) \
 ZITI_VERSION_MODEL(XX, __VA_ARGS__) \
 XX(capabilities, model_string, array, capabilities, __VA_ARGS__) \
-XX(api_versions, ziti_api_versions, ptr, apiVersions, __VA_ARGS__)
+XX(api_versions, ziti_api_versions, none, apiVersions, __VA_ARGS__)
 
 #define TOTP_TOKEN_MODEL(XX, ...) \
 XX(issued_at, timestamp, none, issuedAt, __VA_ARGS__) \

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -29,7 +29,7 @@ typedef void (*ziti_ctrl_redirect_cb)(const char *new_address, void *ctx);
 
 typedef void (*ziti_ctrl_change_cb)(void *ctx, const model_map *endpoints);
 
-typedef void (*ctrl_version_cb)(const ziti_ctrl_version *, const ziti_error *, void *);
+typedef void (*ctrl_version_cb)(ziti_ctrl_version *, const ziti_error *, void *);
 
 typedef void(*routers_cb)(ziti_service_routers *srv_routers, const ziti_error *, void *);
 
@@ -52,9 +52,6 @@ typedef struct ziti_controller_s {
         bool oidc_auth_csr:1;
     } capabilities;
     ziti_ctrl_version version;
-    ctrl_version_cb version_cb;
-    void *version_cb_ctx;
-    void *version_req;
 
     bool has_token;
     cstr instance_id;

--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -51,7 +51,7 @@ typedef struct ziti_controller_s {
         bool oidc_auth:1;
         bool oidc_auth_csr:1;
     } capabilities;
-    ziti_ctrl_version version;
+    ziti_ctrl_version *version;
 
     bool has_token;
     cstr instance_id;

--- a/library/external_auth.c
+++ b/library/external_auth.c
@@ -348,7 +348,8 @@ extern int ziti_ext_auth_token(ziti_context ztx, const char *token) {
     // enrollment based on configured mode
     if (ztx->identity_data == NULL && ztx->id_creds.cert == NULL) {
         if (ztx->opts.enroll_mode == ziti_enroll_cert || ztx->opts.enroll_mode == ziti_enroll_token) {
-            const char *ctrl_ver = ztx_get_controller(ztx)->version.version;
+            ziti_ctrl_version *ctrl_version = ztx_get_controller(ztx)->version;
+            const char *ctrl_ver = ctrl_version ? ctrl_version->version : NULL;
             if (!ctrl_version_supports_enroll_to(ctrl_ver)) {
                 ZTX_LOG(ERROR, "controller %s does not support enrollToCert/enrollToToken (requires v2.0+)", ctrl_ver);
                 return ZITI_INVALID_STATE;

--- a/library/legacy_auth.c
+++ b/library/legacy_auth.c
@@ -166,6 +166,7 @@ int legacy_auth_refresh(ziti_auth_method_t *self) {
 int legacy_auth_stop(ziti_auth_method_t *self) {
     struct legacy_auth_s *auth = container_of(self, struct legacy_auth_s, api);
     uv_timer_stop(&auth->timer);
+    tlsuv_http_cancel_all(&auth->http);
     return ZITI_OK;
 }
 

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -2192,26 +2192,24 @@ static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_err
         ztx_set_deadline(ztx, 5000, &ztx->refresh_deadline, pre_auth_retry, ztx);
         return;
     }
-
-    bool use_oidc = ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_caps.OIDC_AUTH);
-
     ZTX_LOG(INFO, "connected to controller %s version %s(%s %s)",
             ztx_controller(ztx), version->version, version->revision, version->build_date);
+
+    bool use_oidc = ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_caps.OIDC_AUTH);
+    api_path *oidc_path = model_map_get(&version->api_versions->oidc, "v1");
+    if (use_oidc && oidc_path == NULL) {
+        ZTX_LOG(WARN, "controller reported OIDC_AUTH capability without OIDC API version");
+        use_oidc = false;
+    }
+
     ZTX_LOG(INFO, "using %s authentication method", use_oidc ? "OIDC" : "Legacy");
     enum AuthenticationMethod m = use_oidc ? OIDC : LEGACY;
-
     if (ztx->auth_method && ztx->auth_method->kind != m) {
         ZTX_LOG(INFO, "current auth method does not match controller, switching to %s method",
                 use_oidc ? "OIDC" : "LEGACY");
         ztx->auth_method->stop(ztx->auth_method);
         ztx->auth_method->free(ztx->auth_method);
         ztx->auth_method = NULL;
-    }
-
-    api_path *oidc_path = model_map_get(&version->api_versions->oidc, "v1");
-    if (use_oidc && oidc_path == NULL) {
-        ZTX_LOG(ERROR, "controller reported OIDC_AUTH capability without OIDC API version");
-        use_oidc = false;
     }
 
     // make sure ziti_ctrl client is configured for correct auth

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -55,7 +55,7 @@
 
 int code_to_error(const char *code);
 
-static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_error *err, void *ctx);
+static void version_pre_auth_cb(ziti_ctrl_version *version, const ziti_error *err, void *ctx);
 static void update_ctrl_status(ziti_context ztx, int code, const char *msg);
 
 static void edge_routers_cb(ziti_edge_router_array ers, const ziti_error *err, void *ctx);
@@ -1941,7 +1941,7 @@ void ztx_prepare(uv_prepare_t *prep) {
 
     if (ztx->auth_method && ztx->auth_method->kind == LEGACY) {
         if (ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_caps.OIDC_AUTH)) {
-            version_pre_auth_cb(&ztx->ctrl.version, NULL, ztx);
+            ziti_re_auth(ztx);
         }
     }
     if (!cstr_is_empty(&ztx->session_token)) {
@@ -2185,7 +2185,7 @@ static void pre_auth_retry(void *data) {
     }
 }
 
-static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_error *err, void *ctx) {
+static void version_pre_auth_cb(ziti_ctrl_version *version, const ziti_error *err, void *ctx) {
     ziti_context ztx = ctx;
     if (err) {
         ZTX_LOG(WARN, "failed to get controller version: %s/%s", err->code, err->message);
@@ -2196,7 +2196,7 @@ static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_err
             ztx_controller(ztx), version->version, version->revision, version->build_date);
 
     bool use_oidc = ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_caps.OIDC_AUTH);
-    api_path *oidc_path = model_map_get(&version->api_versions->oidc, "v1");
+    api_path *oidc_path = model_map_get(&version->api_versions.oidc, "v1");
     if (use_oidc && oidc_path == NULL) {
         ZTX_LOG(WARN, "controller reported OIDC_AUTH capability without OIDC API version");
         use_oidc = false;
@@ -2228,9 +2228,9 @@ static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_err
         if (ztx->ext_auth == NULL && ztx->id_creds.key == NULL) {
             ZTX_LOG(DEBUG, "no credentials available, starting external auth");
             ztx_init_external_auth(ztx, NULL, false);
-            return;
+        } else {
+            ztx->auth_method->start(ztx->auth_method, ztx_auth_state_cb, ztx);
         }
-        ztx->auth_method->start(ztx->auth_method, ztx_auth_state_cb, ztx);
 
     } else if (ztx->auth_method->set_endpoint) {
         // OIDC endpoint may have changed
@@ -2238,6 +2238,7 @@ static void version_pre_auth_cb(const ziti_ctrl_version *version, const ziti_err
         ztx->auth_method->set_endpoint(ztx->auth_method, oidc_path);
         ztx->auth_method->force_refresh(ztx->auth_method);
     }
+    free_ziti_ctrl_version_ptr(version);
 
     if (ztx->ext_auth) {
         ext_oidc_client_refresh(ztx->ext_auth);

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -896,7 +896,8 @@ void ziti_dump(ziti_context ztx, int (*printer)(void *arg, const char *fmt, ...)
     }
 
     bool is_ha = ziti_ctrl_has_capability(&ztx->ctrl, ziti_ctrl_cap_HA_CONTROLLER);
-    printer(ctx, "Controller%s:\t[%s] %s\n", is_ha ? "[HA]" : "", ztx->ctrl.version.version, ztx_controller(ztx));
+    printer(ctx, "Controller%s:\t[%s] %s\n", is_ha ? "[HA]" : "",
+        ztx->ctrl.version ? ztx->ctrl.version->version : "", ztx_controller(ztx));
     if (is_ha) {
         const char *url;
         ziti_controller_detail *detail;

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -331,8 +331,9 @@ static void internal_ctrl_list_cb(ziti_controller_detail_array arr, const ziti_e
     free(arr);
 }
 
-static void internal_version_cb(ziti_ctrl_version *v, ziti_error *e, struct ctrl_resp *resp) {
-    ziti_controller *ctrl = resp->ctrl;
+static void internal_version_cb(ziti_ctrl_version *v, const ziti_error *e, void *ctx) {
+    ziti_controller *ctrl = ctx;
+
     if (e) {
         CTRL_LOG(WARN, "%s(%s)", e->code, e->message);
     }
@@ -346,13 +347,10 @@ static void internal_version_cb(ziti_ctrl_version *v, ziti_error *e, struct ctrl
         free_ziti_ctrl_version(&ctrl->version);
         ctrl->version = *v;
 
-        api_path *path = NULL;
-        if (v->api_versions) {
-            path = model_map_get(&v->api_versions->edge, "v1");
-        }
+        api_path *path = model_map_get(&v->api_versions.edge, "v1");
 
         if (path) {
-            tlsuv_http_set_path_prefix(resp->ctrl->client, path->path);
+            tlsuv_http_set_path_prefix(ctrl->client, path->path);
         } else {
             CTRL_LOG(WARN, "controller did not provide expected(v1) API version path");
         }
@@ -379,18 +377,7 @@ static void internal_version_cb(ziti_ctrl_version *v, ziti_error *e, struct ctrl
 
         // data was moved to ctrl.version
         free(v);
-        v = &ctrl->version;
     }
-
-    if (ctrl->version_cb) {
-        ctrl->version_cb(v, e, ctrl->version_cb_ctx);
-    }
-
-    ctrl->version_req = NULL;
-    ctrl->version_cb = NULL;
-    ctrl->version_cb_ctx = NULL;
-
-    ctrl_default_cb(NULL, e, resp);
 }
 
 void ziti_ctrl_set_legacy(ziti_controller *ctrl, bool legacy) {
@@ -715,26 +702,12 @@ int ziti_ctrl_close(ziti_controller *ctrl) {
 }
 
 static void internal_get_version(ziti_controller *ctrl) {
-    struct ctrl_resp *resp = MAKE_RESP(ctrl, NULL, ziti_ctrl_version_ptr_from_json, NULL);
-    resp->ctrl_cb = (ctrl_cb_t) internal_version_cb;
-
-    ctrl->version_req = start_request(ctrl->client, "GET", "/version", ctrl_resp_cb, resp);
+    ziti_ctrl_get_version(ctrl, internal_version_cb, ctrl);
 }
 
 void ziti_ctrl_get_version(ziti_controller *ctrl, ctrl_version_cb cb, void *ctx) {
-    // already received version just callback with it
-    if (ctrl->version.version != NULL) {
-        cb(&ctrl->version, NULL, ctx);
-        return;
-    }
-    ctrl->version_cb = cb;
-    ctrl->version_cb_ctx = ctx;
-
-    // if no version present and no active request,
-    // /version might have failed previously, so try requesting it again
-    if (ctrl->version_req == NULL) {
-        internal_get_version(ctrl);
-    }
+    struct ctrl_resp *resp = MAKE_RESP(ctrl, cb, ziti_ctrl_version_ptr_from_json, ctx);
+    start_request(ctrl->client, "GET", "/version", ctrl_resp_cb, resp);
 }
 
 static bool verify_api_session(ziti_controller *ctrl, ctrl_resp_cb_t cb, void *ctx) {
@@ -1180,7 +1153,12 @@ void ziti_ctrl_enroll_token(ziti_controller *ctrl, const char *token, const char
 bool ziti_ctrl_has_capability(ziti_controller *ctrl, ziti_ctrl_cap cap) {
     switch (cap) {
     case ziti_ctrl_cap_HA_CONTROLLER: return ctrl->capabilities.ha;
-    case ziti_ctrl_cap_OIDC_AUTH: return ctrl->capabilities.oidc_auth;
+    case ziti_ctrl_cap_OIDC_AUTH: {
+        // avoid reporting old buggy controllers as OIDC capable
+        // if OIDC binding is missing
+        return ctrl->capabilities.oidc_auth
+               && model_map_get(&ctrl->version.api_versions.oidc, "v1") != NULL;
+    }
     case ziti_ctrl_cap_OIDC_AUTH_WITH_CSR: return ctrl->capabilities.oidc_auth_csr;
     default:
         CTRL_LOG(ERROR, "TODO: add capability %d", cap);

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -127,6 +127,7 @@ struct ctrl_resp {
     ctrl_cb_t ctrl_cb;
 };
 
+static void internal_version_cb(ziti_ctrl_version *v, const ziti_error *e, void *ctx);
 static void internal_get_version(ziti_controller *ctrl);
 
 static struct ctrl_resp *prepare_resp(ziti_controller *ctrl, ctrl_resp_cb_t cb, body_parse_fn parser, void *ctx);
@@ -222,7 +223,8 @@ static void ctrl_resp_cb(tlsuv_http_resp_t *r, void *data) {
 
         const char *instance_id = find_header(r, "ziti-instance-id");
         if (instance_id) {
-            if (!cstr_equals(&ctrl->instance_id, instance_id) && strcmp(r->req->path, "/version") != 0) {
+            if (!cstr_equals(&ctrl->instance_id, instance_id) &&
+                resp->resp_cb != (ctrl_resp_cb_t)internal_version_cb) {
                 CTRL_LOG(DEBUG, "controller restart detected. requesting version information");
                 internal_get_version(ctrl);
             }
@@ -339,13 +341,13 @@ static void internal_version_cb(ziti_ctrl_version *v, const ziti_error *e, void 
     }
 
     if (v) {
-        if (ctrl->version.version != NULL &&
-            strcmp(ctrl->version.version, v->version) != 0) {
+        if (ctrl->version != NULL && ctrl->version->version != NULL &&
+            strcmp(ctrl->version->version, v->version) != 0) {
             CTRL_LOG(INFO, "controller updated to %s(%s)[%s]",
                      v->version, v->revision, v->build_date);
         }
-        free_ziti_ctrl_version(&ctrl->version);
-        ctrl->version = *v;
+        free_ziti_ctrl_version_ptr(ctrl->version);
+        ctrl->version = v;
 
         api_path *path = model_map_get(&v->api_versions.edge, "v1");
 
@@ -355,8 +357,8 @@ static void internal_version_cb(ziti_ctrl_version *v, const ziti_error *e, void 
             CTRL_LOG(WARN, "controller did not provide expected(v1) API version path");
         }
         memset(&ctrl->capabilities, 0, sizeof(ctrl->capabilities));
-        for (int idx = 0; ctrl->version.capabilities[idx] != NULL; idx++) {
-            model_string name = ctrl->version.capabilities[idx];
+        for (int idx = 0; ctrl->version->capabilities[idx] != NULL; idx++) {
+            model_string name = ctrl->version->capabilities[idx];
             ziti_ctrl_cap cap = ziti_ctrl_caps.value_of(name);
             switch (cap) {
             case ziti_ctrl_cap_OIDC_AUTH:
@@ -374,9 +376,6 @@ static void internal_version_cb(ziti_ctrl_version *v, const ziti_error *e, void 
                 break;
             }
         }
-
-        // data was moved to ctrl.version
-        free(v);
     }
 }
 
@@ -690,7 +689,8 @@ int ziti_ctrl_cancel(ziti_controller *ctrl) {
 }
 
 int ziti_ctrl_close(ziti_controller *ctrl) {
-    free_ziti_ctrl_version(&ctrl->version);
+    free_ziti_ctrl_version_ptr(ctrl->version);
+    ctrl->version = NULL;
     model_map_clear(&ctrl->endpoints, (void (*)(void *)) free_ziti_controller_detail_ptr);
     cstr_drop(&ctrl->url);
     cstr_drop(&ctrl->instance_id);
@@ -1157,7 +1157,8 @@ bool ziti_ctrl_has_capability(ziti_controller *ctrl, ziti_ctrl_cap cap) {
         // avoid reporting old buggy controllers as OIDC capable
         // if OIDC binding is missing
         return ctrl->capabilities.oidc_auth
-               && model_map_get(&ctrl->version.api_versions.oidc, "v1") != NULL;
+               && ctrl->version != NULL
+               && model_map_get(&ctrl->version->api_versions.oidc, "v1") != NULL;
     }
     case ziti_ctrl_cap_OIDC_AUTH_WITH_CSR: return ctrl->capabilities.oidc_auth_csr;
     default:

--- a/library/zitilib/zitilib.c
+++ b/library/zitilib/zitilib.c
@@ -177,7 +177,8 @@ static void on_ctx_event(ziti_context ztx, const ziti_event_t *ev) {
         if (ev->auth.action == ziti_auth_select_external) {
             // check controller version for cert/token enrollment
             if (wrap->enroll_mode == ziti_enroll_cert || wrap->enroll_mode == ziti_enroll_token) {
-                const char *ctrl_ver = ztx_get_controller(ztx)->version.version;
+                ziti_ctrl_version *ctrl_version = ztx_get_controller(ztx)->version;
+                const char *ctrl_ver = ctrl_version ? ctrl_version->version : NULL;
                 if (!ctrl_version_supports_enroll_to(ctrl_ver)) {
                     ZITI_LOG(ERROR, "controller %s does not support enrollToCert/enrollToToken (requires v2.0+)", ctrl_ver);
                     fail_future(wrap->enroll_future, ZITI_INVALID_STATE);

--- a/tests/integ/ctrl_tests.cpp
+++ b/tests/integ/ctrl_tests.cpp
@@ -184,7 +184,7 @@ TEST_CASE_METHOD(CtrlTest, "authenticate", "[controller]") {
     check_capability(ziti_ctrl_cap_OIDC_AUTH);
     auto version = CALL(ziti_ctrl_get_version);
     REQUIRE(version);
-    auto p = map_get<api_path*>(version.value()->api_versions->oidc, "v1");
+    auto p = map_get<api_path*>(version.value()->api_versions.oidc, "v1");
     auto auth = new_oidc_auth(loop(), p, cfg->id.ca, &creds);
 
     DEFER {

--- a/tests/integ/legacy-auth.cpp
+++ b/tests/integ/legacy-auth.cpp
@@ -81,7 +81,7 @@ TEST_CASE("controller_test","[integ]") {
         auto v = ctrl_get(ctrl, ziti_ctrl_get_version);
         REQUIRE(v != nullptr);
 
-        auto v1 = (const char*)model_map_get(&v->api_versions->edge, "v1");
+        auto v1 = (const char*)model_map_get(&v->api_versions.edge, "v1");
         CHECK(v1 != nullptr);
 
         auto auth = new_legacy_auth(loop, config.controller_url, tls, true);

--- a/tests/test_ziti_model.cpp
+++ b/tests/test_ziti_model.cpp
@@ -696,8 +696,7 @@ TEST_CASE("parse-ctrl-version", "[model]") {
 
     ziti_ctrl_version ver;
     REQUIRE(parse_ziti_ctrl_version(&ver, json, strlen(json)) > 0);
-    REQUIRE(ver.api_versions != nullptr);
-    auto v1Path = (api_path *) model_map_get(&ver.api_versions->edge, "v1");
+    auto v1Path = (api_path *) model_map_get(&ver.api_versions.edge, "v1");
     REQUIRE(v1Path);
     REQUIRE_THAT(v1Path->path, Catch::Matchers::Equals("/edge/v1"));
 
@@ -707,7 +706,6 @@ TEST_CASE("parse-ctrl-version", "[model]") {
 
     free_ziti_ctrl_version(&ver);
     CHECK(ver.capabilities == nullptr);
-    CHECK(ver.api_versions == nullptr);
     INFO("should be safe to free object again");
     free_ziti_ctrl_version(&ver);
 }


### PR DESCRIPTION
older controllers (seen with 1.1.15) that report OIDC without oidc binding may cause busy spin inside SDK

[fixes #1106]