### PR TITLE
fix(zitilib): avoid loopback accept race in connect_socket on Windows 10

### DIFF
--- a/library/zitilib/zl_sockets.c
+++ b/library/zitilib/zl_sockets.c
@@ -129,7 +129,23 @@ int connect_socket(int af, ziti_socket_t clt_sock, ziti_socket_t *ziti_sock) {
     TRY(WSOCK, WSAGetLastError() != WSAEWOULDBLOCK);
     rc = 0;
 
-    TRY(WSOCK, (ssock = accept(lsock, NULL, NULL)) == SOCKET_ERROR);
+    // Wait for the loopback connection to be ready BEFORE accepting. The
+    // immediate non-blocking accept() loses the race on Windows 10 (the
+    // loopback handshake completes asynchronously) and returns INVALID_SOCKET.
+    // The TRY guard used below is a no-op for this case (PREPF's lt_zero
+    // condition applied to a 0/1 boolean never fires), so INVALID_SOCKET was
+    // passed on as "success" and reached the bridge -> "unsupported fd type",
+    // killing the connection (0 bytes, later RST). select() with a timeout
+    // makes accept() reliable without risking an indefinite block.
+    {
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(lsock, &rfds);
+        struct timeval tv = { 5, 0 };
+        TRY(WSOCK, (select(0, &rfds, NULL, NULL, &tv) <= 0) ? SOCKET_ERROR : 0);
+    }
+    ssock = accept(lsock, NULL, NULL);
+    TRY(WSOCK, (ssock == INVALID_SOCKET) ? SOCKET_ERROR : 0);
 
     nonblocking = 0;
     ioctlsocket(clt_sock, FIONBIO, &nonblocking);


### PR DESCRIPTION
## Summary

Hosted Ziti sockets (created via `Ziti_bind` / `Ziti_accept` — e.g. a zrok public share in `proxy` backend mode) are effectively unusable on **Windows 10 / Server 2019**, while working fine on **Windows 11**. Incoming dials are accepted but the SDK immediately logs `unsupported fd type`, and the caller gets a dead connection (0 bytes, then RST — surfacing as a 502 at a public frontend).

The root cause is a race in `connect_socket()` (`library/zitilib/zl_sockets.c`) combined with an error check that never fires and therefore hides it.

## The bug

For every accepted connection, `on_ziti_accept()` builds a loopback socketpair via `connect_socket()` so the application gets a usable OS socket. On Windows that function:

1. creates a listening socket in **non-blocking** mode;
2. issues a **non-blocking** `connect()` on the client socket (returns `WSAEWOULDBLOCK`; the handshake proceeds in the background);
3. calls `accept()` on the listener **immediately**.

Between steps 2 and 3, the loopback TCP handshake has to have completed for `accept()` to find the connection — which does not reliably happen that fast on Windows 10.

The failure is silent because of this guard:

```c
TRY(WSOCK, (ssock = accept(lsock, NULL, NULL)) == SOCKET_ERROR);
```

`PREPF(WSOCK, ...)` uses the `lt_zero` condition (fires when the value is `< 0`), but `(ssock = accept(...)) == SOCKET_ERROR` evaluates to `0` or `1` — never negative — so the jump to the error label never happens. `connect_socket()` then returns success with `ssock = INVALID_SOCKET`, which is handed to `ziti_conn_bridge_fds()` → `create_uv_handle()`. There, `getsockopt(INVALID_SOCKET, SO_TYPE)` fails, the code falls back to `uv_guess_handle()` on a non-socket handle, and the result is the `unsupported fd type` error and a dead bridge.

## Why Windows 10 and not Windows 11

It is purely loopback timing. On Windows 11 the loopback connection is established synchronously enough that the immediate `accept()` succeeds; on Windows 10 / Server 2019 the AFD/tcpip loopback path completes slightly later, so the non-blocking `accept()` usually returns `INVALID_SOCKET`. It is a race whose odds depend on the OS — which is why the same binary "works on 11, fails on 10". (Field data with an older SDK build showed intermittent ~33% success on Windows 10, consistent with a timing race.)

## The fix

Wait for the listening socket to become readable (a `select()` with a 5s timeout) before calling `accept()`, and check the accept result explicitly (using the `? SOCKET_ERROR : 0` form so the existing `TRY` macro actually detects a failure). This removes the race on every Windows version. POSIX behavior is unchanged.

## Testing

Reproduced and fixed on a Windows 10 host (build 19045) that previously failed nearly 100% of hosted requests:

- **Before** (stock 1.18.6 and 1.18.7): requests failed; every connection logged `unsupported fd type` and closed with 0 bytes.
- **After**: 12/12 requests returned HTTP 200, no `unsupported fd type` was logged, and connections carried real payload and closed gracefully.

Windows 11 behavior is unchanged (it already worked). Built with the standard `x64-windows-static-md` toolchain; the resulting `ziti.dll` has the same runtime dependencies as the official build.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
