### PR TITLE
create json-c overlay pulling in memory leak fixes

### DIFF
--- a/vcpkg-overlays/common/json-c/json_object_put-leak.patch
+++ b/vcpkg-overlays/common/json-c/json_object_put-leak.patch
@@ -1,0 +1,30 @@
+diff --git a/json_object.c b/json_object.c
+index 0a61967..71cd25b 100644
+--- a/json_object.c
++++ b/json_object.c
+@@ -303,6 +303,7 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
+ 
+ 	if (jso->_user_delete)
+ 		jso->_user_delete(jso, jso->_userdata);
++	jso->_user_delete = NULL;
+ 
+ 	switch (jso->o_type)
+ 	{
+@@ -435,11 +436,16 @@ int json_object_put(struct json_object *jso)
+ 		// All slots are cleared, now pop back up to the parent
+ 		{
+ 			json_object *parent = jso->_delete_parent;
++			int rc;
+ 			// jso is a child that's already been detached from its parent
+ 			// so we need to actually free it now
+ 			assert(jso->_ref_count == 0);
+ 			jso->_ref_count++;   // We're the exclusive owner of jso, non-atomic add is ok.
+-			assert(_json_object_put_maybe_free(jso, 1) == 0);
++			// Note: the call must not be inside assert(), or it gets
++			// compiled out when NDEBUG is defined and the memory leaks.
++			rc = _json_object_put_maybe_free(jso, 1);
++			assert(rc == 0);
++			(void)rc;
+ 			jso = parent;
+ 			// iteration will be reset at the top of the loop
+ 		}

--- a/vcpkg-overlays/common/json-c/portfile.cmake
+++ b/vcpkg-overlays/common/json-c/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO json-c/json-c
+    REF "json-c-${VERSION}"
+
+    SHA512 3be9058351acb3d9a66c7ae850391ebaa80472b42ee3f013f8b655743eb41b55513e0546c6798399af98ed049b80d11c93286ea3f5af26dc5f199905a28c4db1
+    HEAD_REF master
+    PATCHES
+        json_object_put-leak.patch
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" JSON_BUILD_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" JSON_BUILD_SHARED)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTING=OFF
+        -DBUILD_STATIC_LIBS=${JSON_BUILD_STATIC}
+        -DBUILD_SHARED_LIBS=${JSON_BUILD_SHARED}
+        -DDISABLE_EXTRA_LIBS=ON
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/vcpkg-overlays/common/json-c/vcpkg.json
+++ b/vcpkg-overlays/common/json-c/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "json-c",
+  "version": "0.19-20260627",
+  "description": "A JSON implementation in C",
+  "homepage": "https://github.com/json-c/json-c",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
add the patch from json-c/json-c#936 to address memory leak in Release/RelWithDebugInfo builds