### PR TITLE
ha enrollment: populate controller endpoints from response

### DIFF
--- a/inc_internal/internal_model.h
+++ b/inc_internal/internal_model.h
@@ -135,7 +135,8 @@ XX(env_info, ziti_env_info, ptr, envInfo, __VA_ARGS__) \
 XX(config_types, model_string, list, configTypes, __VA_ARGS__)
 
 #define ZITI_ENROLLMENT_RESP(XX, ...) \
-XX(cert, model_string, none, cert, __VA_ARGS__)
+XX(cert, model_string, none, cert, __VA_ARGS__) \
+XX(controllers, ziti_controller_detail, list, controllers, __VA_ARGS__)
 
 #define ZITI_PR_BASE(XX, ...) \
 XX(id, model_string, none, id, __VA_ARGS__) \

--- a/library/ziti_enroll.c
+++ b/library/ziti_enroll.c
@@ -450,6 +450,18 @@ static void enroll_cb(ziti_enrollment_resp *resp, const ziti_error *err, void *e
 
     ZITI_LOG(DEBUG, "successfully enrolled with controller %s", ziti_ctrl_get_url(&er->controller));
     er->cfg.id.cert = resp->cert ? strdup(resp->cert) : strdup(er->opts.cert);
+    if (model_list_size(&resp->controllers) > 0) {
+        model_list_clear(&er->cfg.controllers, free);
+        ziti_controller_detail *ctrl;
+        api_address *addr;
+        MODEL_LIST_FOREACH(ctrl, resp->controllers) {
+            MODEL_LIST_FOREACH(addr, ctrl->apis.edge) {
+                if (addr->url != NULL) {
+                    model_list_append(&er->cfg.controllers, strdup(addr->url));
+                }
+            }
+        }
+    }
 
     complete_request(er, ZITI_OK);
     free_ziti_enrollment_resp_ptr(resp);


### PR DESCRIPTION
populate identity file `ztAPIs` from the list returned in enrollment response

see openziti/ziti#3947