### PR TITLE
retry OIDC auth failure to allow HA cluster to catchup

### DIFF
--- a/inc_internal/oidc.h
+++ b/inc_internal/oidc.h
@@ -67,6 +67,13 @@ struct oidc_client_s {
     tlsuv_http_req_t *refresh_req;
     int refresh_failures;
 
+    // initial/full auth flow retry state: a freshly enrolled identity may not
+    // have replicated to the controller node we reached yet, so the login leg
+    // rejects good credentials for a short while. see schedule_auth_retry().
+    int auth_failures;            // consecutive auth-flow failures, feeds next_backoff()
+    uint64_t auth_retry_until;    // uv_now() ms past which a failure is reported; 0 = no window open
+    uint64_t auth_retry_window;   // ms; defaults to OIDC_AUTH_RETRY_WINDOW_MS (tests shorten it)
+
     // auth-method facade (populated only by new_oidc_auth)
     ziti_auth_method_t api;
     uv_loop_t *loop;

--- a/inc_internal/oidc.h
+++ b/inc_internal/oidc.h
@@ -73,6 +73,8 @@ struct oidc_client_s {
     int auth_failures;            // consecutive auth-flow failures, feeds next_backoff()
     uint64_t auth_retry_until;    // uv_now() ms past which a failure is reported; 0 = no window open
     uint64_t auth_retry_window;   // ms; defaults to OIDC_AUTH_RETRY_WINDOW_MS (tests shorten it)
+    bool primary_ok;              // indicates that primary auth succeeded,
+                                  // secondary auth failures do not trigger retry
 
     // auth-method facade (populated only by new_oidc_auth)
     ziti_auth_method_t api;

--- a/inc_internal/utils.h
+++ b/inc_internal/utils.h
@@ -190,8 +190,8 @@ tlsuv_http_req_t* ziti_json_request(
     void *ctx);
 
 // Returns true if an HTTP error response represents a transient/temporary
-// condition that may succeed on retry (network errors, 5xx, or zitadel-style
-// "server_error" returned with a 400 body).
+// condition that may succeed on retry (network errors, 5xx, 429, or
+// zitadel-style "server_error" returned with a 400 body).
 bool ziti_http_error_is_temporary(tlsuv_http_resp_t *resp, json_object *body);
 
 #ifdef __cplusplus

--- a/inc_internal/utils.h
+++ b/inc_internal/utils.h
@@ -156,6 +156,7 @@ if (!uv_is_closing((uv_handle_t*)(h))) uv_close((uv_handle_t*)(h), (uv_close_cb)
 #define HTTP_CONTENT_LENGTH "Content-Length"
 #define HTTP_ACCEPT "Accept"
 #define HTTP_LOCATION "Location"
+#define HTTP_RETRY_AFTER "Retry-After"
 #define APPLICATION_JSON "application/json"
 #define TEXT_PLAIN "text/plain"
 #define HTTP_BEARER_FMT "Bearer %s"

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -315,6 +315,37 @@ static bool auth_error_is_temporary(tlsuv_http_resp_t *resp, json_object *body) 
     }
 }
 
+// A 429 may carry Retry-After (RFC 9110 10.2.3) telling us how long to stay
+// away; honour it instead of our own jitter, since the server knows better when
+// it is rate limiting. Only the delay-seconds form is parsed - the HTTP-date
+// form would need strptime(), which MSVC does not have, and the controller and
+// zitadel both send seconds. Returns 0 when the header is absent or unusable,
+// meaning "fall back to normal backoff".
+static uint64_t auth_retry_after_ms(tlsuv_http_resp_t *resp) {
+    if (resp == NULL || resp->code != HTTP_STATUS_TOO_MANY_REQUESTS) return 0;
+
+    const char *val = tlsuv_http_resp_header(resp, HTTP_RETRY_AFTER);
+    if (val == NULL) return 0;
+
+    char *end = NULL;
+    unsigned long long secs = strtoull(val, &end, 10);
+    if (end == val) {
+        // no leading digits at all: an HTTP-date, or garbage
+        OIDC_LOG(DEBUG, "ignoring un-parsable " HTTP_RETRY_AFTER "[%s], using backoff", val);
+        return 0;
+    }
+    while (*end == ' ' || *end == '\t') end++;
+    if (*end != '\0') {
+        OIDC_LOG(DEBUG, "ignoring malformed " HTTP_RETRY_AFTER "[%s], using backoff", val);
+        return 0;
+    }
+
+    // cap well above the retry window so the multiply below cannot overflow;
+    // schedule_auth_retry() decides what to do with a delay this long
+    if (secs > 24 * 60 * 60) secs = 24 * 60 * 60;
+    return (uint64_t) secs * 1000;
+}
+
 // forget the retry window: called on a successful auth and whenever the app
 // deliberately restarts the flow, so the next failure gets a fresh window
 // rather than an already-exhausted one
@@ -363,8 +394,29 @@ static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, jso
     }
 
     uint64_t remaining = clt->auth_retry_until - now;
+    // always advance the attempt counter, even when the delay comes from the
+    // server, so the log and the eventual give-up still count attempts
     uint64_t delay = next_backoff(&clt->auth_failures, AUTH_BACKOFF_MAX, AUTH_BACKOFF_BASE);
-    if (delay > remaining) delay = remaining; // don't sleep past the window
+
+    uint64_t retry_after = auth_retry_after_ms(resp);
+    if (retry_after > 0) {
+        // Coming back before the server said to would defeat the point of
+        // handling the header, so if the requested wait does not fit in what is
+        // left of the window, give up now instead of clamping it down.
+        if (retry_after > remaining) {
+            OIDC_LOG(WARN, "OIDC auth rate limited for %" PRIu64 " s, longer than the %" PRIu64
+                           " s left in the retry window; giving up after %d attempts",
+                     retry_after / 1000, remaining / 1000, clt->auth_failures);
+            clt->auth_failures = 0;
+            clt->auth_retry_until = 0;
+            return false;
+        }
+        OIDC_LOG(DEBUG, "honouring " HTTP_RETRY_AFTER " of %" PRIu64 " s over computed backoff of %"
+                        PRIu64 " ms", retry_after / 1000, delay);
+        delay = retry_after;
+    } else if (delay > remaining) {
+        delay = remaining; // don't sleep past the window
+    }
     if (delay < AUTH_MIN_BACKOFF) delay = AUTH_MIN_BACKOFF;
 
     OIDC_LOG(WARN, "OIDC auth failed (%d %s), attempt %d; retrying in %" PRIu64 ".%03" PRIu64

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -65,9 +65,11 @@
 
 // how long an auth-flow failure keeps being treated as temporary, and the
 // full-jitter backoff between attempts inside that window (max ~32s/attempt)
-#define OIDC_AUTH_RETRY_WINDOW_MS (120 * 1000)
+// match external auth timing
+#define OIDC_AUTH_RETRY_WINDOW_MS (60 * 1000)
 #define AUTH_BACKOFF_MAX  5
 #define AUTH_BACKOFF_BASE 1000
+#define AUTH_MIN_BACKOFF 10
 
 typedef struct auth_req auth_req;
 
@@ -171,6 +173,7 @@ int oidc_client_init(uv_loop_t *loop, oidc_client_t *clt,
     clt->auth_failures = 0;
     clt->auth_retry_until = 0;
     clt->auth_retry_window = OIDC_AUTH_RETRY_WINDOW_MS;
+    clt->primary_ok = false;
 
     return 0;
 }
@@ -335,6 +338,9 @@ static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, jso
     if (clt->token_cb == NULL) return false;
     if (!auth_error_is_temporary(resp, body)) return false;
 
+    // controller knows about this identity
+    if (clt->primary_ok) return false;
+
     // same guard as oidc_client_refresh(): nothing to arm during/after teardown
     if (clt->timer == NULL || uv_is_closing((const uv_handle_t *) clt->timer)) {
         OIDC_LOG(DEBUG, "not retrying auth: timer is %s", clt->timer ? "closing" : "null");
@@ -359,6 +365,7 @@ static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, jso
     uint64_t remaining = clt->auth_retry_until - now;
     uint64_t delay = next_backoff(&clt->auth_failures, AUTH_BACKOFF_MAX, AUTH_BACKOFF_BASE);
     if (delay > remaining) delay = remaining; // don't sleep past the window
+    if (delay < AUTH_MIN_BACKOFF) delay = AUTH_MIN_BACKOFF;
 
     OIDC_LOG(WARN, "OIDC auth failed (%d %s), attempt %d; retrying in %" PRIu64 ".%03" PRIu64
                    " s (%" PRIu64 " s left in window)",
@@ -458,6 +465,7 @@ static void login_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object 
     }
 
     if (model_list_size(&queries) > 0) {
+        clt->primary_ok = true;
         ziti_auth_query_mfa *q;
         MODEL_LIST_FOREACH(q, queries) {
             switch (q->type_id) {
@@ -480,6 +488,7 @@ static void login_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object 
     }
 
     if (http_resp->code / 100 == 2) {
+        clt->primary_ok = true;
         const char *totp = tlsuv_http_resp_header(http_resp, "totp-required");
         if (totp && tolower(totp[0]) == 't') {
             req->totp = true;
@@ -487,6 +496,7 @@ static void login_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object 
             req->clt->token_cb(req->clt, OIDC_TOTP_NEEDED, NULL);
         }
     } else if (http_resp->code / 100 == 3) {
+        clt->primary_ok = true;
         const char *redirect = tlsuv_http_resp_header(http_resp, HTTP_LOCATION);
         struct tlsuv_url_s uri;
         tlsuv_parse_url(&uri, redirect);
@@ -571,6 +581,13 @@ int oidc_client_start(oidc_client_t *clt, oidc_token_cb cb) {
     }
 
     OIDC_LOG(DEBUG, "starting auth flow");
+    // a new flow has its own credentials to prove: clear here rather than in
+    // reset_auth_retry() so every restart is covered, including oidc_refresh_cb's
+    // give-up path, which restarts the flow without going through it. placed
+    // after the guards above so a flow already past login (TOTP pending) keeps
+    // its primary_ok.
+    clt->primary_ok = false;
+
     json_object *cfg = (json_object *) clt->config;
     json_object *auth_ep = json_object_object_get(cfg, AUTH_EP);
     if (auth_ep  == NULL) {

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -126,6 +126,7 @@ struct auth_req {
     char state[state_code_len];
     cstr id;
     bool totp;
+    bool cert_login; // login leg presented a client cert (not an ext JWT)
 };
 
 
@@ -160,6 +161,11 @@ int oidc_client_init(uv_loop_t *loop, oidc_client_t *clt,
         return rc;
     }
     clt->http.data = clt;
+    // keep the context: auth_cb() and refresh_time_cb() both call
+    // clt->tls->set_own_cert() whenever clt->x509 is set. new_oidc_auth()
+    // assigns the same pointer before calling us; ownership is unchanged - only
+    // the facade's close callback frees it.
+    clt->tls = tls;
     tlsuv_http_set_ssl(&clt->http, tls);
     tlsuv_http_connect_timeout(&clt->http, 10000);
     tlsuv_http_idle_keepalive(&clt->http, 0);
@@ -294,21 +300,35 @@ static void free_auth_req(auth_req *req) {
     free(req);
 }
 
-// Right after enrollment the identity may not have replicated to the controller
-// node (or OIDC issuer) we happen to be talking to, so the authorize/login leg
-// rejects perfectly good credentials as 401/403/404. Treat those as temporary,
-// but only inside the bounded window enforced by schedule_auth_retry().
-// ziti_http_error_is_temporary() covers the always-transient shapes: transport
-// errors, 5xx, and zitadel's generic 400/server_error.
-static bool auth_error_is_temporary(tlsuv_http_resp_t *resp, json_object *body) {
+// ziti_http_error_is_temporary() covers the shapes that are transient wherever
+// they turn up: transport errors, 5xx, and zitadel's generic 400/server_error.
+// This adds the auth-flow-specific cases on top.
+//
+// cert_login says the failed request was the client-cert login leg. That
+// distinction matters for 401/403/404, which all mean "we do not know this
+// identity":
+//   - on the cert login, right after enrollment, that is the controller node we
+//     reached not having the new identity yet - worth waiting out, and the whole
+//     reason this retry exists;
+//   - on the ext-jwt login it means the token maps to no identity, which no
+//     amount of waiting changes (openziti/ziti-tunnel-sdk-c
+//     TestExternalAuthSingleSigner/enrollToNoneRejectsUnknownControllerIdentity
+//     depends on that being reported promptly);
+//   - on the authorize leg no credentials have been presented yet, so it is not
+//     a replication symptom either.
+//
+// 429 is deliberately not here: rate limiting is transient for every caller, so
+// it lives in ziti_http_error_is_temporary() and needs no leg-specific gate.
+static bool auth_error_is_temporary(tlsuv_http_resp_t *resp, json_object *body, bool cert_login) {
     if (resp == NULL) return false; // not an HTTP status: bad redirect, no credentials, cancel
     if (ziti_http_error_is_temporary(resp, body)) return true;
+
+    if (!cert_login) return false;
 
     switch (resp->code) {
         case HTTP_STATUS_UNAUTHORIZED:
         case HTTP_STATUS_FORBIDDEN:
         case HTTP_STATUS_NOT_FOUND:
-        case HTTP_STATUS_TOO_MANY_REQUESTS:
             return true;
         default:
             return false;
@@ -365,9 +385,10 @@ static void auth_retry_cb(uv_timer_t *t) {
 // retry window has not run out. Returns true when a retry is pending, in which
 // case the caller must stay silent: the app keeps whatever auth state it has and
 // is not told about an intermediate failure.
-static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, json_object *body) {
+static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, json_object *body,
+                                bool cert_login) {
     if (clt->token_cb == NULL) return false;
-    if (!auth_error_is_temporary(resp, body)) return false;
+    if (!auth_error_is_temporary(resp, body, cert_login)) return false;
 
     // controller knows about this identity
     if (clt->primary_ok) return false;
@@ -430,6 +451,8 @@ static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, jso
 
 static void failed_auth_req(auth_req *req, tlsuv_http_resp_t *resp, json_object *body, const char *error) {
     oidc_client_t *clt = req->clt;
+    // read off the request before it is freed below
+    const bool cert_login = req->cert_login;
 
     // clear and free before arming a retry: the retry re-enters
     // oidc_client_start(), which allocates a fresh auth_req
@@ -439,7 +462,7 @@ static void failed_auth_req(auth_req *req, tlsuv_http_resp_t *resp, json_object 
     free_auth_req(req);
     if (clt == NULL) return;
 
-    if (schedule_auth_retry(clt, resp, body)) return; // stay silent, retry pending
+    if (schedule_auth_retry(clt, resp, body, cert_login)) return; // stay silent, retry pending
 
     if (clt->token_cb) {
         OIDC_LOG(WARN, "OIDC authorization failed: %s", error);
@@ -587,6 +610,7 @@ static void auth_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object *
         if (clt->x509 && clt->x509->cert != NULL) {
             clt->tls->set_own_cert(clt->tls, clt->x509->key, clt->x509->cert);
             path = LOGIN_CERT;
+            req->cert_login = true;
         } else if (model_map_size(&clt->ext_tokens) > 0) {
             path = LOGIN_JWT;
         } else {

--- a/library/oidc.c
+++ b/library/oidc.c
@@ -63,11 +63,19 @@
 
 #define OIDC_LOG(lvl, fmt, ...) ZITI_LOG(lvl, "oidc[internal] " fmt, ##__VA_ARGS__)
 
+// how long an auth-flow failure keeps being treated as temporary, and the
+// full-jitter backoff between attempts inside that window (max ~32s/attempt)
+#define OIDC_AUTH_RETRY_WINDOW_MS (120 * 1000)
+#define AUTH_BACKOFF_MAX  5
+#define AUTH_BACKOFF_BASE 1000
+
 typedef struct auth_req auth_req;
 
 static void oidc_client_set_tokens(oidc_client_t *clt, json_object *tok_json);
 
-static void failed_auth_req(struct auth_req *req, const char *error);
+// resp/body are NULL for failures that are not an HTTP status:
+// malformed redirect, missing credentials, cancellation
+static void failed_auth_req(struct auth_req *req, tlsuv_http_resp_t *resp, json_object *body, const char *error);
 
 static void refresh_time_cb(uv_timer_t *t);
 
@@ -159,6 +167,10 @@ int oidc_client_init(uv_loop_t *loop, oidc_client_t *clt,
     uv_timer_init(loop, clt->timer);
     clt->timer->data = clt;
     uv_unref((uv_handle_t *) clt->timer);
+
+    clt->auth_failures = 0;
+    clt->auth_retry_until = 0;
+    clt->auth_retry_window = OIDC_AUTH_RETRY_WINDOW_MS;
 
     return 0;
 }
@@ -279,22 +291,101 @@ static void free_auth_req(auth_req *req) {
     free(req);
 }
 
-static void failed_auth_req(auth_req *req, const char *error) {
-    oidc_client_t *clt = req->clt;
-    if (clt) {
-        if (clt->request == req) {
-            clt->request = NULL;
-        }
+// Right after enrollment the identity may not have replicated to the controller
+// node (or OIDC issuer) we happen to be talking to, so the authorize/login leg
+// rejects perfectly good credentials as 401/403/404. Treat those as temporary,
+// but only inside the bounded window enforced by schedule_auth_retry().
+// ziti_http_error_is_temporary() covers the always-transient shapes: transport
+// errors, 5xx, and zitadel's generic 400/server_error.
+static bool auth_error_is_temporary(tlsuv_http_resp_t *resp, json_object *body) {
+    if (resp == NULL) return false; // not an HTTP status: bad redirect, no credentials, cancel
+    if (ziti_http_error_is_temporary(resp, body)) return true;
 
-        if (clt->token_cb) {
-            OIDC_LOG(WARN, "OIDC authorization failed: %s", error);
-            clt->token_cb(clt, OIDC_TOKEN_FAILED, error);
-            clt->request = NULL;
-            clt = NULL;
-        }
+    switch (resp->code) {
+        case HTTP_STATUS_UNAUTHORIZED:
+        case HTTP_STATUS_FORBIDDEN:
+        case HTTP_STATUS_NOT_FOUND:
+        case HTTP_STATUS_TOO_MANY_REQUESTS:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// forget the retry window: called on a successful auth and whenever the app
+// deliberately restarts the flow, so the next failure gets a fresh window
+// rather than an already-exhausted one
+static void reset_auth_retry(oidc_client_t *clt) {
+    clt->auth_failures = 0;
+    clt->auth_retry_until = 0;
+}
+
+static void auth_retry_cb(uv_timer_t *t) {
+    uv_unref((uv_handle_t *) t);
+    oidc_client_t *clt = t->data;
+    OIDC_LOG(DEBUG, "retrying auth flow, attempt %d", clt->auth_failures + 1);
+    oidc_client_start(clt, clt->token_cb);
+}
+
+// Arms a retry of the whole auth flow if this failure looks temporary and the
+// retry window has not run out. Returns true when a retry is pending, in which
+// case the caller must stay silent: the app keeps whatever auth state it has and
+// is not told about an intermediate failure.
+static bool schedule_auth_retry(oidc_client_t *clt, tlsuv_http_resp_t *resp, json_object *body) {
+    if (clt->token_cb == NULL) return false;
+    if (!auth_error_is_temporary(resp, body)) return false;
+
+    // same guard as oidc_client_refresh(): nothing to arm during/after teardown
+    if (clt->timer == NULL || uv_is_closing((const uv_handle_t *) clt->timer)) {
+        OIDC_LOG(DEBUG, "not retrying auth: timer is %s", clt->timer ? "closing" : "null");
+        return false;
     }
 
+    uint64_t now = uv_now(clt->timer->loop);
+    if (clt->auth_retry_until == 0) {
+        uint64_t window = clt->auth_retry_window ? clt->auth_retry_window : OIDC_AUTH_RETRY_WINDOW_MS;
+        clt->auth_retry_until = now + window;
+        OIDC_LOG(DEBUG, "treating auth failures as temporary for the next %" PRIu64 " ms", window);
+    }
+
+    if (now >= clt->auth_retry_until) {
+        OIDC_LOG(WARN, "OIDC auth kept failing for the whole retry window, giving up after %d attempts",
+                 clt->auth_failures);
+        clt->auth_failures = 0;
+        clt->auth_retry_until = 0;
+        return false;
+    }
+
+    uint64_t remaining = clt->auth_retry_until - now;
+    uint64_t delay = next_backoff(&clt->auth_failures, AUTH_BACKOFF_MAX, AUTH_BACKOFF_BASE);
+    if (delay > remaining) delay = remaining; // don't sleep past the window
+
+    OIDC_LOG(WARN, "OIDC auth failed (%d %s), attempt %d; retrying in %" PRIu64 ".%03" PRIu64
+                   " s (%" PRIu64 " s left in window)",
+             resp->code, resp->status, clt->auth_failures, delay / 1000, delay % 1000, remaining / 1000);
+
+    uv_ref((uv_handle_t *) clt->timer);
+    uv_timer_start(clt->timer, auth_retry_cb, delay, 0);
+    return true;
+}
+
+static void failed_auth_req(auth_req *req, tlsuv_http_resp_t *resp, json_object *body, const char *error) {
+    oidc_client_t *clt = req->clt;
+
+    // clear and free before arming a retry: the retry re-enters
+    // oidc_client_start(), which allocates a fresh auth_req
+    if (clt != NULL && clt->request == req) {
+        clt->request = NULL;
+    }
     free_auth_req(req);
+    if (clt == NULL) return;
+
+    if (schedule_auth_retry(clt, resp, body)) return; // stay silent, retry pending
+
+    if (clt->token_cb) {
+        OIDC_LOG(WARN, "OIDC authorization failed: %s", error);
+        clt->token_cb(clt, OIDC_TOKEN_FAILED, error);
+    }
 }
 
 static void token_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object *resp, void *ctx) {
@@ -306,9 +397,11 @@ static void token_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object 
         clt->request = NULL;
         free_auth_req(req);
     } else {
-        failed_auth_req(req, http_resp->status);
-        http_resp->req->data = NULL;
+        // log before failing the request: failed_auth_req may arm a retry that
+        // re-enters the auth flow and retargets clt->http
         handle_unexpected_resp(clt, http_resp, resp);
+        http_resp->req->data = NULL;
+        failed_auth_req(req, http_resp, resp, http_resp->status);
     }
 }
 
@@ -336,19 +429,20 @@ static void code_cb(tlsuv_http_resp_t *http_resp, void *ctx) {
         const char *redirect = tlsuv_http_resp_header(http_resp, HTTP_LOCATION);
         struct tlsuv_url_s uri;
         if (redirect == NULL || tlsuv_parse_url(&uri, redirect) != 0) { // guard against missing/invalid Location header
-            failed_auth_req(req, "missing or invalid redirect");
+            failed_auth_req(req, NULL, NULL, "missing or invalid redirect");
             return;
         }
         char *code = uri.query ? strstr(uri.query, "code=") : NULL; // guard against missing query string
         if (code == NULL) { // guard against missing code= parameter
-            failed_auth_req(req, "missing auth code in redirect");
+            failed_auth_req(req, NULL, NULL, "missing auth code in redirect");
             return;
         }
         code += strlen("code=");
 
         request_token(req, code);
     } else {
-        failed_auth_req(req, http_resp->status);
+        // raw resp_cb: no parsed JSON body to classify against
+        failed_auth_req(req, http_resp, NULL, http_resp->status);
     }
 }
 
@@ -399,7 +493,7 @@ static void login_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object 
         tlsuv_http_set_path_prefix(&req->clt->http, NULL);
         tlsuv_http_req(&req->clt->http, "GET", uri.path, code_cb, req);
     } else {
-        failed_auth_req(req, http_resp->status);
+        failed_auth_req(req, http_resp, body, http_resp->status);
     }
 }
 
@@ -415,12 +509,12 @@ static void auth_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object *
         const char *redirect = tlsuv_http_resp_header(http_resp, HTTP_LOCATION);
         struct tlsuv_url_s uri;
         if (redirect == NULL || tlsuv_parse_url(&uri, redirect) != 0) { // guard against missing/invalid Location header
-            failed_auth_req(req, "missing or invalid redirect");
+            failed_auth_req(req, NULL, NULL, "missing or invalid redirect");
             return;
         }
         char *p = uri.query ? strstr(uri.query, "authRequestID=") : NULL; // guard against missing query string
         if (p == NULL) { // guard against missing authRequestID parameter
-            failed_auth_req(req, "missing authRequestID in redirect");
+            failed_auth_req(req, NULL, NULL, "missing authRequestID in redirect");
             return;
         }
         p += strlen("authRequestID=");
@@ -434,7 +528,7 @@ static void auth_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object *
         } else if (model_map_size(&clt->ext_tokens) > 0) {
             path = LOGIN_JWT;
         } else {
-            failed_auth_req(req, "no credentials provided");
+            failed_auth_req(req, NULL, NULL, "no credentials provided");
             return;
         }
 
@@ -460,7 +554,7 @@ static void auth_cb(tlsuv_http_resp_t *http_resp, const char *err, json_object *
         const char *body = ziti_auth_req_to_json(&authreq, 0, &body_len);
         tlsuv_http_req_data(login_req, body, body_len, free_body_cb);
     } else {
-        failed_auth_req(req, http_resp->status);
+        failed_auth_req(req, http_resp, resp, http_resp->status);
     }
 }
 
@@ -663,7 +757,7 @@ int oidc_client_close(oidc_client_t *clt, oidc_close_cb cb) {
     zt_jwt_drop(&clt->refresh_token);
 
     if (clt->request) {
-        failed_auth_req(clt->request, strerror(ECANCELED));
+        failed_auth_req(clt->request, NULL, NULL, strerror(ECANCELED));
     }
 
     return 0;
@@ -692,6 +786,7 @@ static void oidc_client_set_tokens(oidc_client_t *clt, json_object *tok_json) {
     OIDC_LOG(DEBUG, "using " INTERNAL_TOKEN_TYPE "=%s", json_object_get_string(clt->current.claims));
     OIDC_LOG(DEBUG, "token expires in %" PRIi64 " seconds", clt->current.expiration - now.tv_sec);
 
+    reset_auth_retry(clt);
     if (clt->token_cb) {
         clt->token_cb(clt, OIDC_TOKEN_OK, cstr_str(&clt->current.encoded));
     }
@@ -912,6 +1007,7 @@ static int oidc_auth_set_ca(ziti_auth_method_t *self, const char *ca) {
 
 static int oidc_auth_set_endpoint(ziti_auth_method_t *self, const api_path *api) {
     oidc_client_t *clt = OIDC_AUTH_FROM_API(self);
+    reset_auth_retry(clt);
 
     model_list_clear(&clt->urls, free);
     const char *u;
@@ -959,6 +1055,13 @@ static void oidc_auth_dump(ziti_auth_method_t *self, int (*printer)(void *arg, c
             clt->configuring ? "true" : "false",
             clt->need_refresh ? "true" : "false",
             clt->refresh_failures);
+
+    if (clt->auth_retry_until != 0 && clt->timer) {
+        uint64_t now = uv_now(clt->timer->loop);
+        printer(ctx, "\tauth_failures[%d] retry window %" PRIi64 "s remaining\n",
+                clt->auth_failures,
+                now < clt->auth_retry_until ? (int64_t) ((clt->auth_retry_until - now) / 1000) : (int64_t) 0);
+    }
 
     if (clt->timer && uv_is_active((uv_handle_t*)clt->timer)) {
         printer(ctx, "\trefresh in %" PRIi64 "s\n", uv_timer_get_due_in(clt->timer) / 1000);
@@ -1189,11 +1292,18 @@ static int oidc_auth_stop(ziti_auth_method_t *self) {
     oidc_client_t *clt = OIDC_AUTH_FROM_API(self);
     clt->auth_cb = NULL;
     clt->auth_cb_ctx = NULL;
+
+    // don't keep dialing the controller for a method nobody is listening to
+    if (clt->timer && !uv_is_closing((const uv_handle_t *) clt->timer)) {
+        uv_timer_stop(clt->timer);
+    }
+    reset_auth_retry(clt);
     return 0;
 }
 
 static int oidc_auth_refresh(ziti_auth_method_t *self) {
     oidc_client_t *clt = OIDC_AUTH_FROM_API(self);
+    reset_auth_retry(clt);
     if (clt->request) {
         OIDC_LOG(DEBUG, "skipping refresh while auth request is in progress");
         return ZITI_OK;

--- a/library/utils.c
+++ b/library/utils.c
@@ -820,6 +820,13 @@ bool ziti_http_error_is_temporary(tlsuv_http_resp_t *resp, json_object *body) {
         return true;
     }
 
+    // rate limiting says "not now", not "never" - the server is pacing us
+    // rather than rejecting the request. see HTTP_RETRY_AFTER handling in
+    // callers that want to honour the server's own timing.
+    if (resp->code == HTTP_STATUS_TOO_MANY_REQUESTS) {
+        return true;
+    }
+
     // zitadel returns generic(400) error check error body for transient conditions
     if (resp->code == 400) {
         json_object *err = json_object_object_get(body, "error");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(all_tests
         e2ee_tests.cpp
         util_tests.cpp
         oidc_recovery_tests.cpp
+        oidc_auth_retry_tests.cpp
         ctrl_endpoint_tests.cpp
         posture_tests.cpp)
 

--- a/tests/oidc_auth_retry_tests.cpp
+++ b/tests/oidc_auth_retry_tests.cpp
@@ -1,0 +1,429 @@
+// Copyright (c) 2026.  NetFoundry Inc
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Covers the "identity was just enrolled" failure mode: on an HA controller the
+// new identity may not have replicated to the node the SDK reached yet, so the
+// OIDC authorize/login leg rejects perfectly good credentials with 401/403/404.
+//
+// Before the fix, every failure in the auth chain funneled through
+// failed_auth_req() straight to OIDC_TOKEN_FAILED -> ZitiAuthStateUnauthenticated
+// -> ztx_set_unauthenticated(), which schedules no retry. On a first-ever
+// authentication there is no services-refresh timer running either (that is only
+// armed once auth succeeds), so the context stayed unauthenticated until the
+// process restarted. library/oidc.c now treats such a failure as temporary for a
+// bounded window (clt->auth_retry_window), retrying the whole flow with
+// full-jitter backoff and staying silent - no auth_cb, so no session teardown or
+// event churn - until either the flow succeeds or the window closes.
+//
+// Like tests/oidc_recovery_tests.cpp, these tests drive library/oidc.c's
+// oidc_client_t directly against a local fake HTTP endpoint. Discovery is skipped
+// by hand-populating clt.config's authorization_endpoint/token_endpoint, which is
+// all oidc_client_start() reads. There is no HTTP-mocking seam in this codebase -
+// every "mock" here is a real loopback socket server.
+
+#include "catch2_includes.hpp"
+
+#include "oidc.h"
+#include <ziti/model_collections.h>
+#include <tlsuv/tlsuv.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+static constexpr int INVALID_SOCK = (int) INVALID_SOCKET;
+#define CLOSESOCK closesocket
+#define SHUT_SEND SD_SEND
+#define SHUT_BOTH SD_BOTH
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+static constexpr int INVALID_SOCK = -1;
+#define CLOSESOCK close
+#define SHUT_BOTH SHUT_RDWR
+#define SHUT_SEND SHUT_WR
+#endif
+
+namespace {
+
+// Three dot-separated base64url(no padding) segments; zt_jwt_parse only requires
+// the payload to be valid base64url JSON carrying a string "iss" (and an integer
+// "exp" if present). The signature segment is never decoded or verified.
+// exp = 4000000000 is the year 2096, so these never look expired.
+constexpr const char *FAKE_JWT =
+    "eyJhbGciOiJub25lIn0.eyJpc3MiOiJ0ZXN0IiwiZXhwIjo0MDAwMDAwMDAwfQ.sig";
+
+// oidc.c's auth chain, and the fake response each leg needs to advance:
+//   POST authorization_endpoint  -> 302 Location: ...?authRequestID=..  (auth_cb)
+//   POST /oidc/login/ext-jwt     -> 302 Location: <path>                (login_cb)
+//   GET  <that path>             -> 302 Location: ...?code=..           (code_cb)
+//   POST token_endpoint          -> 200 {access_token, refresh_token}   (token_cb)
+constexpr const char *AUTHORIZE_PATH = "/authorize";
+constexpr const char *LOGIN_PATH = "/oidc/login/ext-jwt";
+constexpr const char *CODE_PATH = "/oidc/redirect";
+constexpr const char *TOKEN_PATH = "/token";
+
+// A local OIDC-ish endpoint. The authorize leg serves a scripted queue of HTTP
+// statuses (so a test can say "fail with 401 twice, then let the flow through");
+// once the queue is drained it answers with the redirect that advances the flow.
+// One thread per connection, independent of the test's uv_loop.
+class FakeOidcEndpoint {
+public:
+    uint16_t port{};
+    std::atomic<int> authorize_count{0};
+    std::atomic<int> token_count{0};
+
+    // each entry is a full status line + optional JSON body served to one
+    // authorize request; empty queue == serve the success redirect
+    void scriptAuthorizeFailure(const std::string &statusLine, const std::string &body = "") {
+        std::lock_guard<std::mutex> lock(mu_);
+        authorize_script_.push_back({statusLine, body});
+    }
+
+    FakeOidcEndpoint() {
+#if _WIN32
+        WSADATA wsaData;
+        WSAStartup(MAKEWORD(2, 2), &wsaData);
+#endif
+        listen_fd_ = (int) ::socket(AF_INET, SOCK_STREAM, 0);
+        int one = 1;
+        setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, (const char *) &one, sizeof(one));
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0;
+        REQUIRE(::bind(listen_fd_, (sockaddr *) &addr, sizeof(addr)) == 0);
+
+        socklen_t len = sizeof(addr);
+        REQUIRE(getsockname(listen_fd_, (sockaddr *) &addr, &len) == 0);
+        port = ntohs(addr.sin_port);
+
+        listen(listen_fd_, 16);
+        accept_thread_ = std::thread([this] { acceptLoop(); });
+    }
+
+    ~FakeOidcEndpoint() {
+        stop_ = true;
+        shutdown(listen_fd_, SHUT_BOTH);
+        CLOSESOCK(listen_fd_);
+        if (accept_thread_.joinable()) accept_thread_.join();
+        for (auto &t: workers_) {
+            if (t.joinable()) t.join();
+        }
+#if _WIN32
+        WSACleanup();
+#endif
+    }
+
+    std::string url(const char *path) const {
+        return "http://127.0.0.1:" + std::to_string(port) + path;
+    }
+
+private:
+    struct ScriptedResp {
+        std::string statusLine;
+        std::string body;
+    };
+
+    void acceptLoop() {
+        while (!stop_) {
+            int client = (int) accept(listen_fd_, nullptr, nullptr);
+            if (client == INVALID_SOCK) {
+                if (stop_) return;
+                continue;
+            }
+            workers_.emplace_back([this, client] { serve(client); });
+        }
+    }
+
+    // Read the request line + headers, then drain exactly Content-Length bytes of
+    // body. Leaving unread bytes in the receive buffer and closing produces an
+    // abortive close (RST) on Windows, which can discard the response we already
+    // handed to send() - see the same note in oidc_recovery_tests.cpp.
+    void serve(int client) {
+        char buf[8192];
+        std::string received;
+        size_t headerEnd;
+        while ((headerEnd = received.find("\r\n\r\n")) == std::string::npos) {
+            ssize_t n = recv(client, buf, sizeof(buf), 0);
+            if (n <= 0) { CLOSESOCK(client); return; }
+            received.append(buf, (size_t) n);
+        }
+
+        size_t contentLength = 0;
+        size_t clPos = received.find("Content-Length:");
+        if (clPos != std::string::npos && clPos < headerEnd) {
+            contentLength = (size_t) std::strtoul(received.c_str() + clPos + strlen("Content-Length:"), nullptr, 10);
+        }
+        size_t bodySoFar = received.size() - (headerEnd + 4);
+        while (bodySoFar < contentLength) {
+            ssize_t n = recv(client, buf, sizeof(buf), 0);
+            if (n <= 0) { CLOSESOCK(client); return; }
+            bodySoFar += (size_t) n;
+        }
+
+        // route on the exact request path: substring matching is a trap here,
+        // since the legs share prefixes with each other
+        std::string requestLine = received.substr(0, received.find("\r\n"));
+        size_t targetStart = requestLine.find(' ');
+        size_t targetEnd = requestLine.rfind(' ');
+        std::string target = (targetStart == std::string::npos || targetEnd <= targetStart)
+                                 ? std::string()
+                                 : requestLine.substr(targetStart + 1, targetEnd - targetStart - 1);
+        std::string path = target.substr(0, target.find('?'));
+        std::string resp = respondTo(path);
+        send(client, resp.data(), resp.size(), 0);
+        // shutdown the write side before closing so the client is guaranteed to
+        // see the response before the FIN
+        shutdown(client, SHUT_SEND);
+        CLOSESOCK(client);
+    }
+
+    std::string respondTo(const std::string &path) {
+        if (path == AUTHORIZE_PATH) {
+            authorize_count++;
+            ScriptedResp scripted;
+            bool haveScripted = false;
+            {
+                std::lock_guard<std::mutex> lock(mu_);
+                if (!authorize_script_.empty()) {
+                    scripted = authorize_script_.front();
+                    authorize_script_.pop_front();
+                    haveScripted = true;
+                }
+            }
+            if (haveScripted) {
+                return response(scripted.statusLine, {}, scripted.body);
+            }
+            return response("302 Found", {{"Location", url(LOGIN_PATH) + "?authRequestID=test-req-1&x=1"}});
+        }
+
+        if (path == LOGIN_PATH) {
+            return response("302 Found", {{"Location", url(CODE_PATH) + "?state=test-state"}});
+        }
+
+        if (path == CODE_PATH) {
+            return response("302 Found", {{"Location", url("/auth/callback") + "?code=test-code&state=test-state"}});
+        }
+
+        if (path == TOKEN_PATH) {
+            token_count++;
+            std::string body = std::string("{\"access_token\":\"") + FAKE_JWT +
+                               "\",\"refresh_token\":\"" + FAKE_JWT + "\"}";
+            return response("200 OK", {{"Content-Type", "application/json"}}, body);
+        }
+
+        return response("404 Not Found");
+    }
+
+    static std::string response(const std::string &statusLine,
+                                const std::vector<std::pair<std::string, std::string>> &headers = {},
+                                const std::string &body = "") {
+        std::string out = "HTTP/1.1 " + statusLine + "\r\n";
+        for (const auto &h: headers) {
+            out += h.first + ": " + h.second + "\r\n";
+        }
+        out += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+        out += "Connection: close\r\n\r\n";
+        out += body;
+        return out;
+    }
+
+    int listen_fd_{};
+    std::atomic<bool> stop_{false};
+    std::thread accept_thread_;
+    std::vector<std::thread> workers_;
+    std::mutex mu_;
+    std::deque<ScriptedResp> authorize_script_;
+};
+
+struct AuthResult {
+    int calls = 0;
+    enum oidc_status status{};
+    std::string token;
+};
+
+// Everything oidc_client_start() and the login leg actually read, wired up
+// without going through discovery: the two endpoints from the OIDC config, and
+// one non-expired ext token so auth_cb picks the ext-jwt login path (a cert
+// would send it to /oidc/login/cert instead, and with neither it bails out with
+// "no credentials provided").
+struct TestClient {
+    uv_loop_t *loop{};
+    tls_context *tls{};
+    oidc_client_t clt{};
+    AuthResult result{};
+
+    TestClient(const FakeOidcEndpoint &server, uint64_t retry_window_ms) {
+        loop = uv_loop_new();
+        tls = default_tls_context(nullptr, 0);
+        REQUIRE(oidc_client_init(loop, &clt, server.url("/oidc").c_str(), tls) == 0);
+
+        clt.auth_retry_window = retry_window_ms;
+        clt.data = &result;
+
+        json_object *cfg = json_object_new_object();
+        json_object_object_add(cfg, "authorization_endpoint",
+                               json_object_new_string(server.url(AUTHORIZE_PATH).c_str()));
+        json_object_object_add(cfg, "token_endpoint",
+                               json_object_new_string(server.url(TOKEN_PATH).c_str()));
+        clt.config = cfg;
+
+        auto *jwt = (zt_jwt *) calloc(1, sizeof(zt_jwt));
+        REQUIRE(zt_jwt_parse(FAKE_JWT, jwt) == 0);
+        model_map_set(&clt.ext_tokens, cstr_str(&jwt->issuer), jwt);
+    }
+
+    ~TestClient() {
+        oidc_client_close(&clt, [](oidc_client_t *) {});
+        for (int i = 0; i < 10 && uv_run(loop, UV_RUN_ONCE) != 0; i++) {}
+        // uv_loop_new() heap-allocates the loop, so uv_loop_close() alone leaks it
+        // and LeakSanitizer flags it even on an otherwise passing run.
+        uv_loop_delete(loop);
+        tls->free_ctx(tls);
+    }
+
+    int start() {
+        return oidc_client_start(&clt, [](oidc_client_t *c, enum oidc_status status, const void *data) {
+            auto *r = (AuthResult *) c->data;
+            r->calls++;
+            r->status = status;
+            if (status == OIDC_TOKEN_OK && data) r->token = (const char *) data;
+        });
+    }
+
+    // pump the loop until pred() or the timeout elapses
+    template<typename Pred>
+    void pumpUntil(Pred pred, std::chrono::milliseconds timeout) {
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (!pred() && std::chrono::steady_clock::now() < deadline) {
+            uv_run(loop, UV_RUN_NOWAIT);
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+
+    void pumpFor(std::chrono::milliseconds duration) {
+        pumpUntil([] { return false; }, duration);
+    }
+};
+
+} // namespace
+
+// A 401 on the authorize leg - what an unreplicated identity looks like - is
+// retried without ever telling the app, and only becomes OIDC_TOKEN_FAILED once
+// the window closes. The 3s window guarantees at least one retry: the first
+// backoff is next_backoff(0, 5, 1000) == random % 2000, clamped to the window.
+TEST_CASE("oidc-auth-retries-transient-401-then-reports-once", "[oidc]") {
+    FakeOidcEndpoint server;
+    for (int i = 0; i < 20; i++) server.scriptAuthorizeFailure("401 Unauthorized");
+
+    TestClient c(server, 3000);
+    REQUIRE(c.start() == 0);
+
+    // while the window is open the app hears nothing at all
+    c.pumpUntil([&] { return server.authorize_count.load() >= 2; }, std::chrono::seconds(4));
+    CHECK(server.authorize_count.load() >= 2);
+    CHECK(c.result.calls == 0);
+
+    // once it closes, the failure surfaces exactly once
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(6));
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_FAILED);
+
+    // and nothing keeps retrying afterwards
+    int settled = server.authorize_count.load();
+    c.pumpFor(std::chrono::milliseconds(500));
+    CHECK(server.authorize_count.load() == settled);
+    CHECK(c.result.calls == 1);
+}
+
+// The window opens *at* the first failure, so the smallest possible window still
+// buys exactly one retry; the failure the app sees is the second attempt's.
+// Pins the floor of the behavior: the window can never swallow the failure
+// entirely, and an exhausted window reports once and stops.
+TEST_CASE("oidc-auth-smallest-window-retries-once-then-reports", "[oidc]") {
+    FakeOidcEndpoint server;
+    for (int i = 0; i < 5; i++) server.scriptAuthorizeFailure("401 Unauthorized");
+
+    TestClient c(server, 1);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(5));
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_FAILED);
+    CHECK(server.authorize_count.load() == 2);
+
+    c.pumpFor(std::chrono::milliseconds(300));
+    CHECK(server.authorize_count.load() == 2);
+    CHECK(c.result.calls == 1);
+}
+
+// Guards against over-broad classification: a 400 that is not zitadel's generic
+// server_error is a real rejection and must fail on the first attempt even with a
+// generous window.
+TEST_CASE("oidc-auth-does-not-retry-permanent-failure", "[oidc]") {
+    FakeOidcEndpoint server;
+    for (int i = 0; i < 5; i++) {
+        server.scriptAuthorizeFailure("400 Bad Request", R"({"error":"invalid_request"})");
+    }
+
+    TestClient c(server, 60000);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(5));
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_FAILED);
+
+    c.pumpFor(std::chrono::milliseconds(500));
+    CHECK(server.authorize_count.load() == 1);
+}
+
+// The bug this whole change exists for: the identity finishes replicating partway
+// through the window, the retried flow completes, and the app sees a single
+// successful auth rather than a permanent failure.
+TEST_CASE("oidc-auth-recovers-once-identity-replicates", "[oidc]") {
+    FakeOidcEndpoint server;
+    server.scriptAuthorizeFailure("401 Unauthorized");
+    server.scriptAuthorizeFailure("404 Not Found");
+    // script exhausted: subsequent authorize requests complete the flow
+
+    TestClient c(server, 20000);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(15));
+
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_OK);
+    CHECK(c.result.token == FAKE_JWT);
+    CHECK(server.authorize_count.load() == 3);
+    CHECK(server.token_count.load() == 1);
+
+    // the window is closed out on success, so a later failure gets a fresh one
+    CHECK(c.clt.auth_failures == 0);
+    CHECK(c.clt.auth_retry_until == 0);
+}

--- a/tests/oidc_auth_retry_tests.cpp
+++ b/tests/oidc_auth_retry_tests.cpp
@@ -74,6 +74,31 @@ namespace {
 // the payload to be valid base64url JSON carrying a string "iss" (and an integer
 // "exp" if present). The signature segment is never decoded or verified.
 // exp = 4000000000 is the year 2096, so these never look expired.
+// A self-signed throwaway, only ever handed to tls->load_cert() so that
+// auth_cb() picks the /oidc/login/cert leg. tlsuv's set_own_cert does not check
+// that the key matches, and the fake endpoint is plain HTTP, so no handshake
+// ever uses either one.
+constexpr const char *FAKE_CERT_PEM =
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIDITCCAgmgAwIBAgIUJw0OAtVUYQKY4TxnlYH1sFAYvFQwDQYJKoZIhvcNAQEL\n"
+    "BQAwHzEdMBsGA1UEAwwUb2lkYy1hdXRoLXJldHJ5LXRlc3QwIBcNMjYwODMxMTgx\n"
+    "NjUxWhgPMjEyNjA4MDcxODE2NTFaMB8xHTAbBgNVBAMMFG9pZGMtYXV0aC1yZXRy\n"
+    "eS10ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArnqNzs1mOV1N\n"
+    "MWA5WJKr/oEi4IBACmVICKyMuvQ0Zd/80A7q7dzg8P57iVc2FNUGKqcwFwnTe8yW\n"
+    "Hd7Ojs60voGi7TQZ09Ss0FJSEIJF+TP2C3Mjpol1lmChq52aIoMAg1kNPYHAChSq\n"
+    "48A33yiBjqHgux/7cqrC30EJuzsEEBxH0AEbtuPaQEmvPQyA/ptwmvjHYOWRh3gC\n"
+    "J9MbjG8CUJ3c1erJOW7RCHoO+SQzcn8JKWsr27nPE5DqIvsGXG71+o4AskNghW8u\n"
+    "65A56UaEL7t2KxNZVuB1M5QiUUxMtlej+8Bt8bUZwJnhBXqn+iNO2nzz8VFuKCKW\n"
+    "FKSUP6FjDQIDAQABo1MwUTAdBgNVHQ4EFgQU+5IiErKluU8fFwavCC7xjN6VJMgw\n"
+    "HwYDVR0jBBgwFoAU+5IiErKluU8fFwavCC7xjN6VJMgwDwYDVR0TAQH/BAUwAwEB\n"
+    "/zANBgkqhkiG9w0BAQsFAAOCAQEAixyiJVX+gyoOOsownVmlo9Th5vhMPZ1Sq2Ge\n"
+    "0pnlTpNpk8ou9PhpXyl46W5xFZBfRH0HoNsyw27BGv6Ps0m1CvL6pQoJHRlSpAPm\n"
+    "DcqzmKH4VvDO47r7JMDrBsiB+YEntLoWgon7W01smIhJKn5ZB8coV0ulscXhnzJc\n"
+    "5wlnsCfZAQmtp8BuJ3aJUgu2QSPWT4uv81ZFBbcVjH2l3AwYyvsu4/oa7KcSnBeG\n"
+    "DVX4mtO9t3Q8Kcjn5x4TmIUTMNIKRhuZZZobZmovjZrhUpLFYjiB4YV27RJoTJYk\n"
+    "VlqVlwrkug/0QtSR4Z0oVjjslpjlpjCjYzTa94qY6sBawZqNGw==\n"
+    "-----END CERTIFICATE-----\n";
+
 constexpr const char *FAKE_JWT =
     "eyJhbGciOiJub25lIn0.eyJpc3MiOiJ0ZXN0IiwiZXhwIjo0MDAwMDAwMDAwfQ.sig";
 
@@ -83,7 +108,8 @@ constexpr const char *FAKE_JWT =
 //   GET  <that path>             -> 302 Location: ...?code=..           (code_cb)
 //   POST token_endpoint          -> 200 {access_token, refresh_token}   (token_cb)
 constexpr const char *AUTHORIZE_PATH = "/authorize";
-constexpr const char *LOGIN_PATH = "/oidc/login/ext-jwt";
+constexpr const char *LOGIN_JWT_PATH = "/oidc/login/ext-jwt";
+constexpr const char *LOGIN_CERT_PATH = "/oidc/login/cert";
 constexpr const char *CODE_PATH = "/oidc/redirect";
 constexpr const char *TOKEN_PATH = "/token";
 
@@ -97,6 +123,7 @@ public:
 
     uint16_t port{};
     std::atomic<int> authorize_count{0};
+    std::atomic<int> login_count{0};
     std::atomic<int> token_count{0};
 
     // each entry is a full status line + optional extra headers + optional JSON
@@ -108,6 +135,12 @@ public:
                                 const Headers &headers = {}) {
         std::lock_guard<std::mutex> lock(mu_);
         authorize_script_.push_back({statusLine, body, headers});
+    }
+
+    // as scriptAuthorizeFailure, but for the login leg (cert or ext-jwt)
+    void scriptLoginFailure(const std::string &statusLine, const std::string &body = "") {
+        std::lock_guard<std::mutex> lock(mu_);
+        login_script_.push_back({statusLine, body, {}});
     }
 
     // milliseconds between the Nth and (N+1)th authorize request
@@ -236,10 +269,27 @@ private:
             if (haveScripted) {
                 return response(scripted.statusLine, scripted.headers, scripted.body);
             }
-            return response("302 Found", {{"Location", url(LOGIN_PATH) + "?authRequestID=test-req-1&x=1"}});
+            // auth_cb only reads authRequestID out of this query - it picks the
+            // login path itself (LOGIN_CERT vs LOGIN_JWT), so the path here is
+            // never followed
+            return response("302 Found", {{"Location", url(LOGIN_JWT_PATH) + "?authRequestID=test-req-1&x=1"}});
         }
 
-        if (path == LOGIN_PATH) {
+        if (path == LOGIN_JWT_PATH || path == LOGIN_CERT_PATH) {
+            login_count++;
+            ScriptedResp scripted;
+            bool haveScripted = false;
+            {
+                std::lock_guard<std::mutex> lock(mu_);
+                if (!login_script_.empty()) {
+                    scripted = login_script_.front();
+                    login_script_.pop_front();
+                    haveScripted = true;
+                }
+            }
+            if (haveScripted) {
+                return response(scripted.statusLine, {}, scripted.body);
+            }
             return response("302 Found", {{"Location", url(CODE_PATH) + "?state=test-state"}});
         }
 
@@ -276,6 +326,7 @@ private:
     std::vector<std::thread> workers_;
     mutable std::mutex mu_;
     std::deque<ScriptedResp> authorize_script_;
+    std::deque<ScriptedResp> login_script_;
     std::vector<std::chrono::steady_clock::time_point> authorize_at_;
 };
 
@@ -290,13 +341,19 @@ struct AuthResult {
 // one non-expired ext token so auth_cb picks the ext-jwt login path (a cert
 // would send it to /oidc/login/cert instead, and with neither it bails out with
 // "no credentials provided").
+// Which credential the client presents. It decides which login leg auth_cb()
+// picks, and therefore whether a 401/403/404 there is treated as replication lag
+// (cert) or as a settled rejection (ext JWT).
+enum class Creds { ExtJwt, Cert };
+
 struct TestClient {
     uv_loop_t *loop{};
     tls_context *tls{};
     oidc_client_t clt{};
     AuthResult result{};
+    zt_x509 x509{};
 
-    TestClient(const FakeOidcEndpoint &server, uint64_t retry_window_ms) {
+    TestClient(const FakeOidcEndpoint &server, uint64_t retry_window_ms, Creds creds = Creds::ExtJwt) {
         loop = uv_loop_new();
         tls = default_tls_context(nullptr, 0);
         REQUIRE(oidc_client_init(loop, &clt, server.url("/oidc").c_str(), tls) == 0);
@@ -311,14 +368,23 @@ struct TestClient {
                                json_object_new_string(server.url(TOKEN_PATH).c_str()));
         clt.config = cfg;
 
-        auto *jwt = (zt_jwt *) calloc(1, sizeof(zt_jwt));
-        REQUIRE(zt_jwt_parse(FAKE_JWT, jwt) == 0);
-        model_map_set(&clt.ext_tokens, cstr_str(&jwt->issuer), jwt);
+        if (creds == Creds::Cert) {
+            REQUIRE(tls->generate_key(&x509.key) == 0);
+            REQUIRE(tls->load_cert(&x509.cert, FAKE_CERT_PEM, strlen(FAKE_CERT_PEM)) == 0);
+            clt.x509 = &x509;
+        } else {
+            auto *jwt = (zt_jwt *) calloc(1, sizeof(zt_jwt));
+            REQUIRE(zt_jwt_parse(FAKE_JWT, jwt) == 0);
+            model_map_set(&clt.ext_tokens, cstr_str(&jwt->issuer), jwt);
+        }
     }
 
     ~TestClient() {
         oidc_client_close(&clt, [](oidc_client_t *) {});
         for (int i = 0; i < 10 && uv_run(loop, UV_RUN_ONCE) != 0; i++) {}
+        // clt.x509 points at our own member, so oidc_client_close does not free
+        // it - drop the key/cert here
+        zt_x509_drop(&x509);
         // uv_loop_new() heap-allocates the loop, so uv_loop_close() alone leaks it
         // and LeakSanitizer flags it even on an otherwise passing run.
         uv_loop_delete(loop);
@@ -351,13 +417,13 @@ struct TestClient {
 
 } // namespace
 
-// A 401 on the authorize leg - what an unreplicated identity looks like - is
-// retried without ever telling the app, and only becomes OIDC_TOKEN_FAILED once
-// the window closes. The 3s window guarantees at least one retry: the first
-// backoff is next_backoff(0, 5, 1000) == random % 2000, clamped to the window.
-TEST_CASE("oidc-auth-retries-transient-401-then-reports-once", "[oidc]") {
+// A 5xx is transient on any leg, so it is retried without ever telling the app,
+// and only becomes OIDC_TOKEN_FAILED once the window closes. The 3s window
+// guarantees at least one retry: the first backoff is
+// next_backoff(0, 5, 1000) == random % 2000, clamped to the window.
+TEST_CASE("oidc-auth-retries-transient-5xx-then-reports-once", "[oidc]") {
     FakeOidcEndpoint server;
-    for (int i = 0; i < 20; i++) server.scriptAuthorizeFailure("401 Unauthorized");
+    for (int i = 0; i < 20; i++) server.scriptAuthorizeFailure("503 Service Unavailable");
 
     TestClient c(server, 3000);
     REQUIRE(c.start() == 0);
@@ -385,7 +451,7 @@ TEST_CASE("oidc-auth-retries-transient-401-then-reports-once", "[oidc]") {
 // entirely, and an exhausted window reports once and stops.
 TEST_CASE("oidc-auth-smallest-window-retries-once-then-reports", "[oidc]") {
     FakeOidcEndpoint server;
-    for (int i = 0; i < 5; i++) server.scriptAuthorizeFailure("401 Unauthorized");
+    for (int i = 0; i < 5; i++) server.scriptAuthorizeFailure("503 Service Unavailable");
 
     TestClient c(server, 1);
     REQUIRE(c.start() == 0);
@@ -420,16 +486,17 @@ TEST_CASE("oidc-auth-does-not-retry-permanent-failure", "[oidc]") {
     CHECK(server.authorize_count.load() == 1);
 }
 
-// The bug this whole change exists for: the identity finishes replicating partway
-// through the window, the retried flow completes, and the app sees a single
-// successful auth rather than a permanent failure.
+// The bug this whole change exists for: a just-enrolled identity has not reached
+// the controller node we landed on, so the *cert* login leg rejects it, then the
+// identity replicates partway through the window and the retried flow completes.
+// The app sees a single successful auth rather than a permanent failure.
 TEST_CASE("oidc-auth-recovers-once-identity-replicates", "[oidc]") {
     FakeOidcEndpoint server;
-    server.scriptAuthorizeFailure("401 Unauthorized");
-    server.scriptAuthorizeFailure("404 Not Found");
-    // script exhausted: subsequent authorize requests complete the flow
+    server.scriptLoginFailure("401 Unauthorized");
+    server.scriptLoginFailure("404 Not Found");
+    // script exhausted: the next login completes the flow
 
-    TestClient c(server, 20000);
+    TestClient c(server, 20000, Creds::Cert);
     REQUIRE(c.start() == 0);
 
     c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(15));
@@ -437,12 +504,55 @@ TEST_CASE("oidc-auth-recovers-once-identity-replicates", "[oidc]") {
     REQUIRE(c.result.calls == 1);
     CHECK(c.result.status == OIDC_TOKEN_OK);
     CHECK(c.result.token == FAKE_JWT);
-    CHECK(server.authorize_count.load() == 3);
+    CHECK(server.login_count.load() == 3);
     CHECK(server.token_count.load() == 1);
 
     // the window is closed out on success, so a later failure gets a fresh one
     CHECK(c.clt.auth_failures == 0);
     CHECK(c.clt.auth_retry_until == 0);
+}
+
+// Regression guard for openziti/ziti-tunnel-sdk-c
+// TestExternalAuthSingleSigner/enrollToNoneRejectsUnknownControllerIdentity: a
+// 401 on the *ext-jwt* login means the token maps to no identity on this
+// controller, which waiting cannot fix. Retrying it silently left the tunneler
+// with no "controller disconnected" event at all, so the test timed out. It must
+// be reported on the first attempt.
+TEST_CASE("oidc-auth-does-not-retry-rejected-ext-jwt-login", "[oidc]") {
+    FakeOidcEndpoint server;
+    for (int i = 0; i < 5; i++) {
+        server.scriptLoginFailure("401 Unauthorized",
+                                  R"({"code":"UNAUTHORIZED","message":"The request could not be completed."})");
+    }
+
+    TestClient c(server, 60000, Creds::ExtJwt);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(5));
+
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_FAILED);
+    CHECK(server.login_count.load() == 1);
+
+    c.pumpFor(std::chrono::milliseconds(500));
+    CHECK(server.login_count.load() == 1);
+    CHECK(c.result.calls == 1);
+}
+
+// The authorize leg runs before any credential is presented, so a 401 there is
+// not a replication symptom either and must not open the window.
+TEST_CASE("oidc-auth-does-not-retry-401-on-authorize-leg", "[oidc]") {
+    FakeOidcEndpoint server;
+    for (int i = 0; i < 5; i++) server.scriptAuthorizeFailure("401 Unauthorized");
+
+    TestClient c(server, 60000, Creds::Cert);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(5));
+
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_FAILED);
+    CHECK(server.authorize_count.load() == 1);
 }
 
 // A 429 carrying Retry-After paces the retry by what the server asked for

--- a/tests/oidc_auth_retry_tests.cpp
+++ b/tests/oidc_auth_retry_tests.cpp
@@ -93,15 +93,29 @@ constexpr const char *TOKEN_PATH = "/token";
 // One thread per connection, independent of the test's uv_loop.
 class FakeOidcEndpoint {
 public:
+    using Headers = std::vector<std::pair<std::string, std::string>>;
+
     uint16_t port{};
     std::atomic<int> authorize_count{0};
     std::atomic<int> token_count{0};
 
-    // each entry is a full status line + optional JSON body served to one
-    // authorize request; empty queue == serve the success redirect
-    void scriptAuthorizeFailure(const std::string &statusLine, const std::string &body = "") {
+    // each entry is a full status line + optional extra headers + optional JSON
+    // body served to one authorize request; empty queue == serve the success
+    // redirect. authorize_at records uv-independent arrival times so a test can
+    // assert on the gap the retry actually waited.
+    void scriptAuthorizeFailure(const std::string &statusLine,
+                                const std::string &body = "",
+                                const Headers &headers = {}) {
         std::lock_guard<std::mutex> lock(mu_);
-        authorize_script_.push_back({statusLine, body});
+        authorize_script_.push_back({statusLine, body, headers});
+    }
+
+    // milliseconds between the Nth and (N+1)th authorize request
+    int64_t authorizeGapMs(size_t n) const {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (authorize_at_.size() <= n + 1) return -1;
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+                   authorize_at_[n + 1] - authorize_at_[n]).count();
     }
 
     FakeOidcEndpoint() {
@@ -148,6 +162,7 @@ private:
     struct ScriptedResp {
         std::string statusLine;
         std::string body;
+        Headers headers;
     };
 
     void acceptLoop() {
@@ -211,6 +226,7 @@ private:
             bool haveScripted = false;
             {
                 std::lock_guard<std::mutex> lock(mu_);
+                authorize_at_.push_back(std::chrono::steady_clock::now());
                 if (!authorize_script_.empty()) {
                     scripted = authorize_script_.front();
                     authorize_script_.pop_front();
@@ -218,7 +234,7 @@ private:
                 }
             }
             if (haveScripted) {
-                return response(scripted.statusLine, {}, scripted.body);
+                return response(scripted.statusLine, scripted.headers, scripted.body);
             }
             return response("302 Found", {{"Location", url(LOGIN_PATH) + "?authRequestID=test-req-1&x=1"}});
         }
@@ -242,7 +258,7 @@ private:
     }
 
     static std::string response(const std::string &statusLine,
-                                const std::vector<std::pair<std::string, std::string>> &headers = {},
+                                const Headers &headers = {},
                                 const std::string &body = "") {
         std::string out = "HTTP/1.1 " + statusLine + "\r\n";
         for (const auto &h: headers) {
@@ -258,8 +274,9 @@ private:
     std::atomic<bool> stop_{false};
     std::thread accept_thread_;
     std::vector<std::thread> workers_;
-    std::mutex mu_;
+    mutable std::mutex mu_;
     std::deque<ScriptedResp> authorize_script_;
+    std::vector<std::chrono::steady_clock::time_point> authorize_at_;
 };
 
 struct AuthResult {
@@ -426,4 +443,64 @@ TEST_CASE("oidc-auth-recovers-once-identity-replicates", "[oidc]") {
     // the window is closed out on success, so a later failure gets a fresh one
     CHECK(c.clt.auth_failures == 0);
     CHECK(c.clt.auth_retry_until == 0);
+}
+
+// A 429 carrying Retry-After paces the retry by what the server asked for
+// rather than by our own jitter, provided the wait still fits in the window.
+TEST_CASE("oidc-auth-honours-retry-after-on-429", "[oidc]") {
+    FakeOidcEndpoint server;
+    // 3s is deliberately outside the range next_backoff() can produce on the
+    // first attempt (random % 2000 ms), so the gap assertion below can only pass
+    // if the header was actually honoured
+    server.scriptAuthorizeFailure("429 Too Many Requests", "", {{"Retry-After", "3"}});
+    // script exhausted: the next authorize completes the flow
+
+    TestClient c(server, 20000);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(10));
+
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_OK);
+    REQUIRE(server.authorize_count.load() == 2);
+
+    // the retry waited ~3s because the server said so; the first-attempt backoff
+    // tops out at 2000 ms, so this gap is unreachable without the header
+    int64_t gap = server.authorizeGapMs(0);
+    CHECK(gap >= 2900);
+    CHECK(gap < 6000);
+}
+
+// Retry-After longer than the remaining window: coming back sooner than the
+// server asked would defeat the header, so stop retrying and report instead.
+TEST_CASE("oidc-auth-gives-up-when-retry-after-exceeds-window", "[oidc]") {
+    FakeOidcEndpoint server;
+    server.scriptAuthorizeFailure("429 Too Many Requests", "", {{"Retry-After", "600"}});
+
+    TestClient c(server, 5000);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(5));
+
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_FAILED);
+    CHECK(server.authorize_count.load() == 1);
+}
+
+// The HTTP-date form of Retry-After is not parsed (it would need strptime, which
+// MSVC lacks); an unusable value must fall back to normal backoff rather than
+// being read as "retry immediately" or aborting the retry.
+TEST_CASE("oidc-auth-falls-back-to-backoff-on-unparsable-retry-after", "[oidc]") {
+    FakeOidcEndpoint server;
+    server.scriptAuthorizeFailure("429 Too Many Requests", "",
+                                  {{"Retry-After", "Wed, 21 Oct 2099 07:28:00 GMT"}});
+
+    TestClient c(server, 20000);
+    REQUIRE(c.start() == 0);
+
+    c.pumpUntil([&] { return c.result.calls > 0; }, std::chrono::seconds(10));
+
+    REQUIRE(c.result.calls == 1);
+    CHECK(c.result.status == OIDC_TOKEN_OK);
+    CHECK(server.authorize_count.load() == 2);
 }

--- a/tests/util_tests.cpp
+++ b/tests/util_tests.cpp
@@ -80,3 +80,53 @@ TEST_CASE("read_file_stdin", "[util]") {
     free(content);
     uv_fs_req_cleanup(&req);
 }
+
+// The shared retry predicate. Three call sites depend on it: the OIDC auth-flow
+// classifier (library/oidc.c auth_error_is_temporary) and the internal and
+// external token-refresh paths (oidc.c / ext_oidc.c). Only resp->code and the
+// body are read, so a zeroed response with a code set is a faithful input.
+TEST_CASE("http_error_is_temporary", "[util]") {
+    auto classify = [](int code, const char *body_json = nullptr) {
+        tlsuv_http_resp_t resp{};
+        resp.code = code;
+        json_object *body = body_json ? json_tokener_parse(body_json) : nullptr;
+        bool result = ziti_http_error_is_temporary(&resp, body);
+        if (body) json_object_put(body);
+        return result;
+    };
+
+    SECTION("transport errors are temporary") {
+        CHECK(classify(UV_ECONNRESET));
+        CHECK(classify(UV_ETIMEDOUT));
+    }
+
+    SECTION("5xx is temporary") {
+        CHECK(classify(500));
+        CHECK(classify(502));
+        CHECK(classify(503));
+    }
+
+    SECTION("429 is temporary: the server is pacing us, not rejecting us") {
+        CHECK(classify(429));
+    }
+
+    SECTION("400 is temporary only for zitadel's generic server_error") {
+        CHECK(classify(400, R"({"error":"server_error"})"));
+        CHECK_FALSE(classify(400, R"({"error":"invalid_request"})"));
+        CHECK_FALSE(classify(400, R"({})"));
+        CHECK_FALSE(classify(400));
+    }
+
+    SECTION("credential rejections are not temporary on their own") {
+        // oidc.c widens 401/403/404 for the cert-login leg only; the shared
+        // predicate must not do it for everyone
+        CHECK_FALSE(classify(401));
+        CHECK_FALSE(classify(403));
+        CHECK_FALSE(classify(404));
+    }
+
+    SECTION("success and other 4xx are not temporary") {
+        CHECK_FALSE(classify(200));
+        CHECK_FALSE(classify(409));
+    }
+}


### PR DESCRIPTION
- retry window: 2 minutes with exponential backoff
- deleted identities will fail and report impossible to authenticate stated after the window

[fixes #1134]