### PR TITLE
don't collect posture responses that haven't been answered yet

### DIFF
--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -49,6 +49,9 @@ void ziti_send_posture_data(ziti_context ztx);
 
 void ziti_send_posture_er(ziti_context ztx, ziti_channel_t *ch);
 
+// collect_all also gathers responses that have not changed since the last send
+void ziti_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all);
+
 bool ziti_service_has_query_with_timeout(ziti_service *service);
 
 #ifdef __cplusplus

--- a/inc_internal/posture.h
+++ b/inc_internal/posture.h
@@ -50,7 +50,7 @@ void ziti_send_posture_data(ziti_context ztx);
 void ziti_send_posture_er(ziti_context ztx, ziti_channel_t *ch);
 
 // collect_all also gathers responses that have not changed since the last send
-void ziti_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all);
+void ztx_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all);
 
 bool ziti_service_has_query_with_timeout(ziti_service *service);
 

--- a/library/posture.c
+++ b/library/posture.c
@@ -576,7 +576,7 @@ static char *ziti_pr_to_json(const ziti_pr_base *pr) {
 
 int model_list_fmt_to_json(string_buf_t *buf, model_list *l, const type_meta *meta, int flags, int indent);
 
-void ziti_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all) {
+void ztx_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all) {
     struct posture_checks *checks = ztx->posture_checks;
     if (!checks) {
         ZTX_LOG(DEBUG, "endpoint is disabled");
@@ -599,7 +599,7 @@ void ziti_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_a
 
 static void ziti_pr_send_bulk(ziti_context ztx) {
     model_list send_prs = {};
-    ziti_collect_posture(ztx, &send_prs, false);
+    ztx_collect_posture(ztx, &send_prs, false);
 
     if (model_list_size(&send_prs) > 0) {
         ZTX_LOG(DEBUG, "sending posture responses [%zd]", model_list_size(&send_prs));
@@ -1293,7 +1293,7 @@ void ziti_send_posture_er(ziti_context ztx, ziti_channel_t *ch) {
     }
 
     model_list send_prs = {};
-    ziti_collect_posture(ztx, &send_prs, true);
+    ztx_collect_posture(ztx, &send_prs, true);
 
     uint8_t pad[128];
     Ziti__EdgeClient__Pb__PostureResponses *resp = create_posture_resp(ztx, &send_prs);

--- a/library/posture.c
+++ b/library/posture.c
@@ -576,7 +576,7 @@ static char *ziti_pr_to_json(const ziti_pr_base *pr) {
 
 int model_list_fmt_to_json(string_buf_t *buf, model_list *l, const type_meta *meta, int flags, int indent);
 
-static void collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all) {
+void ziti_collect_posture(ziti_context ztx, model_list *send_prs, bool collect_all) {
     struct posture_checks *checks = ztx->posture_checks;
     if (!checks) {
         ZTX_LOG(DEBUG, "endpoint is disabled");
@@ -590,7 +590,8 @@ static void collect_posture(ziti_context ztx, model_list *send_prs, bool collect
                 info->should_send ? "sending" : "not sending",
                 info->id,
                 info->pending ? "true" : "false");
-        if (collect_all || info->should_send) {
+        // collect_all bypasses the should_send filter, not the question of whether an answer exists yet
+        if ((collect_all && info->obj != NULL) || info->should_send) {
             model_list_append(send_prs, info);
         }
     }
@@ -598,7 +599,7 @@ static void collect_posture(ziti_context ztx, model_list *send_prs, bool collect
 
 static void ziti_pr_send_bulk(ziti_context ztx) {
     model_list send_prs = {};
-    collect_posture(ztx, &send_prs, false);
+    ziti_collect_posture(ztx, &send_prs, false);
 
     if (model_list_size(&send_prs) > 0) {
         ZTX_LOG(DEBUG, "sending posture responses [%zd]", model_list_size(&send_prs));
@@ -1292,7 +1293,7 @@ void ziti_send_posture_er(ziti_context ztx, ziti_channel_t *ch) {
     }
 
     model_list send_prs = {};
-    collect_posture(ztx, &send_prs, true);
+    ziti_collect_posture(ztx, &send_prs, true);
 
     uint8_t pad[128];
     Ziti__EdgeClient__Pb__PostureResponses *resp = create_posture_resp(ztx, &send_prs);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ add_executable(all_tests
         e2ee_tests.cpp
         util_tests.cpp
         oidc_recovery_tests.cpp
-        ctrl_endpoint_tests.cpp)
+        ctrl_endpoint_tests.cpp
+        posture_tests.cpp)
 
 set_property(TARGET all_tests PROPERTY CXX_STANDARD 20)
 if (WIN32)

--- a/tests/posture_tests.cpp
+++ b/tests/posture_tests.cpp
@@ -83,7 +83,7 @@ namespace {
 
         size_t collect_all() {
             model_list send_prs = {};
-            ziti_collect_posture(&ztx, &send_prs, true);
+            ztx_collect_posture(&ztx, &send_prs, true);
             const size_t n = model_list_size(&send_prs);
             model_list_clear(&send_prs, nullptr);
             return n;

--- a/tests/posture_tests.cpp
+++ b/tests/posture_tests.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026.  NetFoundry Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// An entry is registered before the work that answers it runs, so info->obj is NULL while process collection
+// sits on the threadpool. A router asks for posture inside that window and ziti_send_posture_er collects with
+// collect_all, which used to sweep the empty entry into create_posture_resp's info->obj->typeId.
+
+#include "catch2_includes.hpp"
+
+// stc/cstr.h declares _cstr_init as plain `extern`, which mangles under C++; common.h first, then cstr.h
+// under C linkage, satisfies both without wrapping zt_internal.h (that breaks stc's C++ templates).
+#include <stc/common.h>
+extern "C" {
+#include <stc/cstr.h>
+}
+
+#include "posture.h"
+#include "zt_internal.h"
+
+namespace {
+
+    const char *SERVICE_JSON = R"({"id":"svc-1","name":"test-service","posturePolicies":{"p1":{"policyId":"p1",
+      "isPassing":true,"policyType":"Dial","postureQueries":[{"id":"q1","isPassing":true,"queryType":"PROCESS",
+      "timeout":-1,"process":{"path":"/does/not/matter"}}]}}})";
+
+    bool answer_process_query = false;
+
+    // stands in for the threadpool collection: withholding the callback leaves the entry pending with no obj
+    extern "C" void stub_pq_process(ziti_context ztx, const char *id, const char *path,
+                                    ziti_pr_process_cb response_cb) {
+        if (answer_process_query) {
+            response_cb(ztx, id, path, true, "deadbeef", nullptr, 0);
+        }
+    }
+
+    struct posture_fixture {
+        uv_loop_t loop{};
+        ziti_ctx ztx{};
+        ziti_api_session session{};
+        ziti_service *service = nullptr;
+
+        explicit posture_fixture(bool answer) {
+            answer_process_query = answer;
+
+            uv_loop_init(&loop);
+            ztx.loop = &loop;
+
+            // ziti_send_posture_data collects nothing unless the context is fully authenticated
+            ztx.auth_state = ZitiAuthStateFullyAuthenticated;
+            session.id = "session-1";
+            ztx.session = &session;
+            ztx.opts.pq_process_cb = stub_pq_process;
+
+            REQUIRE(parse_ziti_service_ptr(&service, SERVICE_JSON, strlen(SERVICE_JSON)) > 0);
+            model_map_set(&ztx.services, service->name, service);
+
+            ziti_posture_init(&ztx, 60);
+            ziti_send_posture_data(&ztx);
+        }
+
+        ~posture_fixture() {
+            ziti_posture_checks_free(ztx.posture_checks);
+            ztx.posture_checks = nullptr;
+            model_map_clear(&ztx.services, (_free_f) free_ziti_service_ptr);
+            uv_loop_close(&loop);
+            answer_process_query = false;
+        }
+
+        size_t registered() const { return model_map_size(&ztx.posture_checks->responses); }
+
+        size_t collect_all() {
+            model_list send_prs = {};
+            ziti_collect_posture(&ztx, &send_prs, true);
+            const size_t n = model_list_size(&send_prs);
+            model_list_clear(&send_prs, nullptr);
+            return n;
+        }
+    };
+}
+
+TEST_CASE("posture response still pending is not collected", "[posture]") {
+    posture_fixture f(false);
+
+    REQUIRE(f.registered() == 1);
+    CHECK(f.collect_all() == 0);
+}
+
+TEST_CASE("posture response with an answer is collected", "[posture]") {
+    posture_fixture f(true);
+
+    REQUIRE(f.registered() == 1);
+    CHECK(f.collect_all() == 1);
+}


### PR DESCRIPTION
closes #1123 

and align 'collect_posture' to the 'ziti_' convention